### PR TITLE
docs: add design for inter-document graph structure

### DIFF
--- a/docs/design/document-graph.md
+++ b/docs/design/document-graph.md
@@ -1,0 +1,326 @@
+# 設計: ドキュメント間グラフ構造の整理
+
+- ステータス: ドラフト
+- 対象ブランチ: `claude/document-graph-structure-hjgvia`
+- 作成日: 2026-06-20
+
+## 1. 背景と狙い
+
+spectrace は「仕様 ⇔ 実装」の双方向トレーサビリティを主軸にしてきた。しかし
+本来の狙いは、**SDD（Spec-Driven Development）ツールが出力する各種 Markdown
+ファイル間の依存関係を管理すること**にある。具体的には次のようなツール出力を
+対象とする。
+
+| ツール | 主な出力ファイル | 自然な依存の連鎖 |
+| --- | --- | --- |
+| GitHub Spec Kit | `spec.md` → `plan.md` → `tasks.md`（+ `research.md`） | `plan` derives from `spec`、`tasks` derives from `plan` |
+| AWS Kiro | `requirements.md` → `design.md` → `tasks.md` | `design` derives from `requirements`、`tasks` derives from `design` |
+
+これらのツールでは「個々の要求ID」よりも、**ファイル単位のドキュメントそのもの**が
+依存グラフの基本単位になる。`design.md` が `requirements.md` から派生し、`tasks.md`
+が `design.md` から派生する、という連鎖を管理できることが本質的なゴールである。
+
+参考:
+- GitHub Spec Kit: https://github.com/github/spec-kit/blob/main/spec-driven.md
+- Kiro Specs: https://kiro.dev/docs/specs/
+- Kiro Steering: https://kiro.dev/docs/steering/
+
+## 2. 現状分析
+
+### 2.1 ノード／エッジモデル
+
+`src/types.ts` で 5 種のノードと 5 種のエッジを定義している。
+
+```
+NodeKind = "req" | "doc" | "file" | "symbol" | "test"
+EdgeKind = "depends_on" | "derives_from" | "implements" | "verifies" | "imports"
+```
+
+| エッジ | 意味 | 入力経路 |
+| --- | --- | --- |
+| `implements` | コード → 要求 | `// @impl REQ-ID`（`src/parsers/typescript.ts`） |
+| `verifies` | テスト → 要求 | `[REQ-ID]` / `req:` 注釈 |
+| `imports` | コード → コード | TS AST 解析 |
+| `depends_on` / `derives_from` | doc → 要求 | frontmatter `spectrace.depends_on`（`src/parsers/markdown.ts:54-63`） |
+
+### 2.2 Markdown 取り込みフロー（`src/parsers/markdown.ts`）
+
+1 ファイルからノードが生まれる経路は **3 つだけ**。
+
+1. frontmatter に `spectrace.node_id` がある時のみ `doc` ノードを 1 個生成
+   （`:44-52`）。同時に `depends_on` をエッジ化（`:54-63`）。
+2. リスト項目が `LIST_ITEM_RE`（`- FEAT-001:` 等）にマッチ → `req` ノード（`:66-82`）。
+3. 見出しが `KIRO_HEADING_RE`（`Requirement 1:`）にマッチ → `req` ノード（`:84-100`）。
+
+### 2.3 ここから判明する現状の制約
+
+- **C 相当（ファイル＝ドキュメント）が無い**: `doc` ノードは frontmatter を
+  手書きした時しか作られない。Kiro の `design.md`/`tasks.md`、Spec Kit の
+  `plan.md`/`research.md` のように要求IDの箇条書きを持たない散文 md は、
+  frontmatter を足さない限り **ノードが 1 個も生成されずグラフから消える**。
+- **A 相当（req → req）が無い**: `depends_on` のソースは実質 `doc` 限定
+  （パーサが `node_id` を持つ doc にしか `depends_on` を読みに行かない）。
+  要求どうしの依存を張れない。
+- **B 相当（doc → doc）は部分的に動く**: `depends_on.id` に別 doc の `node_id`
+  を書けば、builder は非 req エッジとして通し（`src/graph/builder.ts:48-56,116-127`）、
+  traverse も双方向に辿る（`src/graph/traverse.ts:13-20`）。ただし両ファイルに
+  frontmatter が必要で、C が無いと実用にならない。
+
+### 2.4 周辺コンポーネントの現状対応
+
+- `src/graph/traverse.ts`: `impact()` は既に双方向 BFS。新エッジ種別を足しても
+  追加実装なしで伝播する。`affectedDocs` は doc ノードを id で収集（`:38-40`）。
+- `src/lock.ts`: `buildLockFromGraph` は `req`/`doc` ノードのみロック化し、
+  `depends_on`/`derives_from` を `dependsOn` 配列に保存（`:48-53`）。doc ノードが
+  増えればそのままロック対象になる。
+- `src/graph/traverse.ts:75-88` `findUncovered`: `req` のみ対象。doc は未カバレッジ
+  判定の対象外（このままで良い）。
+
+## 3. ゴールと非ゴール
+
+### ゴール
+
+- **A**: 要求 ⇔ 要求（`req → req`）の依存を表現できる。
+- **B**: ドキュメント ⇔ ドキュメント（`doc → doc`）の依存を表現できる。
+- **C**: Markdown ファイルそのものを `doc` ノードとして自動登録し、さらに
+  doc → doc リンクを以下 3 方式で取得できる。
+  - **C-1** frontmatter 明示（`spectrace.depends_on`）
+  - **C-2** md 内インラインリンク（`[design](./design.md)`）の自動抽出
+  - **C-3** ツール規約（Kiro / Spec Kit のフォルダ構成）の自動推論
+- 既存の「仕様 ⇔ 実装」トレースと後方互換であること。
+
+### 非ゴール（今回の設計範囲外）
+
+- グラフの可視化出力（DOT/Mermaid エクスポート）— 別設計とする。
+- `symbol` 粒度のトレース。
+- ドキュメントの版管理・履歴追跡。
+
+## 4. エッジの向きとセマンティクス
+
+混乱を避けるため、エッジの向きを次の規約に統一する。
+
+- `derives_from`: **下流 → 上流**。「派生したもの」から「派生元」へ向ける。
+  - `design.md --derives_from--> requirements.md`
+  - `tasks.md --derives_from--> design.md`
+- `depends_on`: 一般的な依存（向きの意味が `derives_from` ほど強くない場合）。
+  - `A --depends_on--> B`（A は B に依存する）
+- 影響解析（`impact`）は双方向 BFS なので、向きは「人間が読むときの意味」と
+  「lock の `dependsOn` 配列の起点」を決めるためのもの。`buildLockFromGraph` は
+  `source === id` のエッジを `dependsOn` に格納する（`src/lock.ts:48-53`）ため、
+  「自分が依存している先」が下流ノードのエントリにまとまる。
+
+> 補足: 既存テスト fixture `tests/fixtures/specs/auth.md` は
+> `depends_on: [{ id: "AUTH-001", relation: implements }]` と書いており、
+> `relation: implements` は現状 `derives_from` 以外として `depends_on` に倒される
+> （`src/parsers/markdown.ts:56`）。本設計では relation の許容値を明確化する
+> （6.1 参照）。
+
+## 5. データモデルの変更
+
+### 5.1 ノード ID 規約
+
+ファイル＝ドキュメントの `doc` ノード ID を規約化する。
+
+- frontmatter に `spectrace.node_id` があればそれを優先（後方互換）。
+- 無ければ **`doc:<specDir からの相対パス>`** を自動採番。
+  - 例: `specs/003-chat/design.md` → `doc:003-chat/design.md`
+- 衝突回避は既存の req と同様、builder で重複検出・警告（`duplicate-id`）。
+
+### 5.2 型の追加・変更（`src/types.ts`）
+
+`EdgeKind` は既存の `depends_on` / `derives_from` を流用するため**追加不要**。
+A（req → req）も B（doc → doc）も同じ 2 種で表現できる。
+
+エッジの出所をデバッグ・出力で区別できるよう、`GraphEdge` に任意メタを足す。
+
+```ts
+export interface GraphEdge {
+  source: string;
+  target: string;
+  kind: EdgeKind;
+  // 追加: リンクの取得元（C-1/C-2/C-3 や @impl などの由来）
+  via?: "frontmatter" | "inline-link" | "convention" | "impl-tag" | "verify-tag" | "import";
+}
+```
+
+`via` は任意。既存コードは無視できるため後方互換。
+
+### 5.3 設定の追加（`SpectraceConfig`）
+
+```ts
+export interface SpectraceConfig {
+  // 既存
+  include: string[];
+  specDirs: string[];
+  testPatterns: string[];
+  lockFile: string;
+  reqPatterns?: ReqPatternConfig;
+  // 追加
+  docGraph?: {
+    autoDocNodes?: boolean;        // C-1: md=doc ノード自動生成（既定 true）
+    inlineLinks?: boolean;         // C-2: インラインリンク抽出（既定 true）
+    conventions?: Array<"kiro" | "spec-kit">; // C-3: 規約推論（既定 []）
+  };
+}
+```
+
+既定値は「自動 doc ノード ON・インラインリンク ON・規約推論 OFF」とし、
+規約推論は明示的にオプトインさせる（誤検出リスクを抑えるため）。
+
+## 6. 各機能の設計
+
+### 6.1 A: 要求 ⇔ 要求の依存（`req → req`）
+
+**入力記法（2 通りをサポート）**
+
+1. frontmatter（ファイル全体ではなく、要求にぶら下げにくいので補助的）。
+2. 要求の箇条書き行内のインライン注釈を推奨。
+
+```md
+- AUTH-002: セッション管理 (depends_on: AUTH-001)
+- AUTH-003: ログアウト機能 (derives_from: AUTH-002)
+```
+
+**パーサ変更（`src/parsers/markdown.ts`）**
+
+- `visit(tree, "listItem")` / `visit(tree, "heading")` の中で、ラベル文字列から
+  `(depends_on: X, Y)` / `(derives_from: Z)` を正規表現抽出し、`source = reqId`,
+  `target = X` のエッジを生成。
+- 抽出後、ラベル/ハッシュ計算には注釈を含めるか除くかを決める（drift 安定性の
+  観点では、注釈変更で req 本体が drift 扱いになるのを避けるため**注釈を除いた
+  本文でハッシュ**するのが望ましい）。
+
+**builder 変更（`src/graph/builder.ts`）**
+
+- 現在 `isFromReq` 判定で req 由来エッジを `req.edges` に振り分けている（`:48-56`）。
+  req → req エッジはソースが req なのでこの経路に乗る。Pass 2 で source/target を
+  最終 ID（衝突時は `specDir/ID`）へ remap する必要がある。現状 target の remap が
+  req → req では未対応なので、**target も `idMapping` で解決**するよう拡張する。
+
+**relation 許容値の明確化**
+
+- `depends_on` / `derives_from` のみ正式サポート。
+- それ以外（例: 既存 fixture の `implements`）は警告を出しつつ `depends_on` に
+  フォールバック（後方互換）。将来的に fixture を `derives_from` へ修正。
+
+### 6.2 B: ドキュメント ⇔ ドキュメントの依存（`doc → doc`）
+
+**入力記法**
+
+1. frontmatter（C-1）:
+
+```yaml
+---
+spectrace:
+  node_id: "doc:003-chat/design"
+  depends_on:
+    - { id: "doc:003-chat/requirements", relation: derives_from }
+---
+```
+
+2. インラインリンク（C-2）/ 規約（C-3）から自動生成（6.3 参照）。
+
+**builder 変更**
+
+- doc → doc エッジはソースが req でないため `nonReqEdges` 経路（`:48-56,116-127`）。
+  現状でも通るが、**target が存在しない doc を指す場合の警告**（`orphan-doc`）を
+  追加する。`findOrphans`（`src/graph/traverse.ts:61-73`）は現在 implements/verifies
+  のみ対象なので、doc 依存先の欠落も検出対象に含めるか検討（既定は警告のみ）。
+
+### 6.3 C: 自動 doc ノード生成とリンク取得
+
+#### C-1: ファイル＝doc ノードの自動生成
+
+**パーサ変更（`src/parsers/markdown.ts`）**
+
+- `config.docGraph.autoDocNodes !== false` のとき、frontmatter の有無に関わらず
+  各 md に対して `doc` ノードを必ず 1 個生成する。
+  - ID は 5.1 の規約。`node_id` があれば優先。
+  - `contentHash` はファイル全体ハッシュ（既存 `fileHash` を流用）。
+- 既存挙動との関係: これまで req ノードしか出さなかった `speckit-style.md` 等も、
+  追加で `doc:...` ノードを持つようになる。req ノードは従来どおり併存。
+- 「その md に属する req は、その doc から `contains`/`derives_from` で結ぶか」は
+  オプション。まずは**結ばない**（要求は引き続き独立ノード）で開始し、必要なら
+  後続で `doc --contains--> req` を追加検討（EdgeKind 追加が必要なので別途）。
+
+> パーサは `config` を受け取っていないため、`parseMarkdown` のシグネチャに
+> `options?: { docGraph?: ... }` を追加し、builder から渡す。
+
+#### C-2: インラインリンクの自動抽出
+
+**パーサ変更**
+
+- remark AST を `visit(tree, "link")` で走査し、`url` が**ローカルの相対 .md**を
+  指すものを抽出。
+- 解決: リンク元 md の doc ノード ID → リンク先パスを正規化し、対応する doc
+  ノード ID（5.1 規約 or `node_id`）へ `derives_from`（既定）または `depends_on`
+  のエッジを張る。`via: "inline-link"`。
+- 向きの既定: 「自分が参照している先 = 依存先」とみなし `A --depends_on--> B`。
+  ただし規約由来（C-3）の連鎖は `derives_from` を使う。
+- 解決できないリンク（外部 URL、アンカーのみ、対象 md がスキャン対象外）は無視。
+
+#### C-3: ツール規約の自動推論
+
+**新規モジュール（例: `src/graph/conventions.ts`）**
+
+- builder が全 md をパースした後、`config.docGraph.conventions` に応じて
+  フォルダ単位でファイル名パターンを照合し、連鎖エッジを生成する。
+
+| 規約 | 検出 | 生成エッジ（derives_from, via: "convention"） |
+| --- | --- | --- |
+| `kiro` | 同一ディレクトリ内の `requirements.md` / `design.md` / `tasks.md` | `design → requirements`、`tasks → design` |
+| `spec-kit` | 同一ディレクトリ内の `spec.md` / `plan.md` / `tasks.md`（+ `research.md`） | `plan → spec`、`tasks → plan`、`research → spec` |
+
+- 規約推論は **C-1（doc ノード自動生成）が前提**。対象ファイルが doc ノードと
+  して存在する場合のみエッジを張る。
+- 重複（C-1/C-2/C-3 で同じ source→target が複数回出る）は builder でデデュープ。
+
+### 6.4 優先順位の推奨実装順
+
+1. C-1（doc ノード自動生成）+ B（doc → doc, frontmatter）— グラフの骨格。
+2. C-2（インラインリンク）— 手書き不要で連鎖が埋まる。
+3. C-3（規約推論）— ツール出力をそのまま投入できる。
+4. A（req → req）— ドキュメント内・要求粒度の依存。
+
+## 7. 影響範囲まとめ（ファイル別）
+
+| ファイル | 変更内容 |
+| --- | --- |
+| `src/types.ts` | `GraphEdge.via?` 追加、`SpectraceConfig.docGraph?` 追加 |
+| `src/parsers/markdown.ts` | C-1 自動 doc ノード、C-2 インラインリンク抽出、A の req→req 注釈抽出、relation 検証、シグネチャに options 追加 |
+| `src/graph/builder.ts` | req→req の target remap、doc→doc の orphan 警告、規約推論呼び出し、エッジ デデュープ |
+| `src/graph/conventions.ts`（新規） | C-3 Kiro/Spec Kit 規約推論 |
+| `src/graph/traverse.ts` | 変更ほぼ不要（双方向 BFS が新エッジを自動処理）。orphan-doc を含める場合のみ拡張 |
+| `src/lock.ts` | 変更不要（doc ノード増・dependsOn は既存ロジックで対応） |
+| `src/cli.ts` | `scan` のサマリにエッジ種別別カウントを追加（任意） |
+
+## 8. 後方互換性
+
+- `node_id` 付き frontmatter は従来どおり動作（優先される）。
+- 既存の `depends_on: [{ relation: implements }]` は警告付きで `depends_on` に
+  フォールバックし、エラーにしない。
+- `docGraph` 未設定でも、自動 doc ノード/インラインリンクは既定 ON のため、
+  既存プロジェクトでもグラフが豊かになる。**lock の差分が出る**点に注意し、
+  リリース時は `reconcile` の実行を案内する。
+- 規約推論（C-3）は既定 OFF。誤検出を避けるためオプトイン。
+
+## 9. テスト方針
+
+- fixtures に Kiro 形式（`requirements.md`/`design.md`/`tasks.md`）と Spec Kit
+  形式（`spec.md`/`plan.md`/`tasks.md`）のフォルダを追加。
+- 単体: markdown パーサが (a) 自動 doc ノード、(b) インラインリンク、(c) req→req
+  注釈、を期待どおり出すこと。
+- 統合: builder + traverse で
+  `tasks.md` を起点に `design.md` → `requirements.md` まで `impact` が伝播すること。
+- 後方互換: 既存 `auth.md`/`speckit-style.md`/`kiro-style.md` のスナップショットが
+  「req ノードは不変・doc ノードが追加される」形であること。
+
+## 10. 未決事項（要レビュー）
+
+1. インラインリンクの既定の向きは `depends_on` でよいか（`derives_from` の方が
+   自然なケースもある）。
+2. `doc --contains--> req`（ファイルとその中の要求の所属関係）を導入するか。
+   導入すると「ファイル単位の影響」と「要求単位の影響」を綺麗に橋渡しできるが、
+   `EdgeKind` 追加が必要。
+3. 規約推論の対象ファイル名は固定でよいか、設定で上書き可能にするか。
+4. 自動 doc ノード ON による既存 lock の差分をどう周知するか（マイグレーション）。

--- a/docs/design/document-graph.md
+++ b/docs/design/document-graph.md
@@ -1,228 +1,185 @@
-# 設計: ドキュメント間グラフ構造の整理
+# 設計: ドキュメント間グラフ構造の整理（リーン v1）
 
-- ステータス: ドラフト
+- ステータス: ドラフト（敵対的レビュー反映済み 2026-06-20）
 - 対象ブランチ: `claude/document-graph-structure-hjgvia`
-- 作成日: 2026-06-20
+
+## 0. この版について
+
+初版（A+B+C 全部入り）に対し、4 視点の敵対的レビューを実施。その結果を受けて
+**スコープを「リーン v1」に縮小**し、前提の弱さ・整合性の穴を是正した。主要な変更:
+
+- C-2（インラインリンク）/ C-3（規約推論・ConventionPreset）/ A（req↔req）/
+  `via` フィールドは **v1 から外し、後続 Issue 化**（§11）。
+- `doc --contains--> req`（旧 Issue #10）を **v1 に昇格**。doc グラフを要求・実装と
+  繋ぐ骨格として必須と判断。
+- **`spectrace graph` 出力コマンドを v1 ゴールに追加**。グラフを「見える化」しないと
+  「md 依存を管理する」という目的が達成されないため。
+
+レビューで指摘された整合性の穴（向き競合・デデュープ未定義・ハッシュ机上論・
+リンク解決の曖昧さ）は、原因だった C-2/C-3/A を後送りしたことで v1 では大半が消滅
+する。残る論点（doc の drift 粒度、contains の影響範囲、orphan 検出）は §6〜§8 で確定。
 
 ## 1. 背景と狙い
 
-spectrace は「仕様 ⇔ 実装」の双方向トレーサビリティを主軸にしてきた。しかし
-本来の狙いは、**SDD（Spec-Driven Development）ツールが出力する各種 Markdown
-ファイル間の依存関係を管理すること**にある。具体的には次のようなツール出力を
-対象とする。
+spectrace は「仕様 ⇔ 実装」の双方向トレーサビリティが主軸。本来の狙いは
+**SDD ツールが出力する Markdown 群の依存関係を管理すること**にある。
 
-| ツール | 主な出力ファイル | 自然な依存の連鎖 |
+| ツール | 主な出力 | 自然な連鎖 |
 | --- | --- | --- |
-| GitHub Spec Kit | `spec.md` → `plan.md` → `tasks.md`（+ `research.md`） | `plan` derives from `spec`、`tasks` derives from `plan` |
-| AWS Kiro | `requirements.md` → `design.md` → `tasks.md` | `design` derives from `requirements`、`tasks` derives from `design` |
+| GitHub Spec Kit | `spec.md` → `plan.md` → `tasks.md`（+ `research.md`） | plan derives from spec、tasks derives from plan |
+| AWS Kiro | `requirements.md` → `design.md` → `tasks.md` | design derives from requirements、tasks derives from design |
 
-これらのツールでは「個々の要求ID」よりも、**ファイル単位のドキュメントそのもの**が
-依存グラフの基本単位になる。`design.md` が `requirements.md` から派生し、`tasks.md`
-が `design.md` から派生する、という連鎖を管理できることが本質的なゴールである。
+### 1.1 前提の明確化（レビュー指摘 #4 への対応）
 
-参考:
-- GitHub Spec Kit: https://github.com/github/spec-kit/blob/main/spec-driven.md
-- Kiro Specs: https://kiro.dev/docs/specs/
-- Kiro Steering: https://kiro.dev/docs/steering/
+実物の Kiro `requirements.md` は EARS 記法（"WHEN … THEN the system SHALL …"）の
+**散文**、Spec Kit `spec.md` も散文中心であり、`FEAT-001:` のような要求 ID の
+箇条書きを必ずしも含まない。したがって本設計では:
+
+- **グラフの基本単位はファイル（doc ノード）**とする。要求 ID 抽出は
+  「ある場合に拾う」ベストエフォートに格下げ。
+- 要求 ID が無くても、ファイル＝ doc ノードとして依存グラフが成立することを保証する
+  （C-1）。
+
+参考: Spec Kit https://github.com/github/spec-kit/blob/main/spec-driven.md ／
+Kiro https://kiro.dev/docs/specs/ ／ https://kiro.dev/docs/steering/
 
 ## 2. 現状分析
 
-### 2.1 ノード／エッジモデル
-
-`src/types.ts` で 5 種のノードと 5 種のエッジを定義している。
+### 2.1 モデル（`src/types.ts`）
 
 ```
 NodeKind = "req" | "doc" | "file" | "symbol" | "test"
 EdgeKind = "depends_on" | "derives_from" | "implements" | "verifies" | "imports"
 ```
 
-| エッジ | 意味 | 入力経路 |
+| エッジ | 意味 | 入力 |
 | --- | --- | --- |
 | `implements` | コード → 要求 | `// @impl REQ-ID`（`src/parsers/typescript.ts`） |
 | `verifies` | テスト → 要求 | `[REQ-ID]` / `req:` 注釈 |
-| `imports` | コード → コード | TS AST 解析 |
+| `imports` | コード → コード | TS AST |
 | `depends_on` / `derives_from` | doc → 要求 | frontmatter `spectrace.depends_on`（`src/parsers/markdown.ts:54-63`） |
 
-### 2.2 Markdown 取り込みフロー（`src/parsers/markdown.ts`）
+### 2.2 Markdown 取り込み（`src/parsers/markdown.ts`）
 
-1 ファイルからノードが生まれる経路は **3 つだけ**。
+ノード生成は 3 経路: (1) frontmatter `spectrace.node_id` がある時のみ `doc` ノード
+（`:44-52`）、(2) リスト項目 `- FEAT-001:`（`:66-82`）→ req、(3) 見出し
+`Requirement 1:`（`:84-100`）→ req。
 
-1. frontmatter に `spectrace.node_id` がある時のみ `doc` ノードを 1 個生成
-   （`:44-52`）。同時に `depends_on` をエッジ化（`:54-63`）。
-2. リスト項目が `LIST_ITEM_RE`（`- FEAT-001:` 等）にマッチ → `req` ノード（`:66-82`）。
-3. 見出しが `KIRO_HEADING_RE`（`Requirement 1:`）にマッチ → `req` ノード（`:84-100`）。
+### 2.3 現状の制約（v1 で解消する範囲）
 
-### 2.3 ここから判明する現状の制約
-
-- **C 相当（ファイル＝ドキュメント）が無い**: `doc` ノードは frontmatter を
-  手書きした時しか作られない。Kiro の `design.md`/`tasks.md`、Spec Kit の
-  `plan.md`/`research.md` のように要求IDの箇条書きを持たない散文 md は、
-  frontmatter を足さない限り **ノードが 1 個も生成されずグラフから消える**。
-- **A 相当（req → req）が無い**: `depends_on` のソースは実質 `doc` 限定
-  （パーサが `node_id` を持つ doc にしか `depends_on` を読みに行かない）。
-  要求どうしの依存を張れない。
-- **B 相当（doc → doc）は部分的に動く**: `depends_on.id` に別 doc の `node_id`
-  を書けば、builder は非 req エッジとして通し（`src/graph/builder.ts:48-56,116-127`）、
-  traverse も双方向に辿る（`src/graph/traverse.ts:13-20`）。ただし両ファイルに
-  frontmatter が必要で、C が無いと実用にならない。
-
-### 2.4 周辺コンポーネントの現状対応
-
-- `src/graph/traverse.ts`: `impact()` は既に双方向 BFS。新エッジ種別を足しても
-  追加実装なしで伝播する。`affectedDocs` は doc ノードを id で収集（`:38-40`）。
-- `src/lock.ts`: `buildLockFromGraph` は `req`/`doc` ノードのみロック化し、
-  `depends_on`/`derives_from` を `dependsOn` 配列に保存（`:48-53`）。doc ノードが
-  増えればそのままロック対象になる。
-- `src/graph/traverse.ts:75-88` `findUncovered`: `req` のみ対象。doc は未カバレッジ
-  判定の対象外（このままで良い）。
+- frontmatter が無い散文 md（design.md 等）は **ノード 0 個**でグラフから消える
+  → C-1 で解消。
+- doc グラフと req/実装が **filePath による暗黙の繋がりしか持たず分断**
+  → `contains` エッジで解消。
+- doc 依存構造を **見るコマンドが無い**（`scan` は件数のみ）
+  → `graph` コマンドで解消。
 
 ## 3. ゴールと非ゴール
 
-### ゴール
+### v1 ゴール
 
-- **A**: 要求 ⇔ 要求（`req → req`）の依存を表現できる。
-- **B**: ドキュメント ⇔ ドキュメント（`doc → doc`）の依存を表現できる。
-- **C**: Markdown ファイルそのものを `doc` ノードとして自動登録し、さらに
-  doc → doc リンクを以下 3 方式で取得できる。
-  - **C-1** frontmatter 明示（`spectrace.depends_on`）
-  - **C-2** md 内インラインリンク（`[design](./design.md)`）の自動抽出
-  - **C-3** ツール規約（Kiro / Spec Kit のフォルダ構成）の自動推論
-- 既存の「仕様 ⇔ 実装」トレースと後方互換であること。
+- **C-1**: 各 md ファイルを `doc` ノードとして自動登録（frontmatter 不要）。
+- **B**: doc → doc 依存を **frontmatter で**表現できる。
+- **contains**: `doc --contains--> req` を生成し、ドキュメント階層 → 要求 → 実装を
+  一気通貫で辿れる。
+- **graph 出力**: `spectrace graph` で doc 依存チェーンを text / JSON で出力。
 
-### 非ゴール（今回の設計範囲外）
+### v1 非ゴール（後続 Issue 化、§11）
 
-- グラフの可視化出力（DOT/Mermaid エクスポート）— 別設計とする。
-- `symbol` 粒度のトレース。
-- ドキュメントの版管理・履歴追跡。
+- C-2 インラインリンク自動抽出。
+- C-3 ツール規約の自動推論 / `ConventionPreset`。
+- A 要求 ⇔ 要求の依存。
+- `via` エッジメタ。
+- DOT / Mermaid 等のリッチ可視化（v1 は text/JSON のみ）。
+- `symbol` 粒度、steering doc、task 粒度のモデル化、版管理。
 
 ## 4. エッジの向きとセマンティクス
 
-混乱を避けるため、エッジの向きを次の規約に統一する。
+- `derives_from`: 下流 → 上流（派生したもの → 派生元）。
+  - 例: `design.md --derives_from--> requirements.md`
+- `depends_on`: 一般的な依存。
+- `contains`: doc → その doc 内で定義された req。**所属関係**（新規 EdgeKind）。
+  - 例: `doc:auth/requirements.md --contains--> AUTH-001`
+- `impact()` は双方向 BFS（`src/graph/traverse.ts:13-20`）。
 
-- `derives_from`: **下流 → 上流**。「派生したもの」から「派生元」へ向ける。
-  - `design.md --derives_from--> requirements.md`
-  - `tasks.md --derives_from--> design.md`
-- `depends_on`: 一般的な依存（向きの意味が `derives_from` ほど強くない場合）。
-  - `A --depends_on--> B`（A は B に依存する）
-- 影響解析（`impact`）は双方向 BFS なので、向きは「人間が読むときの意味」と
-  「lock の `dependsOn` 配列の起点」を決めるためのもの。`buildLockFromGraph` は
-  `source === id` のエッジを `dependsOn` に格納する（`src/lock.ts:48-53`）ため、
-  「自分が依存している先」が下流ノードのエントリにまとまる。
+### 4.1 v1 で向き競合が起きない理由（レビュー指摘 #1 への対応）
 
-> 補足: 既存テスト fixture `tests/fixtures/specs/auth.md` は
-> `depends_on: [{ id: "AUTH-001", relation: implements }]` と書いており、
-> `relation: implements` は現状 `derives_from` 以外として `depends_on` に倒される
-> （`src/parsers/markdown.ts:56`）。本設計では relation の許容値を明確化する
-> （6.1 参照）。
+初版では doc↔doc エッジを frontmatter / インラインリンク / 規約の 3 経路で生成し、
+経路ごとに向きが異なって**同一ペアに逆向きエッジ**が生じ得た。v1 では doc↔doc の
+入力を **frontmatter 1 経路のみ**に限定するため、向きは作者が `relation` で一意に
+指定する。複数経路のデデュープ問題自体が v1 では発生しない。
+
+ただし最小限の防御として builder で**エッジのデデュープ**を入れる（§6.4）。
+デデュープのキーは **`(source, target, kind)`**。同一 source→target でも kind が
+違えば別エッジとして保持する。
 
 ## 5. データモデルの変更
 
-### 5.1 ノード ID 規約
+### 5.1 doc ノード ID 規約
 
-ファイル＝ドキュメントの `doc` ノード ID を規約化する。
-
-- frontmatter に `spectrace.node_id` があればそれを優先（後方互換）。
+- frontmatter `spectrace.node_id` があれば優先。
 - 無ければ **`doc:<specDir からの相対パス>`** を自動採番。
   - 例: `specs/003-chat/design.md` → `doc:003-chat/design.md`
-- 衝突回避は既存の req と同様、builder で重複検出・警告（`duplicate-id`）。
+- 制約: req ID は `doc:` / `file:` / `test:` / `symbol:` プレフィクスを持てない
+  （builder で検出し `duplicate-id` 警告）。レビュー指摘の名前空間衝突対策。
 
-### 5.2 型の追加・変更（`src/types.ts`）
-
-`EdgeKind` は既存の `depends_on` / `derives_from` を流用するため**追加不要**。
-A（req → req）も B（doc → doc）も同じ 2 種で表現できる。
-
-エッジの出所をデバッグ・出力で区別できるよう、`GraphEdge` に任意メタを足す。
+### 5.2 型変更（`src/types.ts`）
 
 ```ts
-export interface GraphEdge {
-  source: string;
-  target: string;
-  kind: EdgeKind;
-  // 追加: リンクの取得元（C-1/C-2/C-3 や @impl などの由来）
-  via?: "frontmatter" | "inline-link" | "convention" | "impl-tag" | "verify-tag" | "import";
-}
+export type EdgeKind =
+  | "depends_on" | "derives_from" | "implements" | "verifies" | "imports"
+  | "contains"; // 追加: doc → req の所属関係
 ```
 
-`via` は任意。既存コードは無視できるため後方互換。
+`via` フィールドは v1 では**追加しない**（消費者がいないため。後続で必要なら導入）。
 
-### 5.3 設定の追加（`SpectraceConfig`）
+### 5.3 設定（`SpectraceConfig`）
 
 ```ts
 export interface SpectraceConfig {
-  // 既存
   include: string[];
   specDirs: string[];
   testPatterns: string[];
   lockFile: string;
   reqPatterns?: ReqPatternConfig;
-  // 追加
+  // 追加（v1 は per-file の 2 フラグのみ）
   docGraph?: {
-    autoDocNodes?: boolean;        // C-1: md=doc ノード自動生成（既定 true）
-    inlineLinks?: boolean;         // C-2: インラインリンク抽出（既定 true）
-    // C-3: 規約推論（既定 []）。組み込みプリセット名か、独自定義を渡せる。
-    conventions?: Array<"kiro" | "spec-kit" | ConventionPreset>;
+    autoDocNodes?: boolean; // C-1: md=doc ノード自動生成（既定 true）
+    contains?: boolean;     // doc→req contains エッジ生成（既定 true）
   };
-}
-
-// 規約推論のプリセット定義。組み込み "kiro"/"spec-kit" もこの形で内部表現する。
-export interface ConventionPreset {
-  name: string;
-  // 同一ディレクトリ内で照合するファイル名と、派生先（上流）のファイル名。
-  // 例: { file: "design.md", derivesFrom: ["requirements.md"] }
-  chain: Array<{ file: string; derivesFrom: string[] }>;
 }
 ```
 
-既定値は「自動 doc ノード ON・インラインリンク ON・規約推論 OFF」とし、
-規約推論は明示的にオプトインさせる（誤検出リスクを抑えるため）。
-
-**規約推論は設定可能（決定 #3）**: 組み込みプリセット `"kiro"` / `"spec-kit"`
-を文字列で指定すれば**設定ゼロで動く**。独自のファイル名・連鎖を使うチームは
-`ConventionPreset` オブジェクトを渡して上書き・追加できる。組み込みプリセットも
-内部的には同じ `ConventionPreset` 構造で定義し、ユーザー定義と同じ経路で処理する。
+`conventions` / `inlineLinks` / `ConventionPreset` は v1 では持たない（後続）。
+パーサに渡すのは per-file フラグのみとし、ディレクトリ横断の関心事を持ち込まない
+（レビュー指摘の層分離）。
 
 ## 6. 各機能の設計
 
-### 6.1 A: 要求 ⇔ 要求の依存（`req → req`）
-
-**入力記法（2 通りをサポート）**
-
-1. frontmatter（ファイル全体ではなく、要求にぶら下げにくいので補助的）。
-2. 要求の箇条書き行内のインライン注釈を推奨。
-
-```md
-- AUTH-002: セッション管理 (depends_on: AUTH-001)
-- AUTH-003: ログアウト機能 (derives_from: AUTH-002)
-```
+### 6.1 C-1: ファイル＝ doc ノードの自動生成
 
 **パーサ変更（`src/parsers/markdown.ts`）**
 
-- `visit(tree, "listItem")` / `visit(tree, "heading")` の中で、ラベル文字列から
-  `(depends_on: X, Y)` / `(derives_from: Z)` を正規表現抽出し、`source = reqId`,
-  `target = X` のエッジを生成。
-- 抽出後、ラベル/ハッシュ計算には注釈を含めるか除くかを決める（drift 安定性の
-  観点では、注釈変更で req 本体が drift 扱いになるのを避けるため**注釈を除いた
-  本文でハッシュ**するのが望ましい）。
+- シグネチャを `parseMarkdown(filePath, rootDir?, options?: ParseMarkdownOptions)`
+  に拡張。`ParseMarkdownOptions = { autoDocNodes?: boolean; contains?: boolean }`。
+  builder から `config.docGraph` の該当フラグを渡す。
+- `autoDocNodes !== false` のとき、frontmatter の有無に関わらず各 md に `doc` ノードを
+  1 個生成。ID は §5.1。`contentHash` はファイル全体ハッシュ（既存 `fileHash`、
+  `:38`）。
+- 既存挙動との関係: req ノードは従来どおり併存。`node_id` 付き frontmatter の doc は
+  自動採番より優先（指定の尊重。互換目的ではない）。
 
-**builder 変更（`src/graph/builder.ts`）**
+**drift 粒度（レビュー指摘への対応）**
 
-- 現在 `isFromReq` 判定で req 由来エッジを `req.edges` に振り分けている（`:48-56`）。
-  req → req エッジはソースが req なのでこの経路に乗る。Pass 2 で source/target を
-  最終 ID（衝突時は `specDir/ID`）へ remap する必要がある。現状 target の remap が
-  req → req では未対応なので、**target も `idMapping` で解決**するよう拡張する。
+- doc ノードの `contentHash` はファイル全体。**散文を直すと doc が drift する**のは
+  仕様として受容する（ドキュメントの変更を検知するのが目的のため妥当）。
+- 同一ファイル内の req ノードは従来どおり**その req の本文のみ**でハッシュ（`:73`,
+  `:90-91`）。doc の drift と req の drift は独立。要求が変わらず散文だけ直した場合は
+  doc のみ drift し、req は drift しない。これは意図どおり。
 
-**relation 許容値の明確化**
+### 6.2 B: ドキュメント ⇔ ドキュメント依存（frontmatter）
 
-- `depends_on` / `derives_from` のみ正式サポート。
-- それ以外の値はビルド警告を出す。未リリースのため後方互換フォールバックは
-  設けず、既存 fixture `tests/fixtures/specs/auth.md` の
-  `relation: implements` は `derives_from` へ**修正する**（決定 #4）。
-
-### 6.2 B: ドキュメント ⇔ ドキュメントの依存（`doc → doc`）
-
-**入力記法**
-
-1. frontmatter（C-1）:
+**入力**
 
 ```yaml
 ---
@@ -233,114 +190,150 @@ spectrace:
 ---
 ```
 
-2. インラインリンク（C-2）/ 規約（C-3）から自動生成（6.3 参照）。
+- `relation` の許容値は **`depends_on` / `derives_from` のみ**。それ以外は
+  ビルド警告（`invalid-relation`）を出す。未リリースのためフォールバックは設けず、
+  既存 fixture `tests/fixtures/specs/auth.md` の `relation: implements` は
+  `derives_from` へ修正する。
+- ターゲットは別 doc の ID（B）または req ID（doc→req を frontmatter で明示する場合）。
 
-**builder 変更**
+**builder（`src/graph/builder.ts`）**
 
-- doc → doc エッジはソースが req でないため `nonReqEdges` 経路（`:48-56,116-127`）。
-  現状でも通るが、**target が存在しない doc を指す場合の警告**（`orphan-doc`）を
-  追加する。`findOrphans`（`src/graph/traverse.ts:61-73`）は現在 implements/verifies
-  のみ対象なので、doc 依存先の欠落も検出対象に含めるか検討（既定は警告のみ）。
+- doc→doc エッジはソースが req でないため `nonReqEdges` 経路（`:48-56,116-127`）。
+  既存どおり通る。
+- ターゲット未存在時に **`orphan-doc` 警告**を出す（§6.5）。
 
-### 6.3 C: 自動 doc ノード生成とリンク取得
+### 6.3 contains: doc → req の所属関係（旧 Issue #10、v1 昇格）
 
-#### C-1: ファイル＝doc ノードの自動生成
+**目的**: doc グラフと req/実装グラフを接続し、`design.md` 変更 → 中の要求 →
+実装まで impact が到達するようにする。
 
-**パーサ変更（`src/parsers/markdown.ts`）**
+**生成ロジック（`src/parsers/markdown.ts`）**
 
-- `config.docGraph.autoDocNodes !== false` のとき、frontmatter の有無に関わらず
-  各 md に対して `doc` ノードを必ず 1 個生成する。
-  - ID は 5.1 の規約。`node_id` があれば優先。
-  - `contentHash` はファイル全体ハッシュ（既存 `fileHash` を流用）。
-- 既存挙動との関係: これまで req ノードしか出さなかった `speckit-style.md` 等も、
-  追加で `doc:...` ノードを持つようになる。req ノードは従来どおり併存。
-- 「その md に属する req を、その doc から `contains` で結ぶか」は**本スコープ外**。
-  要求は引き続き独立ノードとし、`doc --contains--> req` は別タスクとして切り出した
-  （決定 #2 / Issue #10）。EdgeKind 追加が必要なため後続で扱う。
+- `contains !== false` のとき、1 つの md から生成した doc ノードと、その同じ md から
+  抽出した各 req ノードの間に `doc --contains--> req` エッジを張る。
+- doc ノードが無い（autoDocNodes=false かつ node_id 無し）場合は contains を張らない。
+- パーサはファイル単位で完結するため、doc とその file 内 req の対応は自明
+  （同一 `parseMarkdown` 呼び出し内で生成）。
 
-> パーサは `config` を受け取っていないため、`parseMarkdown` のシグネチャに
-> `options?: { docGraph?: ... }` を追加し、builder から渡す。
+**builder の ID remap 整合**
 
-#### C-2: インラインリンクの自動抽出
+- 衝突した req は最終 ID が `specDir/REQ` に変わる（`:77-108`）。contains エッジの
+  ターゲットも同じ remap を通す必要がある。contains は req をソースに持たない
+  （ソースは doc）ため `nonReqEdges` 経路に乗る。`remapId`（`:180-193`）が
+  ターゲット req を解決できるよう、**contains も remap 対象に含める**。
 
-**パーサ変更**
+**impact への影響（ブラストradius、レビュー指摘 #3 への対応）**
 
-- remark AST を `visit(tree, "link")` で走査し、`url` が**ローカルの相対 .md**を
-  指すものを抽出。
-- 解決: リンク元 md の doc ノード ID → リンク先パスを正規化し、対応する doc
-  ノード ID（5.1 規約 or `node_id`）へエッジを張る。`via: "inline-link"`。
-- 向き: **常に `depends_on`**（決定 #1）。インラインリンクは参照・脚注・派生が
-  混在し書き手の意図がばらつくため、弱い意味の `depends_on` で安全側に倒す。
-  強い「派生」の意味を持たせる連鎖は、より確実な C-3（規約推論）で `derives_from`
-  を張る、と役割分担する。frontmatter（C-1）で明示する場合は `relation` で上書き可。
-- 解決できないリンク（外部 URL、アンカーのみ、対象 md がスキャン対象外）は無視。
+- contains により doc 起点の impact が中の全 req＋実装へ広がる。これは**意図した
+  挙動**（一気通貫トレースの実現）。
+- ただし「広がりすぎ」を可視化するため、`impact` 出力に到達ノード数の内訳
+  （docs / reqs / files）を表示する（既存 `ImpactResult` のまま CLI 表示を拡充）。
+- 上限深さ等の制御は v1 では入れない（必要なら後続）。
 
-#### C-3: ツール規約の自動推論
+### 6.4 builder のエッジデデュープ
 
-**新規モジュール（例: `src/graph/conventions.ts`）**
+- 全エッジ確定後、`(source, target, kind)` をキーに重複を除去する単純パスを追加。
+- v1 では入力経路が限られるため重複は稀だが、frontmatter で同じ依存を二重記載した
+  場合などの保険。
 
-- builder が全 md をパースした後、`config.docGraph.conventions` に応じて
-  フォルダ単位でファイル名パターンを照合し、連鎖エッジを生成する。
+### 6.5 orphan-doc / 名前空間検証
 
-| 規約 | 検出 | 生成エッジ（derives_from, via: "convention"） |
-| --- | --- | --- |
-| `kiro` | 同一ディレクトリ内の `requirements.md` / `design.md` / `tasks.md` | `design → requirements`、`tasks → design` |
-| `spec-kit` | 同一ディレクトリ内の `spec.md` / `plan.md` / `tasks.md`（+ `research.md`） | `plan → spec`、`tasks → plan`、`research → spec` |
+- `findOrphans`（`src/graph/traverse.ts:61-73`）を拡張し、`depends_on` /
+  `derives_from` でターゲットノードが存在しないものを `orphan` として報告する
+  （現状は implements/verifies のみ）。
+- builder で req ID が予約プレフィクス（`doc:` 等）を使っていないか検証し、
+  使用時は警告。
 
-- 規約推論は **C-1（doc ノード自動生成）が前提**。対象ファイルが doc ノードと
-  して存在する場合のみエッジを張る。
-- 重複（C-1/C-2/C-3 で同じ source→target が複数回出る）は builder でデデュープ。
+### 6.6 graph 出力コマンド
 
-### 6.4 優先順位の推奨実装順
+**新規 CLI サブコマンド `spectrace graph`（`src/cli.ts`）**
 
-1. C-1（doc ノード自動生成）+ B（doc → doc, frontmatter）— グラフの骨格。
-2. C-2（インラインリンク）— 手書き不要で連鎖が埋まる。
-3. C-3（規約推論）— ツール出力をそのまま投入できる。
-4. A（req → req）— ドキュメント内・要求粒度の依存。
+- `spectrace graph [--format text|json] [--kind doc|req|all]`
+  - `--format text`（既定）: doc を起点に依存チェーンをインデント表示。
+    ```
+    doc:003-chat/tasks.md
+      └─ derives_from → doc:003-chat/design.md
+           └─ derives_from → doc:003-chat/requirements.md
+                └─ contains → AUTH-001  (impl: src/auth/login.ts)
+    ```
+  - `--format json`: `{ nodes: [...], edges: [...] }` をそのまま出力（機械可読・
+    後続の可視化やCIで利用）。
+  - `--kind` で表示対象ノード種別を絞り込み（既定 all）。
+- 実装はグラフを構築して整形するだけ。DOT/Mermaid は後続 Issue。
 
-## 7. 影響範囲まとめ（ファイル別）
+## 7. 影響範囲（ファイル別）
 
-| ファイル | 変更内容 |
+| ファイル | 変更 |
 | --- | --- |
-| `src/types.ts` | `GraphEdge.via?` 追加、`SpectraceConfig.docGraph?` 追加 |
-| `src/parsers/markdown.ts` | C-1 自動 doc ノード、C-2 インラインリンク抽出、A の req→req 注釈抽出、relation 検証、シグネチャに options 追加 |
-| `src/graph/builder.ts` | req→req の target remap、doc→doc の orphan 警告、規約推論呼び出し、エッジ デデュープ |
-| `src/graph/conventions.ts`（新規） | C-3 Kiro/Spec Kit 規約推論 |
-| `src/graph/traverse.ts` | 変更ほぼ不要（双方向 BFS が新エッジを自動処理）。orphan-doc を含める場合のみ拡張 |
-| `src/lock.ts` | 変更不要（doc ノード増・dependsOn は既存ロジックで対応） |
-| `src/cli.ts` | `scan` のサマリにエッジ種別別カウントを追加（任意） |
+| `src/types.ts` | `EdgeKind` に `contains` 追加、`SpectraceConfig.docGraph?`（2 フラグ）追加 |
+| `src/parsers/markdown.ts` | C-1 自動 doc ノード、contains エッジ、relation 検証、options 引数追加 |
+| `src/graph/builder.ts` | contains の target remap、エッジデデュープ、req ID 予約プレフィクス検証、orphan-doc |
+| `src/graph/traverse.ts` | `findOrphans` を depends_on/derives_from に拡張。impact は変更不要（双方向 BFS） |
+| `src/lock.ts` | `contains` は lock 化しない（doc/req のハッシュは従来どおり保存）。doc ノード増は既存ロジックで吸収 |
+| `src/cli.ts` | `graph` サブコマンド追加、`impact` 出力に到達内訳表示 |
 
-## 8. 互換性・移行
+### 7.1 lock と contains（レビュー指摘への対応）
 
-本プロダクトは**未リリース**のため、後方互換性は考慮しない（決定 #4）。
+- `buildLockFromGraph`（`src/lock.ts:24-59`）は req/doc ノードをハッシュ保存する。
+  **`contains` エッジは lock に永続化しない**（毎回グラフから再生成できる構造情報の
+  ため）。lock は drift 検知用のハッシュ台帳という役割を維持し、所属関係は graph で
+  都度導出する。これにより「doc が req を含む／req が doc に属する」の二重管理を避ける。
 
-- `node_id` 付き frontmatter は引き続き優先的に使われる（C-1 の自動採番より優先）。
-  これは互換のためではなく、明示指定を尊重する仕様として残す。
-- 自動 doc ノード ON により lock に doc エントリが増えるが、移行案内・周知は不要。
-  必要なら `reconcile` を一度実行すればよい。
-- relation の不正値はフォールバックせず警告とし、fixture 側を正す（6.1 参照）。
-- 規約推論（C-3）は既定 OFF（オプトイン）。これは互換ではなく誤検出回避のため。
+## 8. 互換性
+
+未リリースのため後方互換は考慮しない。
+
+- 自動 doc ノードで lock に doc エントリが増えるが周知不要。必要なら `reconcile` を実行。
+- relation 不正値はフォールバックせず警告。fixture を修正（§6.2）。
+- `EdgeKind` への `contains` 追加は既存の switch/フィルタに影響しないか確認する
+  （`traverse.ts:32-44` の node-kind switch は影響なし。エッジ kind を網羅的に
+  分岐している箇所が無いか実装時に grep）。
 
 ## 9. テスト方針
 
-- fixtures に Kiro 形式（`requirements.md`/`design.md`/`tasks.md`）と Spec Kit
-  形式（`spec.md`/`plan.md`/`tasks.md`）のフォルダを追加。
-- 単体: markdown パーサが (a) 自動 doc ノード、(b) インラインリンク、(c) req→req
-  注釈、を期待どおり出すこと。
-- 統合: builder + traverse で
-  `tasks.md` を起点に `design.md` → `requirements.md` まで `impact` が伝播すること。
-- 回帰: 既存 `auth.md`/`speckit-style.md`/`kiro-style.md` で「req ノードは不変・
-  doc ノードが追加される」形であること（auth.md の relation 修正は除く）。
+- fixtures に Kiro 形式（`requirements.md`/`design.md`/`tasks.md`、frontmatter で
+  doc 連鎖を記述）を追加。design.md は**要求 ID を含まない散文**にし、C-1 で doc
+  ノードが生成されることを検証。
+- 単体（markdown パーサ）:
+  - 散文のみの md から doc ノードが 1 個生成される。
+  - req を含む md で `doc --contains--> req` が張られる。
+  - frontmatter の不正 relation で警告が出る。
+- 統合（builder + traverse）:
+  - `tasks.md` 起点の `impact` が `design.md` → `requirements.md` → 中の req →
+    実装ファイルまで到達する（contains 経由の一気通貫）。
+  - 衝突 req を含む doc の contains が正しく remap される。
+  - orphan-doc / 予約プレフィクス検証の警告。
+  - エッジデデュープ（frontmatter 二重記載が 1 本になる）。
+- CLI: `graph --format json` の出力スナップショット、`graph --format text` の整形。
+- 回帰: 既存 `auth.md`/`speckit-style.md`/`kiro-style.md` で「req ノード不変・doc
+  ノード追加・contains 追加」（auth.md の relation 修正を除く）。
 
-## 10. 決定事項
+## 10. 実装順
 
-レビューを経て確定した方針（2026-06-20）。
+1. C-1（自動 doc ノード）+ parser options 整備。
+2. contains エッジ + builder remap/dedup/検証。
+3. B（frontmatter doc↔doc）+ orphan-doc。
+4. `graph` 出力コマンド + `impact` 内訳表示。
+
+最小で価値が出るのは 1+2（doc 化と一気通貫）。3 で doc 連鎖、4 で可視化。
+
+## 11. 後続 Issue（v1 から外したもの）
+
+| 項目 | 内容 | 備考 |
+| --- | --- | --- |
+| C-2 | インラインリンク `[x](./y.md)` の doc→doc 自動抽出 | アンカー/参照型リンク/パス正規化/可逆 ID 解決を要設計 |
+| C-3 | Kiro/Spec Kit 規約の自動推論 + 設定可能 `ConventionPreset` | まず固定プリセット、設定可は需要次第 |
+| A | 要求 ⇔ 要求（`req → req`）依存 | 実出力は散文中心で価値限定。インライン注釈の regex 誤検出/ハッシュ安定性を要設計 |
+| via | エッジ取得元メタ + `--explain-edges` | C-2/C-3 導入時に provenance が要るなら |
+| viz | DOT / Mermaid 可視化 | `graph --format json` を入力に後付け可能 |
+
+## 12. 決定ログ
 
 | # | 論点 | 決定 |
 | --- | --- | --- |
-| 1 | インラインリンク（C-2）の向き | **常に `depends_on`**。弱い意味で安全側に倒す。派生の連鎖は C-3 が `derives_from` で担う。 |
-| 2 | `doc --contains--> req` の導入 | **本スコープ外**。Issue #10 として別タスク化。EdgeKind 追加を伴うため後続で対応。 |
-| 3 | 規約推論のファイル名 | **設定可能**にする。組み込み `kiro`/`spec-kit` プリセットで設定ゼロで動き、`ConventionPreset` で上書き・追加可。 |
-| 4 | 自動 doc ノード ON の lock 差分 | 未リリースのため**後方互換・周知は不要**。fixture の不正 relation は修正する。 |
-
-関連 Issue: [#10 doc→req 所属関係エッジ (contains)](https://github.com/ShintaroMorimoto/spectrace/issues/10)
+| 1 | doc↔doc の向き競合・デデュープ | v1 は frontmatter 1 経路に限定し競合を回避。デデュープキーは `(source,target,kind)` |
+| 2 | `doc contains req` | **v1 に昇格**（旧 Issue #10）。一気通貫トレースの骨格 |
+| 3 | 規約推論の設定可能化 | **v1 から除外**。後続 Issue。まず固定、需要次第で設定可 |
+| 4 | 自動 doc ノードの lock 差分 | 未リリースのため周知不要。fixture の不正 relation は修正 |
+| 5 | グラフ可視化 | text/JSON 出力を v1 に追加。リッチ可視化は後続 |
+| 6 | 前提（実 SDD 出力の要求 ID） | 散文中心と認識。doc グラフを基本単位とし req 抽出はベストエフォート |

--- a/docs/design/document-graph.md
+++ b/docs/design/document-graph.md
@@ -159,13 +159,27 @@ export interface SpectraceConfig {
   docGraph?: {
     autoDocNodes?: boolean;        // C-1: md=doc ノード自動生成（既定 true）
     inlineLinks?: boolean;         // C-2: インラインリンク抽出（既定 true）
-    conventions?: Array<"kiro" | "spec-kit">; // C-3: 規約推論（既定 []）
+    // C-3: 規約推論（既定 []）。組み込みプリセット名か、独自定義を渡せる。
+    conventions?: Array<"kiro" | "spec-kit" | ConventionPreset>;
   };
+}
+
+// 規約推論のプリセット定義。組み込み "kiro"/"spec-kit" もこの形で内部表現する。
+export interface ConventionPreset {
+  name: string;
+  // 同一ディレクトリ内で照合するファイル名と、派生先（上流）のファイル名。
+  // 例: { file: "design.md", derivesFrom: ["requirements.md"] }
+  chain: Array<{ file: string; derivesFrom: string[] }>;
 }
 ```
 
 既定値は「自動 doc ノード ON・インラインリンク ON・規約推論 OFF」とし、
 規約推論は明示的にオプトインさせる（誤検出リスクを抑えるため）。
+
+**規約推論は設定可能（決定 #3）**: 組み込みプリセット `"kiro"` / `"spec-kit"`
+を文字列で指定すれば**設定ゼロで動く**。独自のファイル名・連鎖を使うチームは
+`ConventionPreset` オブジェクトを渡して上書き・追加できる。組み込みプリセットも
+内部的には同じ `ConventionPreset` 構造で定義し、ユーザー定義と同じ経路で処理する。
 
 ## 6. 各機能の設計
 
@@ -200,8 +214,9 @@ export interface SpectraceConfig {
 **relation 許容値の明確化**
 
 - `depends_on` / `derives_from` のみ正式サポート。
-- それ以外（例: 既存 fixture の `implements`）は警告を出しつつ `depends_on` に
-  フォールバック（後方互換）。将来的に fixture を `derives_from` へ修正。
+- それ以外の値はビルド警告を出す。未リリースのため後方互換フォールバックは
+  設けず、既存 fixture `tests/fixtures/specs/auth.md` の
+  `relation: implements` は `derives_from` へ**修正する**（決定 #4）。
 
 ### 6.2 B: ドキュメント ⇔ ドキュメントの依存（`doc → doc`）
 
@@ -239,9 +254,9 @@ spectrace:
   - `contentHash` はファイル全体ハッシュ（既存 `fileHash` を流用）。
 - 既存挙動との関係: これまで req ノードしか出さなかった `speckit-style.md` 等も、
   追加で `doc:...` ノードを持つようになる。req ノードは従来どおり併存。
-- 「その md に属する req は、その doc から `contains`/`derives_from` で結ぶか」は
-  オプション。まずは**結ばない**（要求は引き続き独立ノード）で開始し、必要なら
-  後続で `doc --contains--> req` を追加検討（EdgeKind 追加が必要なので別途）。
+- 「その md に属する req を、その doc から `contains` で結ぶか」は**本スコープ外**。
+  要求は引き続き独立ノードとし、`doc --contains--> req` は別タスクとして切り出した
+  （決定 #2 / Issue #10）。EdgeKind 追加が必要なため後続で扱う。
 
 > パーサは `config` を受け取っていないため、`parseMarkdown` のシグネチャに
 > `options?: { docGraph?: ... }` を追加し、builder から渡す。
@@ -253,10 +268,11 @@ spectrace:
 - remark AST を `visit(tree, "link")` で走査し、`url` が**ローカルの相対 .md**を
   指すものを抽出。
 - 解決: リンク元 md の doc ノード ID → リンク先パスを正規化し、対応する doc
-  ノード ID（5.1 規約 or `node_id`）へ `derives_from`（既定）または `depends_on`
-  のエッジを張る。`via: "inline-link"`。
-- 向きの既定: 「自分が参照している先 = 依存先」とみなし `A --depends_on--> B`。
-  ただし規約由来（C-3）の連鎖は `derives_from` を使う。
+  ノード ID（5.1 規約 or `node_id`）へエッジを張る。`via: "inline-link"`。
+- 向き: **常に `depends_on`**（決定 #1）。インラインリンクは参照・脚注・派生が
+  混在し書き手の意図がばらつくため、弱い意味の `depends_on` で安全側に倒す。
+  強い「派生」の意味を持たせる連鎖は、より確実な C-3（規約推論）で `derives_from`
+  を張る、と役割分担する。frontmatter（C-1）で明示する場合は `relation` で上書き可。
 - 解決できないリンク（外部 URL、アンカーのみ、対象 md がスキャン対象外）は無視。
 
 #### C-3: ツール規約の自動推論
@@ -294,15 +310,16 @@ spectrace:
 | `src/lock.ts` | 変更不要（doc ノード増・dependsOn は既存ロジックで対応） |
 | `src/cli.ts` | `scan` のサマリにエッジ種別別カウントを追加（任意） |
 
-## 8. 後方互換性
+## 8. 互換性・移行
 
-- `node_id` 付き frontmatter は従来どおり動作（優先される）。
-- 既存の `depends_on: [{ relation: implements }]` は警告付きで `depends_on` に
-  フォールバックし、エラーにしない。
-- `docGraph` 未設定でも、自動 doc ノード/インラインリンクは既定 ON のため、
-  既存プロジェクトでもグラフが豊かになる。**lock の差分が出る**点に注意し、
-  リリース時は `reconcile` の実行を案内する。
-- 規約推論（C-3）は既定 OFF。誤検出を避けるためオプトイン。
+本プロダクトは**未リリース**のため、後方互換性は考慮しない（決定 #4）。
+
+- `node_id` 付き frontmatter は引き続き優先的に使われる（C-1 の自動採番より優先）。
+  これは互換のためではなく、明示指定を尊重する仕様として残す。
+- 自動 doc ノード ON により lock に doc エントリが増えるが、移行案内・周知は不要。
+  必要なら `reconcile` を一度実行すればよい。
+- relation の不正値はフォールバックせず警告とし、fixture 側を正す（6.1 参照）。
+- 規約推論（C-3）は既定 OFF（オプトイン）。これは互換ではなく誤検出回避のため。
 
 ## 9. テスト方針
 
@@ -312,15 +329,18 @@ spectrace:
   注釈、を期待どおり出すこと。
 - 統合: builder + traverse で
   `tasks.md` を起点に `design.md` → `requirements.md` まで `impact` が伝播すること。
-- 後方互換: 既存 `auth.md`/`speckit-style.md`/`kiro-style.md` のスナップショットが
-  「req ノードは不変・doc ノードが追加される」形であること。
+- 回帰: 既存 `auth.md`/`speckit-style.md`/`kiro-style.md` で「req ノードは不変・
+  doc ノードが追加される」形であること（auth.md の relation 修正は除く）。
 
-## 10. 未決事項（要レビュー）
+## 10. 決定事項
 
-1. インラインリンクの既定の向きは `depends_on` でよいか（`derives_from` の方が
-   自然なケースもある）。
-2. `doc --contains--> req`（ファイルとその中の要求の所属関係）を導入するか。
-   導入すると「ファイル単位の影響」と「要求単位の影響」を綺麗に橋渡しできるが、
-   `EdgeKind` 追加が必要。
-3. 規約推論の対象ファイル名は固定でよいか、設定で上書き可能にするか。
-4. 自動 doc ノード ON による既存 lock の差分をどう周知するか（マイグレーション）。
+レビューを経て確定した方針（2026-06-20）。
+
+| # | 論点 | 決定 |
+| --- | --- | --- |
+| 1 | インラインリンク（C-2）の向き | **常に `depends_on`**。弱い意味で安全側に倒す。派生の連鎖は C-3 が `derives_from` で担う。 |
+| 2 | `doc --contains--> req` の導入 | **本スコープ外**。Issue #10 として別タスク化。EdgeKind 追加を伴うため後続で対応。 |
+| 3 | 規約推論のファイル名 | **設定可能**にする。組み込み `kiro`/`spec-kit` プリセットで設定ゼロで動き、`ConventionPreset` で上書き・追加可。 |
+| 4 | 自動 doc ノード ON の lock 差分 | 未リリースのため**後方互換・周知は不要**。fixture の不正 relation は修正する。 |
+
+関連 Issue: [#10 doc→req 所属関係エッジ (contains)](https://github.com/ShintaroMorimoto/spectrace/issues/10)


### PR DESCRIPTION
Design covering req↔req (A), doc↔doc (B), and auto doc-node generation
with three link-acquisition methods (frontmatter, inline links, tool
conventions for Kiro/Spec Kit) (C).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0134GEjnQQJNi6GMyQw1PiUH