### PR TITLE
feat: symbol-level 粒度の解析モードを追加

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,18 +7,27 @@ import { impact, resolveStartIds } from "./graph/traverse.js";
 import { check } from "./check.js";
 import { readLock } from "./lock.js";
 import { getGitDiffFiles } from "./diff.js";
+import type { SpectraceConfig } from "./types.js";
 
 const program = new Command();
 
 program.name("spectrace").description("Typed artifact graph for TS/JS").version("0.1.0");
 
+function applyMode(config: SpectraceConfig, modeFlag?: string): SpectraceConfig {
+  if (modeFlag === "symbol" || modeFlag === "file") {
+    return { ...config, mode: modeFlag };
+  }
+  return config;
+}
+
 program
   .command("scan")
   .description("Build the artifact graph and show summary")
   .option("--format <format>", "Output format: json | text", "text")
+  .option("--mode <mode>", "Analysis mode: file | symbol")
   .action((opts) => {
     const rootDir = process.cwd();
-    const config = loadConfig(rootDir);
+    const config = applyMode(loadConfig(rootDir), opts.mode);
     const result = scan(rootDir, config);
 
     if (opts.format === "json") {
@@ -29,15 +38,22 @@ program
           reqCount: result.reqCount,
           docCount: result.docCount,
           fileCount: result.fileCount,
+          symbolCount: result.symbolCount,
           testCount: result.testCount,
           warnings: result.warnings,
         }),
       );
     } else {
       console.log(`Nodes: ${result.nodeCount}  Edges: ${result.edgeCount}`);
-      console.log(
-        `  req: ${result.reqCount}  doc: ${result.docCount}  file: ${result.fileCount}  test: ${result.testCount}`,
-      );
+      if (result.symbolCount > 0) {
+        console.log(
+          `  req: ${result.reqCount}  doc: ${result.docCount}  file: ${result.fileCount}  symbol: ${result.symbolCount}  test: ${result.testCount}`,
+        );
+      } else {
+        console.log(
+          `  req: ${result.reqCount}  doc: ${result.docCount}  file: ${result.fileCount}  test: ${result.testCount}`,
+        );
+      }
       for (const w of result.warnings) {
         if (w.type === "ambiguous-id") {
           const hint = w.files.length > 0 ? ` (candidates: ${w.files.join(", ")})` : "";
@@ -55,9 +71,10 @@ program
   .argument("[targets...]", "File paths or REQ-IDs")
   .option("--diff", "Use git diff to detect changed files")
   .option("--format <format>", "Output format: json | text", "text")
+  .option("--mode <mode>", "Analysis mode: file | symbol")
   .action((targets: string[], opts) => {
     const rootDir = process.cwd();
-    const config = loadConfig(rootDir);
+    const config = applyMode(loadConfig(rootDir), opts.mode);
     const { graph } = scan(rootDir, config);
     const lock = readLock(rootDir, config.lockFile);
 
@@ -92,9 +109,10 @@ program
   .option("--gate", "Exit 2 on any issue (for Stop hook)")
   .option("--diff", "Scope check to files changed in git diff")
   .option("--format <format>", "Output format: json | text", "text")
+  .option("--mode <mode>", "Analysis mode: file | symbol")
   .action((opts) => {
     const rootDir = process.cwd();
-    const config = loadConfig(rootDir);
+    const config = applyMode(loadConfig(rootDir), opts.mode);
     const { graph, warnings } = scan(rootDir, config);
     const lock = readLock(rootDir, config.lockFile);
 
@@ -117,6 +135,13 @@ program
         ...impactResult.affectedDocs.map((d) => d),
         ...impactResult.affectedFiles.map((f) => `file:${f}`),
       ]);
+      for (const f of impactResult.affectedFiles) {
+        for (const [id, node] of graph.nodes) {
+          if (node.kind === "symbol" && node.filePath === f) {
+            scopedNodeIds.add(id);
+          }
+        }
+      }
     }
     const result = check(graph, lock, scopedNodeIds);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { loadConfig } from "./config.js";
 import { scan, reconcile } from "./scan.js";
 import { impact, resolveStartIds } from "./graph/traverse.js";
@@ -24,7 +24,7 @@ program
   .command("scan")
   .description("Build the artifact graph and show summary")
   .option("--format <format>", "Output format: json | text", "text")
-  .option("--mode <mode>", "Analysis mode: file | symbol")
+  .addOption(new Option("--mode <mode>", "Analysis mode").choices(["file", "symbol"]))
   .action((opts) => {
     const rootDir = process.cwd();
     const config = applyMode(loadConfig(rootDir), opts.mode);
@@ -71,7 +71,7 @@ program
   .argument("[targets...]", "File paths or REQ-IDs")
   .option("--diff", "Use git diff to detect changed files")
   .option("--format <format>", "Output format: json | text", "text")
-  .option("--mode <mode>", "Analysis mode: file | symbol")
+  .addOption(new Option("--mode <mode>", "Analysis mode").choices(["file", "symbol"]))
   .action((targets: string[], opts) => {
     const rootDir = process.cwd();
     const config = applyMode(loadConfig(rootDir), opts.mode);
@@ -109,7 +109,7 @@ program
   .option("--gate", "Exit 2 on any issue (for Stop hook)")
   .option("--diff", "Scope check to files changed in git diff")
   .option("--format <format>", "Output format: json | text", "text")
-  .option("--mode <mode>", "Analysis mode: file | symbol")
+  .addOption(new Option("--mode <mode>", "Analysis mode").choices(["file", "symbol"]))
   .action((opts) => {
     const rootDir = process.cwd();
     const config = applyMode(loadConfig(rootDir), opts.mode);
@@ -167,9 +167,10 @@ program
 program
   .command("reconcile")
   .description("Update the lock file to match current state")
-  .action(() => {
+  .addOption(new Option("--mode <mode>", "Analysis mode").choices(["file", "symbol"]))
+  .action((opts) => {
     const rootDir = process.cwd();
-    const config = loadConfig(rootDir);
+    const config = applyMode(loadConfig(rootDir), opts.mode);
     const { graph } = scan(rootDir, config);
     reconcile(rootDir, config, graph);
     console.log(`Lock file updated: ${config.lockFile}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,5 +22,6 @@ export function loadConfig(rootDir: string): SpectraceConfig {
     testPatterns: raw.testPatterns ?? DEFAULT_CONFIG.testPatterns,
     lockFile: raw.lockFile ?? DEFAULT_CONFIG.lockFile,
     reqPatterns: raw.reqPatterns,
+    mode: raw.mode === "symbol" ? "symbol" : "file",
   };
 }

--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -128,7 +128,7 @@ export function buildGraph(
 
   // Parse TypeScript files
   const codePatterns = [...config.include, ...config.testPatterns];
-  const tsParser = createTSParser(rootDir, codePatterns);
+  const tsParser = createTSParser(rootDir, codePatterns, config.mode ?? "file");
   const tsResult = tsParser.parse();
 
   for (const node of tsResult.nodes) {

--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -99,6 +99,11 @@ export function resolveStartIds(graph: ArtifactGraph, inputs: string[]): string[
     const fileId = `file:${input}`;
     if (graph.nodes.has(fileId)) {
       ids.push(fileId);
+      for (const [id, node] of graph.nodes) {
+        if (node.kind === "symbol" && node.filePath === input) {
+          ids.push(id);
+        }
+      }
       continue;
     }
 

--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -10,6 +10,15 @@ export function impact(graph: ArtifactGraph, startIds: string[], lock: LockFile)
     if (visited.has(id)) continue;
     visited.add(id);
 
+    const node = graph.nodes.get(id);
+    if (node && node.kind === "file") {
+      for (const [symId, symNode] of graph.nodes) {
+        if (symNode.kind === "symbol" && symNode.filePath === node.filePath && !visited.has(symId)) {
+          queue.push(symId);
+        }
+      }
+    }
+
     for (const edge of graph.edges) {
       if (edge.source === id && !visited.has(edge.target)) {
         queue.push(edge.target);
@@ -20,7 +29,7 @@ export function impact(graph: ArtifactGraph, startIds: string[], lock: LockFile)
     }
   }
 
-  const affectedFiles: string[] = [];
+  const affectedFileSet = new Set<string>();
   const affectedDocs: string[] = [];
   const affectedReqs: string[] = [];
   const drifted: DriftEntry[] = [];
@@ -33,7 +42,7 @@ export function impact(graph: ArtifactGraph, startIds: string[], lock: LockFile)
       case "file":
       case "symbol":
       case "test":
-        affectedFiles.push(node.filePath);
+        affectedFileSet.add(node.filePath);
         break;
       case "doc":
         affectedDocs.push(id);
@@ -55,7 +64,7 @@ export function impact(graph: ArtifactGraph, startIds: string[], lock: LockFile)
     }
   }
 
-  return { affectedFiles, affectedDocs, affectedReqs, drifted };
+  return { affectedFiles: [...affectedFileSet], affectedDocs, affectedReqs, drifted };
 }
 
 export function findOrphans(graph: ArtifactGraph): string[] {

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -26,7 +26,7 @@ export function buildLockFromGraph(graph: ArtifactGraph): LockFile {
   const now = new Date().toISOString();
 
   for (const [id, node] of graph.nodes) {
-    if (node.kind !== "req" && node.kind !== "doc") continue;
+    if (node.kind !== "req" && node.kind !== "doc" && node.kind !== "symbol") continue;
 
     const entry: LockEntry = {
       contentHash: node.contentHash,

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -28,6 +28,11 @@ export function buildLockFromGraph(graph: ArtifactGraph): LockFile {
   for (const [id, node] of graph.nodes) {
     if (node.kind !== "req" && node.kind !== "doc" && node.kind !== "symbol") continue;
 
+    if (node.kind === "symbol") {
+      lock[id] = { contentHash: node.contentHash, lastReconciled: now };
+      continue;
+    }
+
     const entry: LockEntry = {
       contentHash: node.contentHash,
       lastReconciled: now,

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -77,28 +77,31 @@ function extractSymbols(
 ): SymbolRange[] {
   const ranges: SymbolRange[] = [];
   const exported = sourceFile.getExportedDeclarations();
+  const seen = new Set<string>();
 
   for (const [name, declarations] of exported) {
-    for (const decl of declarations) {
-      if (decl.getSourceFile() !== sourceFile) continue;
+    const symbolName = name === "default" ? "default" : name;
+    if (seen.has(symbolName)) continue;
 
-      const symbolName = name === "default" ? "default" : name;
-      const symbolId = `symbol:${relPath}#${symbolName}`;
-      const symbolHash = hash(decl.getText());
+    const localDecl = declarations.find((d) => d.getSourceFile() === sourceFile);
+    if (!localDecl) continue;
 
-      nodes.push({
-        id: symbolId,
-        kind: "symbol",
-        filePath: relPath,
-        contentHash: symbolHash,
-      });
+    seen.add(symbolName);
+    const symbolId = `symbol:${relPath}#${symbolName}`;
+    const symbolHash = hash(localDecl.getText());
 
-      ranges.push({
-        name: symbolName,
-        startLine: decl.getStartLineNumber(),
-        endLine: decl.getEndLineNumber(),
-      });
-    }
+    nodes.push({
+      id: symbolId,
+      kind: "symbol",
+      filePath: relPath,
+      contentHash: symbolHash,
+    });
+
+    ranges.push({
+      name: symbolName,
+      startLine: localDecl.getStartLineNumber(),
+      endLine: localDecl.getEndLineNumber(),
+    });
   }
 
   return ranges;

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -17,7 +17,13 @@ interface ParsedTS {
   edges: GraphEdge[];
 }
 
-export function createTSParser(rootDir: string, patterns: string[]) {
+interface SymbolRange {
+  name: string;
+  startLine: number;
+  endLine: number;
+}
+
+export function createTSParser(rootDir: string, patterns: string[], mode: "file" | "symbol" = "file") {
   const tsconfigPath = resolve(rootDir, "tsconfig.json");
   const projectOpts = existsSync(tsconfigPath)
     ? { tsConfigFilePath: tsconfigPath, skipAddingFilesFromTsConfig: true }
@@ -28,10 +34,10 @@ export function createTSParser(rootDir: string, patterns: string[]) {
     project.addSourceFilesAtPaths(resolve(rootDir, pattern));
   }
 
-  return { project, parse: () => parseProject(project, rootDir) };
+  return { project, parse: () => parseProject(project, rootDir, mode) };
 }
 
-function parseProject(project: Project, rootDir: string): ParsedTS {
+function parseProject(project: Project, rootDir: string, mode: "file" | "symbol"): ParsedTS {
   const nodes: GraphNode[] = [];
   const edges: GraphEdge[] = [];
 
@@ -51,11 +57,51 @@ function parseProject(project: Project, rootDir: string): ParsedTS {
       contentHash: fileHash,
     });
 
-    extractImports(sourceFile, relPath, rootDir, edges);
-    extractImplTags(fileContent, relPath, isTest, edges);
+    let symbolRanges: SymbolRange[] = [];
+
+    if (mode === "symbol" && !isTest) {
+      symbolRanges = extractSymbols(sourceFile, relPath, nodes);
+    }
+
+    extractImports(sourceFile, relPath, rootDir, edges, mode, isTest);
+    extractImplTags(fileContent, relPath, isTest, edges, mode, symbolRanges);
   }
 
   return { nodes, edges };
+}
+
+function extractSymbols(
+  sourceFile: SourceFile,
+  relPath: string,
+  nodes: GraphNode[],
+): SymbolRange[] {
+  const ranges: SymbolRange[] = [];
+  const exported = sourceFile.getExportedDeclarations();
+
+  for (const [name, declarations] of exported) {
+    for (const decl of declarations) {
+      if (decl.getSourceFile() !== sourceFile) continue;
+
+      const symbolName = name === "default" ? "default" : name;
+      const symbolId = `symbol:${relPath}#${symbolName}`;
+      const symbolHash = hash(decl.getText());
+
+      nodes.push({
+        id: symbolId,
+        kind: "symbol",
+        filePath: relPath,
+        contentHash: symbolHash,
+      });
+
+      ranges.push({
+        name: symbolName,
+        startLine: decl.getStartLineNumber(),
+        endLine: decl.getEndLineNumber(),
+      });
+    }
+  }
+
+  return ranges;
 }
 
 function extractImports(
@@ -63,21 +109,44 @@ function extractImports(
   relPath: string,
   rootDir: string,
   edges: GraphEdge[],
+  mode: "file" | "symbol" = "file",
+  isTest: boolean = false,
 ) {
   const sourceId = `file:${relPath}`;
+  const useSymbol = mode === "symbol" && !isTest;
 
   for (const decl of sourceFile.getImportDeclarations()) {
     const moduleSpecifier = decl.getModuleSpecifierValue();
-    if (moduleSpecifier.startsWith(".")) {
-      const resolved = resolveImport(sourceFile, decl);
-      if (resolved) {
-        const targetRel = relative(rootDir, resolved);
-        edges.push({
-          source: sourceId,
-          target: `file:${targetRel}`,
-          kind: "imports",
-        });
+    if (!moduleSpecifier.startsWith(".")) continue;
+
+    const resolved = resolveImport(sourceFile, decl);
+    if (!resolved) continue;
+
+    const targetRel = relative(rootDir, resolved);
+
+    if (useSymbol) {
+      const namedImports = decl.getNamedImports();
+      const defaultImport = decl.getDefaultImport();
+      const namespaceImport = decl.getNamespaceImport();
+
+      if (namespaceImport) {
+        edges.push({ source: sourceId, target: `file:${targetRel}`, kind: "imports" });
+      } else {
+        if (defaultImport) {
+          edges.push({ source: sourceId, target: `symbol:${targetRel}#default`, kind: "imports" });
+        }
+        for (const named of namedImports) {
+          const importName = named.getAliasNode()
+            ? named.getNameNode().getText()
+            : named.getName();
+          edges.push({ source: sourceId, target: `symbol:${targetRel}#${importName}`, kind: "imports" });
+        }
+        if (!defaultImport && namedImports.length === 0 && !namespaceImport) {
+          edges.push({ source: sourceId, target: `file:${targetRel}`, kind: "imports" });
+        }
       }
+    } else {
+      edges.push({ source: sourceId, target: `file:${targetRel}`, kind: "imports" });
     }
   }
 
@@ -106,22 +175,35 @@ function resolveImport(sourceFile: SourceFile, decl: any): string | undefined {
   }
 }
 
-function extractImplTags(content: string, relPath: string, isTest: boolean, edges: GraphEdge[]) {
-  const sourceId = `file:${relPath}`;
+function extractImplTags(
+  content: string,
+  relPath: string,
+  isTest: boolean,
+  edges: GraphEdge[],
+  mode: "file" | "symbol" = "file",
+  symbolRanges: SymbolRange[] = [],
+) {
+  const fileSourceId = `file:${relPath}`;
 
   let match: RegExpExecArray | null;
 
   IMPL_RE.lastIndex = 0;
   while ((match = IMPL_RE.exec(content)) !== null) {
     const reqIds = match[1].match(REQ_ID_RE);
-    if (reqIds) {
-      for (const reqId of reqIds) {
-        edges.push({
-          source: sourceId,
-          target: reqId,
-          kind: "implements",
-        });
+    if (!reqIds) continue;
+
+    let sourceId = fileSourceId;
+
+    if (mode === "symbol" && !isTest && symbolRanges.length > 0) {
+      const line = lineNumberAt(content, match.index);
+      const resolved = resolveSymbolAtLine(symbolRanges, line);
+      if (resolved) {
+        sourceId = `symbol:${relPath}#${resolved}`;
       }
+    }
+
+    for (const reqId of reqIds) {
+      edges.push({ source: sourceId, target: reqId, kind: "implements" });
     }
   }
 
@@ -129,22 +211,34 @@ function extractImplTags(content: string, relPath: string, isTest: boolean, edge
     TEST_REQ_RE.lastIndex = 0;
     while ((match = TEST_REQ_RE.exec(content)) !== null) {
       const reqId = match[0].slice(1, -1);
-      edges.push({
-        source: sourceId,
-        target: reqId,
-        kind: "verifies",
-      });
+      edges.push({ source: fileSourceId, target: reqId, kind: "verifies" });
     }
 
     TEST_ANNOTATION_RE.lastIndex = 0;
     while ((match = TEST_ANNOTATION_RE.exec(content)) !== null) {
-      edges.push({
-        source: sourceId,
-        target: match[1],
-        kind: "verifies",
-      });
+      edges.push({ source: fileSourceId, target: match[1], kind: "verifies" });
     }
   }
+}
+
+function lineNumberAt(content: string, index: number): number {
+  let line = 1;
+  for (let i = 0; i < index; i++) {
+    if (content[i] === "\n") line++;
+  }
+  return line;
+}
+
+function resolveSymbolAtLine(ranges: SymbolRange[], line: number): string | null {
+  let best: SymbolRange | null = null;
+  for (const range of ranges) {
+    if (line >= range.startLine && line <= range.endLine) {
+      if (!best || (range.endLine - range.startLine) < (best.endLine - best.startLine)) {
+        best = range;
+      }
+    }
+  }
+  return best?.name ?? null;
 }
 
 function hash(content: string): string {

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -11,6 +11,7 @@ export interface ScanResult {
   reqCount: number;
   docCount: number;
   fileCount: number;
+  symbolCount: number;
   testCount: number;
 }
 
@@ -21,6 +22,7 @@ export function scan(rootDir: string, config: SpectraceConfig): ScanResult {
   let reqCount = 0;
   let docCount = 0;
   let fileCount = 0;
+  let symbolCount = 0;
   let testCount = 0;
 
   for (const node of graph.nodes.values()) {
@@ -32,8 +34,10 @@ export function scan(rootDir: string, config: SpectraceConfig): ScanResult {
         docCount++;
         break;
       case "file":
-      case "symbol":
         fileCount++;
+        break;
+      case "symbol":
+        symbolCount++;
         break;
       case "test":
         testCount++;
@@ -49,6 +53,7 @@ export function scan(rootDir: string, config: SpectraceConfig): ScanResult {
     reqCount,
     docCount,
     fileCount,
+    symbolCount,
     testCount,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export interface SpectraceConfig {
   testPatterns: string[];
   lockFile: string;
   reqPatterns?: ReqPatternConfig;
+  mode?: "file" | "symbol";
 }
 
 export const DEFAULT_CONFIG: SpectraceConfig = {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -261,3 +261,47 @@ describe("CLI: error cases", () => {
     expect(stdout).toContain("reconcile");
   });
 });
+
+// ---------------------------------------------------------------------------
+// symbol mode
+// ---------------------------------------------------------------------------
+const SYM_FIXTURE = resolve(import.meta.dirname, "fixtures/symbol-level");
+const SYM_LOCK_PATH = resolve(SYM_FIXTURE, ".trace.lock");
+
+function runSym(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execFileSync("node", [CLI, ...args], {
+      encoding: "utf-8",
+      cwd: SYM_FIXTURE,
+      timeout: 30000,
+    });
+    return { stdout, stderr: "", exitCode: 0 };
+  } catch (e: any) {
+    return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", exitCode: e.status ?? 1 };
+  }
+}
+
+describe("CLI: symbol mode", () => {
+  afterEach(() => {
+    if (existsSync(SYM_LOCK_PATH)) unlinkSync(SYM_LOCK_PATH);
+  });
+
+  it("should show symbol count with --mode symbol", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = runSym(["scan", "--mode", "symbol"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("symbol:");
+  });
+
+  it("should not show symbol count in file mode", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = runSym(["scan"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain("symbol:");
+  });
+
+  it("should include symbolCount in JSON output", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = runSym(["scan", "--mode", "symbol", "--format", "json"]);
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.symbolCount).toBeGreaterThan(0);
+  });
+});

--- a/tests/fixtures/symbol-level/src/arrow.ts
+++ b/tests/fixtures/symbol-level/src/arrow.ts
@@ -1,0 +1,4 @@
+export const handler = () => {
+  // @impl FR-001
+  return "handled";
+};

--- a/tests/fixtures/symbol-level/src/consumer.ts
+++ b/tests/fixtures/symbol-level/src/consumer.ts
@@ -1,8 +1,12 @@
-import { foo } from "./utils";
+import { foo, bar as myBar } from "./utils";
 import defaultFn from "./defaults";
 
 export function useFoo() {
   return foo();
+}
+
+export function useBar() {
+  return myBar();
 }
 
 export function useDefault() {

--- a/tests/fixtures/symbol-level/src/consumer.ts
+++ b/tests/fixtures/symbol-level/src/consumer.ts
@@ -1,0 +1,10 @@
+import { foo } from "./utils";
+import defaultFn from "./defaults";
+
+export function useFoo() {
+  return foo();
+}
+
+export function useDefault() {
+  return defaultFn();
+}

--- a/tests/fixtures/symbol-level/src/defaults.ts
+++ b/tests/fixtures/symbol-level/src/defaults.ts
@@ -1,0 +1,3 @@
+export default function defaultFn() {
+  return "default";
+}

--- a/tests/fixtures/symbol-level/src/ns-consumer.ts
+++ b/tests/fixtures/symbol-level/src/ns-consumer.ts
@@ -1,0 +1,5 @@
+import * as utils from "./utils";
+
+export function useAll() {
+  return utils.foo();
+}

--- a/tests/fixtures/symbol-level/src/toplevel-impl.ts
+++ b/tests/fixtures/symbol-level/src/toplevel-impl.ts
@@ -1,0 +1,6 @@
+// @impl SC-001
+const CONFIG = { debug: false };
+
+export function getConfig() {
+  return CONFIG;
+}

--- a/tests/fixtures/symbol-level/src/utils.ts
+++ b/tests/fixtures/symbol-level/src/utils.ts
@@ -1,0 +1,8 @@
+export function foo() {
+  // @impl FR-001
+  return "foo";
+}
+
+export function bar() {
+  return "bar";
+}

--- a/tests/fixtures/symbol-level/tsconfig.json
+++ b/tests/fixtures/symbol-level/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/tests/traverse.test.ts
+++ b/tests/traverse.test.ts
@@ -97,3 +97,28 @@ describe("resolveStartIds", () => {
     expect(ids).toEqual(["file:src/auth/login.ts"]);
   });
 });
+
+describe("resolveStartIds (symbol mode)", () => {
+  const SYM_FIXTURE = resolve(import.meta.dirname, "fixtures/symbol-level");
+  const symConfig: SpectraceConfig = {
+    include: ["src/**/*.ts"],
+    specDirs: ["specs"],
+    testPatterns: [],
+    lockFile: ".trace.lock",
+    mode: "symbol",
+  };
+  const { graph } = buildGraph(SYM_FIXTURE, symConfig);
+
+  it("should include symbol nodes when resolving file path", () => {
+    const ids = resolveStartIds(graph, ["src/utils.ts"]);
+    expect(ids).toContain("file:src/utils.ts");
+    expect(ids).toContain("symbol:src/utils.ts#foo");
+    expect(ids).toContain("symbol:src/utils.ts#bar");
+  });
+
+  it("should not include symbol nodes from other files", () => {
+    const ids = resolveStartIds(graph, ["src/utils.ts"]);
+    const defaultSymbols = ids.filter((id) => id.includes("defaults.ts"));
+    expect(defaultSymbols).toHaveLength(0);
+  });
+});

--- a/tests/typescript.test.ts
+++ b/tests/typescript.test.ts
@@ -95,3 +95,101 @@ describe("createTSParser", () => {
     expect(verifyEdges[0].target).toBe("Requirement-1");
   });
 });
+
+describe("createTSParser (symbol mode)", () => {
+  const SYM_FIXTURE = resolve(import.meta.dirname, "fixtures/symbol-level");
+  const parser = createTSParser(SYM_FIXTURE, ["src/**/*.ts"], "symbol");
+  const result = parser.parse();
+
+  it("should extract symbol nodes for exported functions", () => {
+    const symbolNodes = result.nodes.filter((n) => n.kind === "symbol");
+    const symbolIds = symbolNodes.map((n) => n.id);
+
+    expect(symbolIds).toContain("symbol:src/utils.ts#foo");
+    expect(symbolIds).toContain("symbol:src/utils.ts#bar");
+  });
+
+  it("should keep file nodes alongside symbol nodes", () => {
+    const fileNodes = result.nodes.filter((n) => n.kind === "file");
+    const filePaths = fileNodes.map((n) => n.filePath);
+
+    expect(filePaths).toContain("src/utils.ts");
+    expect(filePaths).toContain("src/consumer.ts");
+  });
+
+  it("should resolve named import to symbol-level edge", () => {
+    const importEdges = result.edges.filter(
+      (e) => e.kind === "imports" && e.source === "file:src/consumer.ts",
+    );
+
+    const symbolTargets = importEdges.filter((e) => e.target.startsWith("symbol:"));
+    expect(symbolTargets).toContainEqual({
+      source: "file:src/consumer.ts",
+      target: "symbol:src/utils.ts#foo",
+      kind: "imports",
+    });
+  });
+
+  it("should fallback namespace import to file-level edge", () => {
+    const importEdges = result.edges.filter(
+      (e) => e.kind === "imports" && e.source === "file:src/ns-consumer.ts",
+    );
+
+    expect(importEdges).toContainEqual({
+      source: "file:src/ns-consumer.ts",
+      target: "file:src/utils.ts",
+      kind: "imports",
+    });
+    const symbolTargets = importEdges.filter((e) => e.target.startsWith("symbol:"));
+    expect(symbolTargets).toHaveLength(0);
+  });
+
+  it("should resolve default import to symbol:path#default edge", () => {
+    const importEdges = result.edges.filter(
+      (e) => e.kind === "imports" && e.source === "file:src/consumer.ts",
+    );
+
+    expect(importEdges).toContainEqual({
+      source: "file:src/consumer.ts",
+      target: "symbol:src/defaults.ts#default",
+      kind: "imports",
+    });
+  });
+
+  it("should extract default export as symbol:path#default node", () => {
+    const symbolNodes = result.nodes.filter((n) => n.kind === "symbol");
+    const symbolIds = symbolNodes.map((n) => n.id);
+
+    expect(symbolIds).toContain("symbol:src/defaults.ts#default");
+  });
+
+  it("should resolve @impl inside exported function to symbol source", () => {
+    const implEdges = result.edges.filter(
+      (e) => e.kind === "implements" && e.target === "FR-001",
+    );
+
+    expect(implEdges).toHaveLength(1);
+    expect(implEdges[0].source).toBe("symbol:src/utils.ts#foo");
+  });
+
+  it("should fallback @impl at top-level to file source", () => {
+    const implEdges = result.edges.filter(
+      (e) => e.kind === "implements" && e.target === "SC-001",
+    );
+
+    expect(implEdges).toHaveLength(1);
+    expect(implEdges[0].source).toBe("file:src/toplevel-impl.ts");
+  });
+
+  it("should use file source for @impl in file mode (regression)", () => {
+    const fileParser = createTSParser(SYM_FIXTURE, ["src/**/*.ts"], "file");
+    const fileResult = fileParser.parse();
+
+    const implEdges = fileResult.edges.filter(
+      (e) => e.kind === "implements" && e.target === "FR-001",
+    );
+
+    expect(implEdges).toHaveLength(1);
+    expect(implEdges[0].source).toBe("file:src/utils.ts");
+  });
+});

--- a/tests/typescript.test.ts
+++ b/tests/typescript.test.ts
@@ -163,9 +163,30 @@ describe("createTSParser (symbol mode)", () => {
     expect(symbolIds).toContain("symbol:src/defaults.ts#default");
   });
 
+  it("should resolve aliased import { bar as myBar } to original export name", () => {
+    const importEdges = result.edges.filter(
+      (e) => e.kind === "imports" && e.source === "file:src/consumer.ts",
+    );
+
+    expect(importEdges).toContainEqual({
+      source: "file:src/consumer.ts",
+      target: "symbol:src/utils.ts#bar",
+      kind: "imports",
+    });
+  });
+
+  it("should resolve @impl inside arrow function export to symbol source", () => {
+    const implEdges = result.edges.filter(
+      (e) => e.kind === "implements" && e.target === "FR-001" && e.source.includes("arrow"),
+    );
+
+    expect(implEdges).toHaveLength(1);
+    expect(implEdges[0].source).toBe("symbol:src/arrow.ts#handler");
+  });
+
   it("should resolve @impl inside exported function to symbol source", () => {
     const implEdges = result.edges.filter(
-      (e) => e.kind === "implements" && e.target === "FR-001",
+      (e) => e.kind === "implements" && e.target === "FR-001" && e.source.includes("utils"),
     );
 
     expect(implEdges).toHaveLength(1);
@@ -186,7 +207,7 @@ describe("createTSParser (symbol mode)", () => {
     const fileResult = fileParser.parse();
 
     const implEdges = fileResult.edges.filter(
-      (e) => e.kind === "implements" && e.target === "FR-001",
+      (e) => e.kind === "implements" && e.target === "FR-001" && e.source === "file:src/utils.ts",
     );
 
     expect(implEdges).toHaveLength(1);


### PR DESCRIPTION
## Summary

- TypeScript パーサーに `--mode symbol` を追加し、エクスポートされたシンボル（関数・クラス・変数・型）を個別の `symbol` ノードとして登録
- `@impl` タグを行番号ベースで最寄りのエクスポートシンボルに解決（範囲外は file フォールバック）
- named/default import を symbol-level エッジとして解決（namespace/dynamic import は file フォールバック）
- `SpectraceConfig.mode` + CLI `--mode file|symbol` フラグでモード切り替え
- scan サマリに `symbolCount` 追加、lock に symbol ノード記録、`resolveStartIds` の symbol 展開、`check --diff` スコープの symbol 対応

## Test plan

- [ ] `pnpm test` で全 87 テスト PASS（既存 73 + 新規 14）
- [ ] `spectrace scan --mode symbol` で symbol ノードが表示される
- [ ] `spectrace scan --mode file` で従来通りの出力（リグレッションなし）
- [ ] fixture: named import → symbol-level エッジ、namespace import → file フォールバック
- [ ] fixture: @impl in function → symbol source、@impl at top-level → file source
- [ ] JSON 出力に `symbolCount` フィールドが含まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)