### PR TITLE
test: CLI 統合テストを拡充

### DIFF
--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { existsSync, unlinkSync } from "node:fs";
@@ -24,6 +24,8 @@ function cleanup() {
   if (existsSync(LOCK_PATH)) unlinkSync(LOCK_PATH);
 }
 
+afterEach(cleanup);
+
 // ---------------------------------------------------------------------------
 // scan
 // ---------------------------------------------------------------------------
@@ -41,8 +43,8 @@ describe("CLI: scan", () => {
   it("should output human-readable text by default", { timeout: 30000 }, () => {
     const { stdout, exitCode } = run(["scan"]);
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("Nodes:");
-    expect(stdout).toContain("Edges:");
+    expect(stdout).toMatch(/Nodes:\s+[1-9]/);
+    expect(stdout).toMatch(/Edges:\s+[1-9]/);
     expect(stdout).toContain("req:");
     expect(stdout).toContain("file:");
   });
@@ -79,7 +81,8 @@ describe("CLI: impact", () => {
   it("should output human-readable text by default", { timeout: 30000 }, () => {
     const { stdout, exitCode } = run(["impact", "REQ-7f3a"]);
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("Affected");
+    expect(stdout).toContain("Affected REQs:");
+    expect(stdout).toContain("REQ-7f3a");
   });
 
   it("should show impact for multiple targets", { timeout: 30000 }, () => {
@@ -109,9 +112,9 @@ describe("CLI: impact", () => {
     expect(stderr).toContain("No matching nodes found");
   });
 
+  // Smoke test: --diff depends on real git state so the result is non-deterministic.
+  // A proper test would need a temporary git repo with a controlled diff.
   it("should not crash with --diff flag", { timeout: 30000 }, () => {
-    // --diff depends on git state; we just verify it doesn't throw an unhandled error.
-    // It will either exit 0 (no diff / some diff) or exit 1, but not crash.
     const { exitCode } = run(["impact", "--diff"]);
     expect([0, 1]).toContain(exitCode);
   });
@@ -143,12 +146,13 @@ describe("CLI: check", () => {
     expect(stdout).toContain("COVERAGE:");
   });
 
+  // Smoke test: --diff depends on real git state so the result is non-deterministic.
+  // A proper test would need a temporary git repo with a controlled diff.
   it("should not crash with --diff flag", { timeout: 30000 }, () => {
     cleanup();
     const { exitCode } = run(["check", "--diff"]);
-    // Should exit 0 if no diff or changed files are not in graph,
-    // or produce check results otherwise. Either way, no crash.
-    expect([0, 2]).toContain(exitCode);
+    // Without --gate, check never calls process.exit(2).
+    expect(exitCode).toBe(0);
   });
 });
 
@@ -187,8 +191,9 @@ describe("CLI: reconcile then check (no drift)", () => {
     const result = JSON.parse(chk.stdout);
     expect(result.drifted).toEqual([]);
     expect(result.orphans).toEqual([]);
-
-    cleanup();
+    // REQ-c3d4 has no @impl, so pass is false and uncovered contains it.
+    expect(result.pass).toBe(false);
+    expect(result.uncovered).toContain("REQ-c3d4");
   });
 
   it("should include coverage information after reconcile", { timeout: 30000 }, () => {
@@ -205,8 +210,7 @@ describe("CLI: reconcile then check (no drift)", () => {
 
     // REQ-7f3a should be verified (has both impl and test).
     const req7f3a = result.coverage.find((c: any) => c.reqId === "REQ-7f3a");
-    expect(req7f3a).toBeDefined();
-    expect(req7f3a.status).toBe("verified");
+    expect(req7f3a).toEqual(expect.objectContaining({ status: "verified" }));
 
     cleanup();
   });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -7,16 +7,16 @@ const CLI = resolve(import.meta.dirname, "../dist/cli.js");
 const FIXTURE_DIR = resolve(import.meta.dirname, "fixtures");
 const LOCK_PATH = resolve(FIXTURE_DIR, ".trace.lock");
 
-function run(args: string[]): { stdout: string; exitCode: number } {
+function run(args: string[]): { stdout: string; stderr: string; exitCode: number } {
   try {
     const stdout = execFileSync("node", [CLI, ...args], {
       encoding: "utf-8",
       cwd: FIXTURE_DIR,
       timeout: 30000,
     });
-    return { stdout, exitCode: 0 };
+    return { stdout, stderr: "", exitCode: 0 };
   } catch (e: any) {
-    return { stdout: e.stdout ?? "", exitCode: e.status ?? 1 };
+    return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", exitCode: e.status ?? 1 };
   }
 }
 
@@ -24,6 +24,9 @@ function cleanup() {
   if (existsSync(LOCK_PATH)) unlinkSync(LOCK_PATH);
 }
 
+// ---------------------------------------------------------------------------
+// scan
+// ---------------------------------------------------------------------------
 describe("CLI: scan", () => {
   it("should output graph summary as JSON", { timeout: 30000 }, () => {
     const { stdout, exitCode } = run(["scan", "--format", "json"]);
@@ -34,10 +37,29 @@ describe("CLI: scan", () => {
     expect(result.edgeCount).toBeGreaterThan(0);
     expect(result.reqCount).toBeGreaterThanOrEqual(2);
   });
+
+  it("should output human-readable text by default", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = run(["scan"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Nodes:");
+    expect(stdout).toContain("Edges:");
+    expect(stdout).toContain("req:");
+    expect(stdout).toContain("file:");
+  });
+
+  it("should output text with --format text", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = run(["scan", "--format", "text"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Nodes:");
+    expect(stdout).toContain("Edges:");
+  });
 });
 
+// ---------------------------------------------------------------------------
+// impact
+// ---------------------------------------------------------------------------
 describe("CLI: impact", () => {
-  it("should show impact for a REQ-ID", () => {
+  it("should show impact for a REQ-ID", { timeout: 30000 }, () => {
     const { stdout, exitCode } = run(["impact", "REQ-7f3a", "--format", "json"]);
     expect(exitCode).toBe(0);
 
@@ -46,37 +68,192 @@ describe("CLI: impact", () => {
     expect(result.affectedReqs).toContain("REQ-7f3a");
   });
 
-  it("should show impact for a file path", () => {
+  it("should show impact for a file path", { timeout: 30000 }, () => {
     const { stdout, exitCode } = run(["impact", "src/auth/login.ts", "--format", "json"]);
     expect(exitCode).toBe(0);
 
     const result = JSON.parse(stdout);
     expect(result.affectedReqs).toContain("REQ-7f3a");
   });
+
+  it("should output human-readable text by default", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = run(["impact", "REQ-7f3a"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Affected");
+  });
+
+  it("should show impact for multiple targets", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = run([
+      "impact",
+      "REQ-7f3a",
+      "src/auth/session.ts",
+      "--format",
+      "json",
+    ]);
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.affectedReqs).toContain("REQ-7f3a");
+    expect(result.affectedFiles.length).toBeGreaterThan(0);
+  });
+
+  it("should fail when no targets are given", { timeout: 30000 }, () => {
+    const { exitCode, stderr } = run(["impact"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No targets specified");
+  });
+
+  it("should fail when target does not match any node", { timeout: 30000 }, () => {
+    const { exitCode, stderr } = run(["impact", "NONEXISTENT-ID"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("No matching nodes found");
+  });
+
+  it("should not crash with --diff flag", { timeout: 30000 }, () => {
+    // --diff depends on git state; we just verify it doesn't throw an unhandled error.
+    // It will either exit 0 (no diff / some diff) or exit 1, but not crash.
+    const { exitCode } = run(["impact", "--diff"]);
+    expect([0, 1]).toContain(exitCode);
+  });
 });
 
+// ---------------------------------------------------------------------------
+// check
+// ---------------------------------------------------------------------------
 describe("CLI: check", () => {
-  it("should exit 2 with --gate when issues exist", () => {
+  it("should exit 2 with --gate when issues exist", { timeout: 30000 }, () => {
     cleanup();
     const { exitCode } = run(["check", "--gate"]);
     expect(exitCode).toBe(2);
   });
 
-  it("should report issues in JSON format", () => {
+  it("should report issues in JSON format", { timeout: 30000 }, () => {
     cleanup();
     const { stdout } = run(["check", "--format", "json"]);
     const result = JSON.parse(stdout);
 
     expect(result.uncovered.length).toBeGreaterThan(0);
   });
+
+  it("should output human-readable text by default", { timeout: 30000 }, () => {
+    cleanup();
+    const { stdout } = run(["check"]);
+    // Without a lock file, there will be uncovered items.
+    expect(stdout).toContain("UNCOVERED:");
+    expect(stdout).toContain("COVERAGE:");
+  });
+
+  it("should not crash with --diff flag", { timeout: 30000 }, () => {
+    cleanup();
+    const { exitCode } = run(["check", "--diff"]);
+    // Should exit 0 if no diff or changed files are not in graph,
+    // or produce check results otherwise. Either way, no crash.
+    expect([0, 2]).toContain(exitCode);
+  });
 });
 
+// ---------------------------------------------------------------------------
+// reconcile
+// ---------------------------------------------------------------------------
 describe("CLI: reconcile", () => {
-  it("should create a lock file after reconcile", () => {
+  it("should create a lock file after reconcile", { timeout: 30000 }, () => {
     cleanup();
-    const { exitCode } = run(["reconcile"]);
+    const { exitCode, stdout } = run(["reconcile"]);
     expect(exitCode).toBe(0);
     expect(existsSync(LOCK_PATH)).toBe(true);
+    expect(stdout).toContain("Lock file updated");
     cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reconcile -> check scenario (no drift expected)
+// ---------------------------------------------------------------------------
+describe("CLI: reconcile then check (no drift)", () => {
+  it("should have no drift immediately after reconcile", { timeout: 30000 }, () => {
+    cleanup();
+
+    // Step 1: reconcile to create a fresh lock.
+    const rec = run(["reconcile"]);
+    expect(rec.exitCode).toBe(0);
+    expect(existsSync(LOCK_PATH)).toBe(true);
+
+    // Step 2: check should report zero drift and zero orphans.
+    // Note: pass may still be false due to uncovered REQs in the fixture
+    // (REQ-c3d4 has no @impl), but drift should be empty.
+    const chk = run(["check", "--format", "json"]);
+    expect(chk.exitCode).toBe(0);
+
+    const result = JSON.parse(chk.stdout);
+    expect(result.drifted).toEqual([]);
+    expect(result.orphans).toEqual([]);
+
+    cleanup();
+  });
+
+  it("should include coverage information after reconcile", { timeout: 30000 }, () => {
+    cleanup();
+
+    const rec = run(["reconcile"]);
+    expect(rec.exitCode).toBe(0);
+
+    const chk = run(["check", "--format", "json"]);
+    expect(chk.exitCode).toBe(0);
+
+    const result = JSON.parse(chk.stdout);
+    expect(result.coverage.length).toBeGreaterThan(0);
+
+    // REQ-7f3a should be verified (has both impl and test).
+    const req7f3a = result.coverage.find((c: any) => c.reqId === "REQ-7f3a");
+    expect(req7f3a).toBeDefined();
+    expect(req7f3a.status).toBe("verified");
+
+    cleanup();
+  });
+
+  it("should show COVERAGE in text output after reconcile", { timeout: 30000 }, () => {
+    cleanup();
+
+    const rec = run(["reconcile"]);
+    expect(rec.exitCode).toBe(0);
+
+    const chk = run(["check"]);
+    expect(chk.exitCode).toBe(0);
+    expect(chk.stdout).toContain("COVERAGE:");
+
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// error cases
+// ---------------------------------------------------------------------------
+describe("CLI: error cases", () => {
+  it("should show usage info when no command is given", { timeout: 30000 }, () => {
+    const { stderr, exitCode } = run([]);
+    // Commander exits 1 and prints usage info to stderr when no command is provided.
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Usage:");
+  });
+
+  it("should fail for unknown command", { timeout: 30000 }, () => {
+    const { exitCode, stderr } = run(["foobar"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("unknown command");
+  });
+
+  it("should show version with --version", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = run(["--version"]);
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("should show help with --help", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = run(["--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("scan");
+    expect(stdout).toContain("impact");
+    expect(stdout).toContain("check");
+    expect(stdout).toContain("reconcile");
   });
 });


### PR DESCRIPTION
## Summary
- scan/impact/check のテキスト出力 (`--format text` / デフォルト) のテストを追加
- impact のエラーケース (ターゲットなし、未知ターゲット) と複数ターゲット対応テストを追加
- `--diff` フラグの非クラッシュ確認テスト (impact/check 両方) を追加
- reconcile -> check シナリオテスト (ドリフトなし、カバレッジ情報確認) を追加
- CLI 全般のエラーケース (不明コマンド、コマンドなし、--version、--help) を追加
- テスト数を 8 件から 22 件に拡充

## Test plan
- [x] `npm run build && npx vitest run tests/cli.test.ts` で全 22 テストが pass することを確認済み
- [x] ソースコードファイルへの変更なし (テストファイルのみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)