### PR TITLE
feat: add spectrace init command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,10 +7,45 @@ import { impact, resolveStartIds } from "./graph/traverse.js";
 import { check } from "./check.js";
 import { readLock } from "./lock.js";
 import { getGitDiffFiles } from "./diff.js";
+import { runInit } from "./init.js";
 
 const program = new Command();
 
 program.name("spectrace").description("Typed artifact graph for TS/JS").version("0.1.0");
+
+program
+  .command("init")
+  .description("Initialize spectrace for this project")
+  .option("--force", "Overwrite existing .spectrace.json")
+  .option("--no-scan", "Generate config only, skip scan and reconcile")
+  .action((opts) => {
+    const rootDir = process.cwd();
+    try {
+      const result = runInit(rootDir, { force: opts.force, noScan: !opts.scan });
+
+      for (const tool of result.sddTools) {
+        console.log(`${tool.name} detected (${tool.marker}/)`);
+      }
+
+      if (result.scanSummary) {
+        console.log(`\nNodes: ${result.scanSummary.nodeCount}  Edges: ${result.scanSummary.edgeCount}`);
+        console.log(
+          `  req: ${result.scanSummary.reqCount}  doc: ${result.scanSummary.docCount}  file: ${result.scanSummary.fileCount}  test: ${result.scanSummary.testCount}`,
+        );
+        console.log(`\nCreated .spectrace.json`);
+        console.log(`Created ${result.config.lockFile}`);
+        console.log(`\nRun "spectrace check" to verify traceability.`);
+        console.log(`Run "spectrace impact --diff" to see impact of your changes.`);
+      } else {
+        console.log(`Created .spectrace.json (scan skipped)`);
+        console.log(`\nTo scan later, run: spectrace scan && spectrace reconcile`);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`Error: ${msg}`);
+      process.exit(1);
+    }
+  });
 
 program
   .command("scan")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,27 +18,49 @@ program
   .description("Initialize spectrace for this project")
   .option("--force", "Overwrite existing .spectrace.json")
   .option("--no-scan", "Generate config only, skip scan and reconcile")
+  .option("--format <format>", "Output format: json | text", "text")
   .action((opts) => {
     const rootDir = process.cwd();
     try {
       const result = runInit(rootDir, { force: opts.force, noScan: !opts.scan });
 
-      for (const tool of result.sddTools) {
-        console.log(`${tool.name} detected (${tool.marker}/)`);
-      }
-
-      if (result.scanSummary) {
-        console.log(`\nNodes: ${result.scanSummary.nodeCount}  Edges: ${result.scanSummary.edgeCount}`);
+      if (opts.format === "json") {
         console.log(
-          `  req: ${result.scanSummary.reqCount}  doc: ${result.scanSummary.docCount}  file: ${result.scanSummary.fileCount}  test: ${result.scanSummary.testCount}`,
+          JSON.stringify({
+            configPath: result.configPath,
+            config: result.config,
+            sddTools: result.sddTools,
+            scanSummary: result.scanSummary ?? null,
+            warnings: result.warnings,
+            lockPath: result.lockPath ?? null,
+          }),
         );
-        console.log(`\nCreated .spectrace.json`);
-        console.log(`Created ${result.config.lockFile}`);
-        console.log(`\nRun "spectrace check" to verify traceability.`);
-        console.log(`Run "spectrace impact --diff" to see impact of your changes.`);
       } else {
-        console.log(`Created .spectrace.json (scan skipped)`);
-        console.log(`\nTo scan later, run: spectrace scan && spectrace reconcile`);
+        for (const tool of result.sddTools) {
+          console.log(`${tool.name} detected (${tool.marker}/)`);
+        }
+
+        if (result.scanSummary) {
+          console.log(`\nNodes: ${result.scanSummary.nodeCount}  Edges: ${result.scanSummary.edgeCount}`);
+          console.log(
+            `  req: ${result.scanSummary.reqCount}  doc: ${result.scanSummary.docCount}  file: ${result.scanSummary.fileCount}  test: ${result.scanSummary.testCount}`,
+          );
+          for (const w of result.warnings) {
+            if (w.type === "ambiguous-id") {
+              const hint = w.files.length > 0 ? ` (candidates: ${w.files.join(", ")})` : "";
+              console.error(`WARNING: ambiguous ID "${w.id}"${hint}`);
+            } else {
+              console.error(`WARNING: duplicate ID "${w.id}" in ${w.files.join(", ")}`);
+            }
+          }
+          console.log(`\nCreated .spectrace.json`);
+          console.log(`Created ${result.config.lockFile}`);
+          console.log(`\nRun "spectrace check" to verify traceability.`);
+          console.log(`Run "spectrace impact --diff" to see impact of your changes.`);
+        } else {
+          console.log(`Created .spectrace.json (scan skipped)`);
+          console.log(`\nTo scan later, run: spectrace scan && spectrace reconcile`);
+        }
       }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,37 +1,22 @@
 import { existsSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { DEFAULT_CONFIG, type SpectraceConfig } from "./types.js";
+import {
+  DEFAULT_CONFIG,
+  type SpectraceConfig,
+  type ScanSummary,
+  type SddToolInfo,
+  type DetectionResult,
+  type InitOptions,
+} from "./types.js";
 import { scan, reconcile } from "./scan.js";
-
-export interface SddToolInfo {
-  name: string;
-  marker: string;
-}
-
-export interface DetectionResult {
-  hasSrc: boolean;
-  hasSpecs: boolean;
-  hasDocs: boolean;
-  sddTools: SddToolInfo[];
-}
-
-export interface InitOptions {
-  force?: boolean;
-  noScan?: boolean;
-}
+import type { BuildWarning } from "./graph/builder.js";
 
 export interface InitResult {
   configPath: string;
   config: SpectraceConfig;
   sddTools: SddToolInfo[];
-  scanSummary?: {
-    nodeCount: number;
-    edgeCount: number;
-    reqCount: number;
-    docCount: number;
-    fileCount: number;
-    testCount: number;
-  };
+  scanSummary?: ScanSummary;
+  warnings: BuildWarning[];
   lockPath?: string;
 }
 
@@ -82,14 +67,14 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
   const detection = detectProject(abs);
   const config = generateConfig(detection);
 
-  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
-
   if (options.noScan) {
-    return { configPath, config, sddTools: detection.sddTools };
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+    return { configPath, config, sddTools: detection.sddTools, warnings: [] };
   }
 
   const result = scan(abs, config);
   reconcile(abs, config, result.graph);
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
 
   const lockPath = resolve(abs, config.lockFile);
 
@@ -105,6 +90,7 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
       fileCount: result.fileCount,
       testCount: result.testCount,
     },
+    warnings: result.warnings,
     lockPath,
   };
 }

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,0 +1,110 @@
+import { existsSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { DEFAULT_CONFIG, type SpectraceConfig } from "./types.js";
+import { scan, reconcile } from "./scan.js";
+
+export interface SddToolInfo {
+  name: string;
+  marker: string;
+}
+
+export interface DetectionResult {
+  hasSrc: boolean;
+  hasSpecs: boolean;
+  hasDocs: boolean;
+  sddTools: SddToolInfo[];
+}
+
+export interface InitOptions {
+  force?: boolean;
+  noScan?: boolean;
+}
+
+export interface InitResult {
+  configPath: string;
+  config: SpectraceConfig;
+  sddTools: SddToolInfo[];
+  scanSummary?: {
+    nodeCount: number;
+    edgeCount: number;
+    reqCount: number;
+    docCount: number;
+    fileCount: number;
+    testCount: number;
+  };
+  lockPath?: string;
+}
+
+export function detectProject(rootDir: string): DetectionResult {
+  const abs = resolve(rootDir);
+  const sddTools: SddToolInfo[] = [];
+  if (existsSync(resolve(abs, ".specify"))) {
+    sddTools.push({ name: "Spec Kit", marker: ".specify" });
+  }
+  if (existsSync(resolve(abs, ".kiro"))) {
+    sddTools.push({ name: "Kiro", marker: ".kiro" });
+  }
+
+  return {
+    hasSrc: existsSync(resolve(abs, "src")),
+    hasSpecs: existsSync(resolve(abs, "specs")),
+    hasDocs: existsSync(resolve(abs, "docs")),
+    sddTools,
+  };
+}
+
+export function generateConfig(detection: DetectionResult): SpectraceConfig {
+  const include = detection.hasSrc
+    ? [...DEFAULT_CONFIG.include]
+    : ["**/*.ts", "**/*.tsx"];
+
+  const specDirs: string[] = [];
+  if (detection.hasSpecs) specDirs.push("specs");
+  if (detection.hasDocs) specDirs.push("docs");
+  if (specDirs.length === 0) specDirs.push(...DEFAULT_CONFIG.specDirs);
+
+  return {
+    include,
+    specDirs,
+    testPatterns: [...DEFAULT_CONFIG.testPatterns],
+    lockFile: DEFAULT_CONFIG.lockFile,
+  };
+}
+
+export function runInit(rootDir: string, options: InitOptions = {}): InitResult {
+  const abs = resolve(rootDir);
+  const configPath = resolve(abs, ".spectrace.json");
+
+  if (existsSync(configPath) && !options.force) {
+    throw new Error(".spectrace.json already exists. Use --force to overwrite.");
+  }
+
+  const detection = detectProject(abs);
+  const config = generateConfig(detection);
+
+  writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+
+  if (options.noScan) {
+    return { configPath, config, sddTools: detection.sddTools };
+  }
+
+  const result = scan(abs, config);
+  reconcile(abs, config, result.graph);
+
+  const lockPath = resolve(abs, config.lockFile);
+
+  return {
+    configPath,
+    config,
+    sddTools: detection.sddTools,
+    scanSummary: {
+      nodeCount: result.nodeCount,
+      edgeCount: result.edgeCount,
+      reqCount: result.reqCount,
+      docCount: result.docCount,
+      fileCount: result.fileCount,
+      testCount: result.testCount,
+    },
+    lockPath,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,32 @@ export interface CheckResult {
   pass: boolean;
 }
 
+export interface ScanSummary {
+  nodeCount: number;
+  edgeCount: number;
+  reqCount: number;
+  docCount: number;
+  fileCount: number;
+  testCount: number;
+}
+
+export interface SddToolInfo {
+  name: string;
+  marker: string;
+}
+
+export interface DetectionResult {
+  hasSrc: boolean;
+  hasSpecs: boolean;
+  hasDocs: boolean;
+  sddTools: SddToolInfo[];
+}
+
+export interface InitOptions {
+  force?: boolean;
+  noScan?: boolean;
+}
+
 export interface ReqPatternConfig {
   listItem?: string;
   heading?: string;

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { existsSync, unlinkSync } from "node:fs";
@@ -226,6 +226,85 @@ describe("CLI: reconcile then check (no drift)", () => {
     expect(chk.stdout).toContain("COVERAGE:");
 
     cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// init
+// ---------------------------------------------------------------------------
+describe("CLI: init", () => {
+  let initTmp: string;
+
+  function runInit(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+    try {
+      const stdout = execFileSync("node", [CLI, "init", ...args], {
+        encoding: "utf-8",
+        cwd: initTmp,
+        timeout: 30000,
+      });
+      return { stdout, stderr: "", exitCode: 0 };
+    } catch (e: any) {
+      return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", exitCode: e.status ?? 1 };
+    }
+  }
+
+  beforeEach(() => {
+    const { mkdtempSync, mkdirSync, writeFileSync } = require("node:fs");
+    const { tmpdir } = require("node:os");
+    const { join } = require("node:path");
+    initTmp = mkdtempSync(join(tmpdir(), "spectrace-cli-init-"));
+    mkdirSync(join(initTmp, "src"));
+    writeFileSync(join(initTmp, "src", "app.ts"), "export const x = 1;\n");
+  });
+
+  afterEach(() => {
+    const { rmSync } = require("node:fs");
+    rmSync(initTmp, { recursive: true, force: true });
+  });
+
+  it("should create .spectrace.json and .trace.lock", { timeout: 30000 }, () => {
+    const { exitCode, stdout } = runInit([]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Created .spectrace.json");
+    expect(stdout).toContain("Created .trace.lock");
+    expect(stdout).toContain("Nodes:");
+  });
+
+  it("should output JSON with --format json", { timeout: 30000 }, () => {
+    const { exitCode, stdout } = runInit(["--format", "json"]);
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.configPath).toBeDefined();
+    expect(result.scanSummary).toBeDefined();
+    expect(result.scanSummary.nodeCount).toBeGreaterThanOrEqual(0);
+    expect(result.warnings).toBeDefined();
+  });
+
+  it("should fail when .spectrace.json already exists", { timeout: 30000 }, () => {
+    const { writeFileSync } = require("node:fs");
+    const { join } = require("node:path");
+    writeFileSync(join(initTmp, ".spectrace.json"), "{}\n");
+
+    const { exitCode, stderr } = runInit([]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("already exists");
+  });
+
+  it("should succeed with --force when .spectrace.json exists", { timeout: 30000 }, () => {
+    const { writeFileSync } = require("node:fs");
+    const { join } = require("node:path");
+    writeFileSync(join(initTmp, ".spectrace.json"), "{}\n");
+
+    const { exitCode, stdout } = runInit(["--force"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Created .spectrace.json");
+  });
+
+  it("should skip scan with --no-scan", { timeout: 30000 }, () => {
+    const { exitCode, stdout } = runInit(["--no-scan"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("scan skipped");
+    expect(stdout).not.toContain("Nodes:");
   });
 });
 

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -12,7 +12,7 @@ function cleanup(dir: string) {
   rmSync(dir, { recursive: true, force: true });
 }
 
-describe("init", () => {
+describe("detectProject", () => {
   let tmp: string;
 
   beforeEach(() => {
@@ -23,7 +23,71 @@ describe("init", () => {
     cleanup(tmp);
   });
 
-  // T003: basic init generates .spectrace.json
+  it("detects src/ directory", () => {
+    mkdirSync(join(tmp, "src"));
+    const result = detectProject(tmp);
+    expect(result.hasSrc).toBe(true);
+    expect(result.hasSpecs).toBe(false);
+    expect(result.hasDocs).toBe(false);
+  });
+
+  it("detects specs/ and docs/ directories", () => {
+    mkdirSync(join(tmp, "specs"));
+    mkdirSync(join(tmp, "docs"));
+    const result = detectProject(tmp);
+    expect(result.hasSpecs).toBe(true);
+    expect(result.hasDocs).toBe(true);
+  });
+
+  it("detects both .specify/ and .kiro/ simultaneously", () => {
+    mkdirSync(join(tmp, ".specify"));
+    mkdirSync(join(tmp, ".kiro"));
+    const result = detectProject(tmp);
+    expect(result.sddTools).toHaveLength(2);
+    expect(result.sddTools).toContainEqual({ name: "Spec Kit", marker: ".specify" });
+    expect(result.sddTools).toContainEqual({ name: "Kiro", marker: ".kiro" });
+  });
+
+  it("returns empty sddTools when no SDD tool dirs exist", () => {
+    const result = detectProject(tmp);
+    expect(result.sddTools).toEqual([]);
+  });
+});
+
+describe("generateConfig", () => {
+  it("uses src/**/*.ts when hasSrc is true", () => {
+    const config = generateConfig({ hasSrc: true, hasSpecs: false, hasDocs: false, sddTools: [] });
+    expect(config.include).toContain("src/**/*.ts");
+  });
+
+  it("uses **/*.ts when hasSrc is false", () => {
+    const config = generateConfig({ hasSrc: false, hasSpecs: false, hasDocs: false, sddTools: [] });
+    expect(config.include).toContain("**/*.ts");
+    expect(config.include).not.toContain("src/**/*.ts");
+  });
+
+  it("includes both specs and docs in specDirs when both exist", () => {
+    const config = generateConfig({ hasSrc: true, hasSpecs: true, hasDocs: true, sddTools: [] });
+    expect(config.specDirs).toEqual(["specs", "docs"]);
+  });
+
+  it("falls back to default specDirs when neither specs/ nor docs/ exist", () => {
+    const config = generateConfig({ hasSrc: true, hasSpecs: false, hasDocs: false, sddTools: [] });
+    expect(config.specDirs).toEqual(["specs", "docs"]);
+  });
+});
+
+describe("runInit", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = makeTmpDir();
+  });
+
+  afterEach(() => {
+    cleanup(tmp);
+  });
+
   it("generates .spectrace.json with defaults for a project with src/", () => {
     mkdirSync(join(tmp, "src"));
     writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
@@ -35,7 +99,6 @@ describe("init", () => {
     expect(config.include).toContain("src/**/*.ts");
   });
 
-  // T004: scan produces .trace.lock
   it("generates .trace.lock after scan", () => {
     mkdirSync(join(tmp, "src"));
     writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
@@ -46,7 +109,6 @@ describe("init", () => {
     expect(result.lockPath).toBeDefined();
   });
 
-  // T005: returns scan summary
   it("returns scan summary with node and edge counts", () => {
     mkdirSync(join(tmp, "src"));
     writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
@@ -62,7 +124,15 @@ describe("init", () => {
     expect(typeof result.scanSummary!.testCount).toBe("number");
   });
 
-  // T010: no specs/ but docs/ → specDirs: ["docs"]
+  it("returns warnings array", () => {
+    mkdirSync(join(tmp, "src"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+
+    const result = runInit(tmp);
+
+    expect(Array.isArray(result.warnings)).toBe(true);
+  });
+
   it("sets specDirs to docs when only docs/ exists", () => {
     mkdirSync(join(tmp, "src"));
     mkdirSync(join(tmp, "docs"));
@@ -74,7 +144,6 @@ describe("init", () => {
     expect(config.specDirs).toEqual(["docs"]);
   });
 
-  // T011: no src/ → include widens to **/*.ts
   it("widens include pattern when src/ does not exist", () => {
     writeFileSync(join(tmp, "app.ts"), "export const x = 1;\n");
 
@@ -85,7 +154,18 @@ describe("init", () => {
     expect(config.include).not.toContain("src/**/*.ts");
   });
 
-  // T012: .specify/ → Spec Kit detected
+  it("includes both specs and docs when both directories exist", () => {
+    mkdirSync(join(tmp, "src"));
+    mkdirSync(join(tmp, "specs"));
+    mkdirSync(join(tmp, "docs"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+
+    const result = runInit(tmp);
+
+    const config = JSON.parse(readFileSync(join(tmp, ".spectrace.json"), "utf-8"));
+    expect(config.specDirs).toEqual(["specs", "docs"]);
+  });
+
   it("detects Spec Kit when .specify/ exists", () => {
     mkdirSync(join(tmp, "src"));
     mkdirSync(join(tmp, ".specify"));
@@ -96,7 +176,6 @@ describe("init", () => {
     expect(result.sddTools).toContainEqual({ name: "Spec Kit", marker: ".specify" });
   });
 
-  // T013: .kiro/ → Kiro detected
   it("detects Kiro when .kiro/ exists", () => {
     mkdirSync(join(tmp, "src"));
     mkdirSync(join(tmp, ".kiro"));
@@ -107,7 +186,19 @@ describe("init", () => {
     expect(result.sddTools).toContainEqual({ name: "Kiro", marker: ".kiro" });
   });
 
-  // T017: existing .spectrace.json without --force → error
+  it("detects both .specify/ and .kiro/ simultaneously", () => {
+    mkdirSync(join(tmp, "src"));
+    mkdirSync(join(tmp, ".specify"));
+    mkdirSync(join(tmp, ".kiro"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+
+    const result = runInit(tmp);
+
+    expect(result.sddTools).toHaveLength(2);
+    expect(result.sddTools).toContainEqual({ name: "Spec Kit", marker: ".specify" });
+    expect(result.sddTools).toContainEqual({ name: "Kiro", marker: ".kiro" });
+  });
+
   it("throws error when .spectrace.json already exists", () => {
     mkdirSync(join(tmp, "src"));
     writeFileSync(join(tmp, ".spectrace.json"), "{}\n");
@@ -115,7 +206,6 @@ describe("init", () => {
     expect(() => runInit(tmp)).toThrow(".spectrace.json already exists");
   });
 
-  // T018: --force overwrites existing config
   it("overwrites existing .spectrace.json with --force", () => {
     mkdirSync(join(tmp, "src"));
     writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
@@ -128,7 +218,6 @@ describe("init", () => {
     expect(config.include).not.toContain("old");
   });
 
-  // T020: --no-scan generates config only
   it("generates only .spectrace.json with --no-scan", () => {
     mkdirSync(join(tmp, "src"));
     writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
@@ -139,5 +228,27 @@ describe("init", () => {
     expect(existsSync(join(tmp, ".trace.lock"))).toBe(false);
     expect(result.scanSummary).toBeUndefined();
     expect(result.lockPath).toBeUndefined();
+  });
+
+  it("supports --force combined with --no-scan", () => {
+    mkdirSync(join(tmp, "src"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+    writeFileSync(join(tmp, ".spectrace.json"), '{"include":["old"]}\n');
+
+    const result = runInit(tmp, { force: true, noScan: true });
+
+    expect(existsSync(join(tmp, ".spectrace.json"))).toBe(true);
+    expect(existsSync(join(tmp, ".trace.lock"))).toBe(false);
+    const config = JSON.parse(readFileSync(join(tmp, ".spectrace.json"), "utf-8"));
+    expect(config.include).not.toContain("old");
+  });
+
+  it("handles empty project with no ts files", () => {
+    const result = runInit(tmp);
+
+    expect(existsSync(join(tmp, ".spectrace.json"))).toBe(true);
+    expect(existsSync(join(tmp, ".trace.lock"))).toBe(true);
+    expect(result.scanSummary).toBeDefined();
+    expect(result.scanSummary!.nodeCount).toBe(0);
   });
 });

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runInit, detectProject, generateConfig } from "../src/init.js";
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "spectrace-init-"));
+}
+
+function cleanup(dir: string) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+describe("init", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = makeTmpDir();
+  });
+
+  afterEach(() => {
+    cleanup(tmp);
+  });
+
+  // T003: basic init generates .spectrace.json
+  it("generates .spectrace.json with defaults for a project with src/", () => {
+    mkdirSync(join(tmp, "src"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+
+    const result = runInit(tmp);
+
+    expect(existsSync(join(tmp, ".spectrace.json"))).toBe(true);
+    const config = JSON.parse(readFileSync(join(tmp, ".spectrace.json"), "utf-8"));
+    expect(config.include).toContain("src/**/*.ts");
+  });
+
+  // T004: scan produces .trace.lock
+  it("generates .trace.lock after scan", () => {
+    mkdirSync(join(tmp, "src"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+
+    const result = runInit(tmp);
+
+    expect(existsSync(join(tmp, ".trace.lock"))).toBe(true);
+    expect(result.lockPath).toBeDefined();
+  });
+
+  // T005: returns scan summary
+  it("returns scan summary with node and edge counts", () => {
+    mkdirSync(join(tmp, "src"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+
+    const result = runInit(tmp);
+
+    expect(result.scanSummary).toBeDefined();
+    expect(result.scanSummary!.nodeCount).toBeGreaterThanOrEqual(1);
+    expect(typeof result.scanSummary!.edgeCount).toBe("number");
+    expect(typeof result.scanSummary!.reqCount).toBe("number");
+    expect(typeof result.scanSummary!.docCount).toBe("number");
+    expect(typeof result.scanSummary!.fileCount).toBe("number");
+    expect(typeof result.scanSummary!.testCount).toBe("number");
+  });
+
+  // T010: no specs/ but docs/ → specDirs: ["docs"]
+  it("sets specDirs to docs when only docs/ exists", () => {
+    mkdirSync(join(tmp, "src"));
+    mkdirSync(join(tmp, "docs"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+
+    const result = runInit(tmp);
+
+    const config = JSON.parse(readFileSync(join(tmp, ".spectrace.json"), "utf-8"));
+    expect(config.specDirs).toEqual(["docs"]);
+  });
+
+  // T011: no src/ → include widens to **/*.ts
+  it("widens include pattern when src/ does not exist", () => {
+    writeFileSync(join(tmp, "app.ts"), "export const x = 1;\n");
+
+    const result = runInit(tmp);
+
+    const config = JSON.parse(readFileSync(join(tmp, ".spectrace.json"), "utf-8"));
+    expect(config.include).toContain("**/*.ts");
+    expect(config.include).not.toContain("src/**/*.ts");
+  });
+
+  // T012: .specify/ → Spec Kit detected
+  it("detects Spec Kit when .specify/ exists", () => {
+    mkdirSync(join(tmp, "src"));
+    mkdirSync(join(tmp, ".specify"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+
+    const result = runInit(tmp);
+
+    expect(result.sddTools).toContainEqual({ name: "Spec Kit", marker: ".specify" });
+  });
+
+  // T013: .kiro/ → Kiro detected
+  it("detects Kiro when .kiro/ exists", () => {
+    mkdirSync(join(tmp, "src"));
+    mkdirSync(join(tmp, ".kiro"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+
+    const result = runInit(tmp);
+
+    expect(result.sddTools).toContainEqual({ name: "Kiro", marker: ".kiro" });
+  });
+
+  // T017: existing .spectrace.json without --force → error
+  it("throws error when .spectrace.json already exists", () => {
+    mkdirSync(join(tmp, "src"));
+    writeFileSync(join(tmp, ".spectrace.json"), "{}\n");
+
+    expect(() => runInit(tmp)).toThrow(".spectrace.json already exists");
+  });
+
+  // T018: --force overwrites existing config
+  it("overwrites existing .spectrace.json with --force", () => {
+    mkdirSync(join(tmp, "src"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+    writeFileSync(join(tmp, ".spectrace.json"), '{"include":["old"]}\n');
+
+    const result = runInit(tmp, { force: true });
+
+    const config = JSON.parse(readFileSync(join(tmp, ".spectrace.json"), "utf-8"));
+    expect(config.include).toContain("src/**/*.ts");
+    expect(config.include).not.toContain("old");
+  });
+
+  // T020: --no-scan generates config only
+  it("generates only .spectrace.json with --no-scan", () => {
+    mkdirSync(join(tmp, "src"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+
+    const result = runInit(tmp, { noScan: true });
+
+    expect(existsSync(join(tmp, ".spectrace.json"))).toBe(true);
+    expect(existsSync(join(tmp, ".trace.lock"))).toBe(false);
+    expect(result.scanSummary).toBeUndefined();
+    expect(result.lockPath).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- `spectrace init` コマンドを追加。プロジェクト構造を自動検出し、`.spectrace.json` 生成 → scan → `.trace.lock` 生成までを1コマンドで実行
- ディレクトリ検出: `src/`, `specs/`, `docs/` の有無に応じて `include` / `specDirs` のデフォルトを自動調整
- SDD ツール検出: `.specify/`（Spec Kit）、`.kiro/`（Kiro）を検出しメッセージ表示
- `--force`: 既存 `.spectrace.json` の上書き許可
- `--no-scan`: 設定ファイル生成のみで scan/reconcile をスキップ

## Changes

- `src/init.ts` (new): `detectProject()`, `generateConfig()`, `runInit()` 
- `src/cli.ts`: `init` サブコマンド追加
- `tests/init.test.ts` (new): 10 テストケース

## Test plan

- [x] 基本 init フロー（`.spectrace.json` + `.trace.lock` 生成）
- [x] ディレクトリ検出バリエーション（`src/` なし、`docs/` のみ等）
- [x] SDD ツール検出（`.specify/`, `.kiro/`）
- [x] 既存ファイル保護（上書き拒否 + `--force`）
- [x] `--no-scan`（設定のみ、lock なし）
- [x] 全 83 テストパス、リグレッションなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)