### PR TITLE
feat: Claude Code Skills 配布と spectrace coverage コマンド

### DIFF
--- a/.claude/skills/spectrace-coverage.md
+++ b/.claude/skills/spectrace-coverage.md
@@ -1,0 +1,56 @@
+---
+name: "spectrace-coverage"
+description: "進捗確認や残作業確認の依頼時にトリガー。spectrace coverage を実行し、各仕様の coverage 状態（verified / impl-only / untagged）を一覧表示して残作業を可視化する。"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## 目的
+
+進捗確認時に `spectrace coverage` を実行し、各仕様の coverage 状態を一覧表示する。
+残作業の把握と優先順位付けに活用する。
+
+## 実行手順
+
+### 1. spectrace の存在確認
+
+```bash
+command -v spectrace || npx spectrace --version
+```
+
+コマンドが見つからない場合は以下を案内して終了:
+
+```
+spectrace がインストールされていません。
+セットアップ手順:
+  npm install -D spectrace
+  npx spectrace init
+```
+
+### 2. カバレッジ状況の取得
+
+```bash
+spectrace coverage --format json
+```
+
+### 3. 結果の表示
+
+実行結果の JSON を解析し、以下の情報を報告する:
+
+items: 各仕様のカバレッジ状態
+- reqId: 仕様 ID
+- status: verified（実装+テストあり）/ impl-only（実装のみ）/ untagged（未実装）
+
+summary: 集計情報
+- total: 仕様の総数
+- verified: verified の数
+- implOnly: impl-only の数
+- untagged: untagged の数
+
+### 4. 進捗サマリの提示
+
+カバレッジ状態に基づいて進捗を報告する:
+
+- 全仕様が verified の場合: 「全仕様が verified 状態です」と報告
+- untagged が存在する場合: 未実装の仕様一覧を表示し、優先的に着手すべき項目を提案する
+- impl-only が存在する場合: テストが不足している仕様の一覧を表示する

--- a/.claude/skills/spectrace-plan.md
+++ b/.claude/skills/spectrace-plan.md
@@ -1,0 +1,54 @@
+---
+name: "spectrace-plan"
+description: "Plan 策定や設計検討の依頼時にトリガー。spectrace impact を実行し、変更の影響範囲をコンテキストに注入して、既存仕様との整合性を考慮した Plan 策定を支援する。"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## 目的
+
+Plan 策定前に `spectrace impact` を実行し、変更対象の仕様に波及する既存の仕様・実装・テストの影響範囲を把握する。
+エージェントはこの情報を踏まえて、既存仕様との矛盾や影響漏れを考慮した Plan を立てる。
+
+## 実行手順
+
+### 1. spectrace の存在確認
+
+```bash
+command -v spectrace || npx spectrace --version
+```
+
+コマンドが見つからない場合は以下を案内して終了:
+
+```
+spectrace がインストールされていません。
+セットアップ手順:
+  npm install -D spectrace
+  npx spectrace init
+```
+
+### 2. Impact 分析の実行
+
+```bash
+spectrace impact --diff --format json
+```
+
+- `--diff` で git diff から変更ファイルを自動検出する
+- 差分がない場合（初回コミット等）は「差分なし」として正常終了し、Plan 策定を続行する
+
+### 3. 結果のコンテキスト注入
+
+実行結果の JSON を解析し、以下の情報を Plan のコンテキストとして活用する:
+
+- affectedReqs: 影響を受ける仕様 ID の一覧
+- affectedDocs: 影響を受けるドキュメントの一覧
+- affectedFiles: 影響を受ける実装ファイルの一覧
+- drifted: 仕様変更が未反映の項目（drift 検出）
+
+### 4. Plan 策定への反映
+
+上記の影響範囲情報を踏まえて:
+
+- 影響を受ける仕様への言及を Plan に含める
+- drift が検出された場合は Plan 内で対処方針を明記する
+- 影響を受けるファイルの変更が Plan と矛盾しないか確認する

--- a/.claude/skills/spectrace-verify.md
+++ b/.claude/skills/spectrace-verify.md
@@ -1,0 +1,63 @@
+---
+name: "spectrace-verify"
+description: "実装完了報告やコードレビュー前にトリガー。spectrace check を実行し、drift/orphan/uncovered を検出して仕様と実装の整合性をセルフチェックする。"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## 目的
+
+実装完了時に `spectrace check` を実行し、仕様と実装の整合性を検証する。
+Stop hook（`spectrace check --gate`）でブロックされる前にセルフチェックすることで、手戻りコストを削減する。
+
+## 実行手順
+
+### 1. spectrace の存在確認
+
+```bash
+command -v spectrace || npx spectrace --version
+```
+
+コマンドが見つからない場合は以下を案内して終了:
+
+```
+spectrace がインストールされていません。
+セットアップ手順:
+  npm install -D spectrace
+  npx spectrace init
+```
+
+### 2. 整合性チェックの実行
+
+```bash
+spectrace check --diff --format text
+```
+
+- `--diff` で git diff にスコープを絞り、変更に関連する部分のみチェックする
+- `--gate` は付けない（ゲーティングはせず結果表示のみ）
+
+### 3. 結果の表示と対応
+
+出力結果を解析し、以下の項目を報告する:
+
+DRIFT (仕様変更の未反映):
+- 検出された場合: 各 drift 項目のノード ID と種別を表示し、実装の更新が必要であることを報告する
+
+ORPHANS (実装タグの宙ぶらりん):
+- 検出された場合: 対応する仕様が存在しない `@impl` / `@verify` タグの一覧を表示する
+
+UNCOVERED (未実装の仕様):
+- 検出された場合: 実装が紐づいていない仕様 ID の一覧を表示する
+
+COVERAGE (各仕様のカバレッジ状態):
+- 各仕様の状態（verified / impl-only / untagged）を一覧表示する
+
+全ての仕様が整合している場合:
+- 「全てのチェックが通過しました」と報告する
+
+### 4. 問題がある場合の対応提案
+
+問題が検出された場合は、具体的な修正アクションを提案する:
+- drift: 実装を仕様に合わせて更新し、`spectrace reconcile` を実行する
+- orphan: 不要なタグを削除するか、対応する仕様を追加する
+- uncovered: `@impl` タグを追加して仕様と実装を紐づける

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,10 @@ dist/
 .trace.lock
 
 # Dev tooling (personal)
-.claude/
+.claude/*
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/spectrace-*.md
 .specify/
 specs/
 CLAUDE.md

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,3 @@
+{
+  "feature_directory": "specs/003-skills"
+}

--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -1,0 +1,111 @@
+# spectrace Claude Code Skills ガイド
+
+## 概要
+
+spectrace は仕様・実装・テストの整合性を追跡するツールです。
+Claude Code Skills を使うことで、エージェントのワークフローに spectrace を自然に組み込み、
+Plan 策定時の影響分析、実装完了時の整合性チェック、進捗確認時のカバレッジ表示を自動化できます。
+
+## セットアップ
+
+### 1. spectrace のインストール
+
+```bash
+npm install -D spectrace
+```
+
+### 2. 初期化
+
+```bash
+npx spectrace init
+```
+
+これにより `.spectrace.json` 設定ファイルが作成されます。
+
+### 3. Skills ファイルの配置
+
+`.claude/skills/` ディレクトリに以下の 3 つのスキルファイルを配置します:
+
+```
+.claude/skills/
+  spectrace-plan.md
+  spectrace-verify.md
+  spectrace-coverage.md
+```
+
+これらのファイルは spectrace パッケージに含まれています。
+Claude Code が `.claude/skills/` 内の `.md` ファイルを自動的にスキルとして認識します。
+
+## Skills 一覧
+
+### spectrace-plan
+
+トリガー: Plan 策定や設計検討の依頼時
+
+`spectrace impact --diff --format json` を実行し、git diff から変更の影響範囲を分析します。
+影響を受ける仕様・ドキュメント・実装ファイルの情報がエージェントのコンテキストに注入され、
+既存仕様との矛盾や影響漏れを考慮した Plan 策定を支援します。
+
+使用する CLI コマンド:
+```bash
+spectrace impact --diff --format json
+```
+
+### spectrace-verify
+
+トリガー: 実装完了報告やコードレビュー前
+
+`spectrace check --diff --format text` を実行し、仕様と実装の整合性を検証します。
+以下の問題を検出します:
+
+- drift: 仕様が変更されたが実装が未更新
+- orphan: `@impl` タグが存在するが対応する仕様がない
+- uncovered: 仕様に対する実装が紐づいていない
+
+Stop hook（`spectrace check --gate`）でブロックされる前にセルフチェックでき、手戻りを削減します。
+
+使用する CLI コマンド:
+```bash
+spectrace check --diff --format text
+```
+
+### spectrace-coverage
+
+トリガー: 進捗確認や残作業確認の依頼時
+
+`spectrace coverage --format json` を実行し、各仕様のカバレッジ状態を一覧表示します。
+
+各仕様は以下のいずれかの状態で表示されます:
+- verified: 実装とテストの両方が紐づいている
+- impl-only: 実装はあるがテストが不足している
+- untagged: 実装が紐づいていない
+
+使用する CLI コマンド:
+```bash
+spectrace coverage --format json
+```
+
+## Skills と Stop Hook の関係
+
+Skills はエージェントのワークフロー内で自動実行され、問題を早期に検出します。
+Stop hook は Git の pre-commit/pre-push で `spectrace check --gate` を実行し、
+問題がある場合にコミットをブロックします。
+
+両者は補完関係にあり、同じ `spectrace` CLI を共有しています:
+
+1. Plan 策定時: spectrace-plan スキルが影響分析を実行
+2. 実装中: 開発者がコードを書く
+3. 実装完了時: spectrace-verify スキルがセルフチェックを実行
+4. コミット時: Stop hook がゲーティングを実行
+
+Skills と Stop hook の両方を導入することで最大の効果が得られますが、
+それぞれ独立して使用することも可能です。
+
+## カスタマイズ
+
+各スキルファイルは Markdown で記述されており、プロジェクトの要件に合わせて自由に編集できます。
+例えば:
+
+- トリガー条件の調整: frontmatter の `description` を変更して発火タイミングを調整
+- 実行コマンドのオプション変更: `--diff` を外して全体チェックに切り替え
+- 追加の指示: 結果に対するエージェントのアクションをカスタマイズ

--- a/specs/003-skills/checklists/requirements.md
+++ b/specs/003-skills/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Claude Code Skills 配布
+
+Purpose: Validate specification completeness and quality before proceeding to planning
+Created: 2026-06-20
+Feature: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- ロードマップに詳細な仕様が記載済みのため、NEEDS CLARIFICATION なし
+- MCP サーバは明示的にスコープ外としている（CLI-First Interface の原則に従い、Skills で CLI を呼び出す設計）
+- スキルの発火精度はエージェントの判断に依存するため、description の記述が品質に直結する

--- a/specs/003-skills/spec.md
+++ b/specs/003-skills/spec.md
@@ -1,0 +1,118 @@
+# Feature Specification: Claude Code Skills 配布
+
+Feature Branch: `003-skills`
+
+Created: 2026-06-20
+
+Status: Draft
+
+Input: spectrace の CLI を適切なタイミングで呼び出す Claude Code Skills を配布し、エージェントのワークフローに spectrace を組み込む
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Plan 前のインパクト分析 (Priority: P1)
+
+開発者が新機能の Plan 策定をエージェントに依頼する。
+エージェントは spectrace-plan スキルにより `spectrace impact` を自動実行し、
+変更対象の仕様に波及する既存の仕様・実装・テストの影響範囲をコンテキストに注入する。
+エージェントはこの情報を踏まえて、既存仕様との矛盾や影響漏れを考慮した Plan を立てる。
+
+Why this priority: Plan の質はエージェントが持つコンテキストに直結する。影響範囲を事前に把握せずに Plan を立てると、既存仕様への矛盾や実装の破壊が発生する。spectrace の中核価値である「仕様と実装の整合性」をエージェントワークフローに最初に組み込むべきポイント。
+
+Independent Test: 仕様と実装が紐づいたプロジェクトで Plan 策定を依頼し、spectrace-plan スキルが発火して影響範囲がコンテキストに含まれることを確認する。
+
+Acceptance Scenarios:
+
+1. Given spectrace が導入済みのプロジェクトで仕様と実装が紐づいている, When ユーザーが Plan 策定を依頼する, Then spectrace-plan スキルが発火し `spectrace impact --diff --format json` の結果がエージェントのコンテキストに注入される
+2. Given impact の結果に影響を受ける仕様が存在する, When エージェントが Plan を立てる, Then Plan 内に影響を受ける仕様への言及が含まれる
+3. Given spectrace がインストールされていない環境, When ユーザーが Plan 策定を依頼する, Then スキルはエラーを適切にハンドリングし、spectrace のセットアップを案内する
+
+---
+
+### User Story 2 - 実装後の整合性セルフチェック (Priority: P1)
+
+開発者が実装を完了し、コードレビュー前にエージェントへ確認を依頼する。
+エージェントは spectrace-verify スキルにより `spectrace check` を自動実行し、
+drift（仕様変更の未反映）、orphan（実装タグの宙ぶらりん）、uncovered（未実装の仕様）を検出する。
+Stop hook のゲートに引っかかる前にセルフチェックできる。
+
+Why this priority: Stop hook（`spectrace check --gate`）はコミット時にブロックするが、そこで初めて問題に気づくと手戻りが大きい。実装完了時点でセルフチェックできれば、手戻りコストを削減できる。Plan スキルと並び、ワークフローの両端（計画と検証）を押さえる。
+
+Independent Test: 意図的に drift/orphan/uncovered を含むプロジェクトで実装完了を報告し、spectrace-verify スキルが問題を検出・表示することを確認する。
+
+Acceptance Scenarios:
+
+1. Given drift が存在する（仕様が変更されたが実装が未更新）, When ユーザーが実装完了を報告する, Then spectrace-verify スキルが発火し、drift の詳細がエージェントに表示される
+2. Given orphan が存在する（`@impl` タグが存在するが対応する仕様がない）, When ユーザーが実装完了を報告する, Then orphan の一覧がエージェントに表示される
+3. Given 全ての仕様が正しく実装されている（問題なし）, When ユーザーが実装完了を報告する, Then 「全ての仕様が整合しています」という旨のメッセージが表示される
+4. Given spectrace がインストールされていない環境, When ユーザーが実装完了を報告する, Then スキルはエラーを適切にハンドリングし、spectrace のセットアップを案内する
+
+---
+
+### User Story 3 - カバレッジ状況の確認 (Priority: P2)
+
+開発者がフィーチャーの進捗確認をエージェントに依頼する。
+エージェントは spectrace-coverage スキルにより `spectrace scan` を自動実行し、
+各仕様の coverage 状態（untagged / impl-only / verified）を一覧表示する。
+残作業の把握と優先順位付けに活用する。
+
+Why this priority: Plan と Verify が P1 として動作した後に、進捗の可視化として価値が出る。カバレッジ確認は任意のタイミングで行えるため、ワークフローの必須ステップではないが、残作業の把握に有用。
+
+Independent Test: 仕様が複数ある状態で進捗確認を依頼し、各仕様の coverage 状態が一覧表示されることを確認する。
+
+Acceptance Scenarios:
+
+1. Given 仕様が複数あり、一部のみ実装されている, When ユーザーが進捗確認を依頼する, Then spectrace-coverage スキルが発火し、各仕様の coverage 状態（untagged / impl-only / verified）が一覧表示される
+2. Given 全仕様が verified 状態, When ユーザーが進捗確認を依頼する, Then 全仕様が verified であることが明示される
+3. Given spectrace がインストールされていない環境, When ユーザーが進捗確認を依頼する, Then スキルはエラーを適切にハンドリングし、spectrace のセットアップを案内する
+
+---
+
+### Edge Cases
+
+- spectrace がインストールされていない、またはパスが通っていない場合 → 各スキルはコマンド実行前に存在確認を行い、未インストール時はセットアップ手順を案内する
+- `spectrace impact --diff` の実行対象となる差分が存在しない場合（初回コミット等）→ 「差分なし」として正常終了し、Plan 策定を続行する
+- spectrace の設定ファイル（`.spectrace.json`）が存在しない場合 → `spectrace init` の実行を案内する
+- スキルのトリガー判定が誤発火する場合（例: Plan という言葉がコンテキストに出現するが Plan 策定ではない）→ スキルの description で発火条件を厳密に定義し、誤発火を最小化する
+- `spectrace check` の出力が非常に大きい場合（大規模プロジェクト）→ サマリーを先に表示し、詳細は必要に応じて展開する構成にする
+- 複数のスキルが同時にトリガーされる場合（例: Plan 策定時に Verify も発火）→ 各スキルは独立して動作し、競合しない設計にする
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- FR-001: spectrace-plan スキルは、ユーザーが Plan 策定を依頼した際に `spectrace impact --diff --format json` を実行し、影響範囲をエージェントのコンテキストに注入する
+- FR-002: spectrace-verify スキルは、ユーザーが実装完了を報告した際またはコードレビュー前に `spectrace check --diff --format text` を実行し、drift/orphan/uncovered をエージェントに表示する
+- FR-003: spectrace-coverage スキルは、ユーザーが進捗確認を依頼した際に `spectrace scan --format json` を実行し、仕様ごとの coverage 状態を一覧表示する
+- FR-004: 各スキルは spectrace コマンドの存在を事前に確認し、未インストール時はセットアップ手順を案内する
+- FR-005: 各スキルは `.claude/skills/` ディレクトリに `.md` ファイルとして配置され、外部依存なしで動作する
+- FR-006: 各スキルの description にトリガー条件を明記し、適切なタイミングでのみ発火するようにする
+- FR-007: `docs/skills-guide.md` にスキルの概要、セットアップ手順、各スキルの詳細を記述し、ユーザーが導入・カスタマイズできるようにする
+- FR-008: 各スキルは spectrace CLI の Stop hook（`spectrace check --gate`）と同じ CLI を使用し、ツールチェーンを統一する
+
+### Key Entities
+
+- Claude Code Skill: `.claude/skills/` に配置される Markdown ファイル。description でトリガー条件を定義し、エージェントのワークフローに組み込まれる
+- spectrace-plan スキル: Plan 策定前に影響分析を実行するスキル。`spectrace impact` コマンドを呼び出す
+- spectrace-verify スキル: 実装後に整合性チェックを実行するスキル。`spectrace check` コマンドを呼び出す
+- spectrace-coverage スキル: 進捗確認時にカバレッジ状況を表示するスキル。`spectrace scan` コマンドを呼び出す
+- Stop Hook: Git の pre-commit/pre-push で `spectrace check --gate` を実行するフック。スキルと同じ CLI を共有する
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- SC-001: spectrace-plan スキルが Plan 策定依頼時に発火し、`spectrace impact` の結果がエージェントコンテキストに含まれる
+- SC-002: spectrace-verify スキルが実装完了報告時に発火し、drift/orphan/uncovered が検出・表示される
+- SC-003: spectrace-coverage スキルが進捗確認依頼時に発火し、全仕様の coverage 状態が一覧表示される
+- SC-004: 全スキルが `.md` ファイルのみで構成され、`@modelcontextprotocol/sdk` 等の外部依存がゼロである
+- SC-005: spectrace 未インストール環境でスキルが発火した場合、エラーではなくセットアップ案内が表示される
+- SC-006: `docs/skills-guide.md` を読んだユーザーが、追加の説明なしにスキルを導入・利用開始できる
+
+## Assumptions
+
+- spectrace CLI が npm パッケージとしてインストール済み、または npx 経由で実行可能である
+- Claude Code が `.claude/skills/` ディレクトリ内の `.md` ファイルをスキルとして認識する（Claude Code の標準機能）
+- スキルの発火判定は Claude Code のエージェントが description を参照して行う。発火条件の精度はエージェントの判断に依存する
+- Stop hook（pre-commit / pre-push）は別途設定済み、またはユーザーが独立して設定する。スキルと hook は補完関係であり、両方の導入は必須ではない
+- `spectrace impact --diff`, `spectrace check --diff`, `spectrace scan` の各コマンドは既に実装済みで、JSON/text 出力に対応している

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { loadConfig } from "./config.js";
 import { scan, reconcile } from "./scan.js";
 import { impact, resolveStartIds } from "./graph/traverse.js";
 import { check } from "./check.js";
+import { computeCoverage } from "./coverage.js";
 import { readLock } from "./lock.js";
 import { getGitDiffFiles } from "./diff.js";
 
@@ -136,6 +137,39 @@ program
 
     if (opts.gate && !result.pass) {
       process.exit(2);
+    }
+  });
+
+program
+  .command("coverage")
+  .description("Show coverage status for each requirement")
+  .option("--format <format>", "Output format: json | text", "text")
+  .action((opts) => {
+    const rootDir = process.cwd();
+    const config = loadConfig(rootDir);
+    const { graph } = scan(rootDir, config);
+    const entries = computeCoverage(graph);
+
+    if (opts.format === "json") {
+      const items = entries.map((e) => ({ reqId: e.reqId, status: e.status }));
+      const summary = {
+        total: entries.length,
+        verified: entries.filter((e) => e.status === "verified").length,
+        implOnly: entries.filter((e) => e.status === "impl-only").length,
+        untagged: entries.filter((e) => e.status === "untagged").length,
+      };
+      console.log(JSON.stringify({ items, summary }));
+    } else {
+      console.log("COVERAGE:");
+      for (const e of entries) {
+        console.log(`  ${e.reqId}: ${e.status}`);
+      }
+      const verified = entries.filter((e) => e.status === "verified").length;
+      const implOnly = entries.filter((e) => e.status === "impl-only").length;
+      const untagged = entries.filter((e) => e.status === "untagged").length;
+      console.log(
+        `\nSummary: total=${entries.length} verified=${verified} impl-only=${implOnly} untagged=${untagged}`,
+      );
     }
   });
 

--- a/tests/coverage-cli.test.ts
+++ b/tests/coverage-cli.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { existsSync, unlinkSync } from "node:fs";
+
+const CLI = resolve(import.meta.dirname, "../dist/cli.js");
+const FIXTURE_DIR = resolve(import.meta.dirname, "fixtures");
+const LOCK_PATH = resolve(FIXTURE_DIR, ".trace.lock");
+
+function run(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execFileSync("node", [CLI, ...args], {
+      encoding: "utf-8",
+      cwd: FIXTURE_DIR,
+      timeout: 30000,
+    });
+    return { stdout, stderr: "", exitCode: 0 };
+  } catch (e: any) {
+    return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", exitCode: e.status ?? 1 };
+  }
+}
+
+function cleanup() {
+  if (existsSync(LOCK_PATH)) unlinkSync(LOCK_PATH);
+}
+
+afterEach(cleanup);
+
+// ---------------------------------------------------------------------------
+// coverage
+// ---------------------------------------------------------------------------
+describe("CLI: coverage", () => {
+  it("should output coverage as JSON", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = run(["coverage", "--format", "json"]);
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.items).toBeDefined();
+    expect(Array.isArray(result.items)).toBe(true);
+    expect(result.items.length).toBeGreaterThan(0);
+    expect(result.summary).toBeDefined();
+    expect(result.summary.total).toBeGreaterThan(0);
+    expect(typeof result.summary.verified).toBe("number");
+    expect(typeof result.summary.implOnly).toBe("number");
+    expect(typeof result.summary.untagged).toBe("number");
+  });
+
+  it("should include correct status for each REQ in JSON", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = run(["coverage", "--format", "json"]);
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+
+    // AUTH-001 has both impl and test -> verified
+    const auth001 = result.items.find((i: any) => i.reqId === "AUTH-001");
+    expect(auth001).toBeDefined();
+    expect(auth001.status).toBe("verified");
+
+    // AUTH-002 has impl but no test -> impl-only
+    const auth002 = result.items.find((i: any) => i.reqId === "AUTH-002");
+    expect(auth002).toBeDefined();
+    expect(auth002.status).toBe("impl-only");
+
+    // AUTH-003 has no impl -> untagged
+    const auth003 = result.items.find((i: any) => i.reqId === "AUTH-003");
+    expect(auth003).toBeDefined();
+    expect(auth003.status).toBe("untagged");
+  });
+
+  it("should output summary counts matching items in JSON", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = run(["coverage", "--format", "json"]);
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    const { items, summary } = result;
+
+    const verifiedCount = items.filter((i: any) => i.status === "verified").length;
+    const implOnlyCount = items.filter((i: any) => i.status === "impl-only").length;
+    const untaggedCount = items.filter((i: any) => i.status === "untagged").length;
+
+    expect(summary.total).toBe(items.length);
+    expect(summary.verified).toBe(verifiedCount);
+    expect(summary.implOnly).toBe(implOnlyCount);
+    expect(summary.untagged).toBe(untaggedCount);
+  });
+
+  it("should output human-readable text by default", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = run(["coverage"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("AUTH-001");
+    expect(stdout).toContain("verified");
+    expect(stdout).toContain("untagged");
+  });
+
+  it("should output text with --format text", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = run(["coverage", "--format", "text"]);
+    expect(exitCode).toBe(0);
+    // Should contain status lines for each REQ
+    expect(stdout).toContain("AUTH-001");
+    expect(stdout).toContain("AUTH-002");
+    expect(stdout).toContain("AUTH-003");
+    // Should contain a summary line
+    expect(stdout).toMatch(/total/i);
+  });
+
+  it("should always exit 0 (no gating)", { timeout: 30000 }, () => {
+    // Even with uncovered items, coverage should exit 0
+    const { exitCode } = run(["coverage"]);
+    expect(exitCode).toBe(0);
+  });
+
+  it("should appear in --help output", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = run(["--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("coverage");
+  });
+});


### PR DESCRIPTION
## Summary

- `spectrace coverage` サブコマンドを追加。`--format json|text` オプションに対応し、各仕様の coverage 状態（verified / impl-only / untagged）とサマリを表示
- Claude Code Skills を 3 つ作成（`.claude/skills/spectrace-{plan,verify,coverage}.md`）。エージェントのワークフローに spectrace を組み込み、Plan 策定時の影響分析、実装完了時の整合性チェック、進捗確認時のカバレッジ表示を自動化
- `docs/skills-guide.md` を作成。Skills の概要、セットアップ手順、各スキルの説明を記述
- `.gitignore` を更新し、spectrace スキルファイルのみトラッキング対象に追加

## Test plan

- [x] `spectrace coverage --format json` が正しい JSON 構造（items + summary）を返すことを確認
- [x] JSON 出力の各 REQ の status が正しい（AUTH-001: verified, AUTH-002: impl-only, AUTH-003: untagged）
- [x] summary の集計値が items の内容と一致することを確認
- [x] `spectrace coverage` がデフォルトで text 出力し、各 REQ と summary を表示することを確認
- [x] `spectrace coverage --format text` が text 出力することを確認
- [x] 終了コードが常に 0 であることを確認
- [x] `--help` 出力に coverage コマンドが含まれることを確認
- [x] 既存テスト含め全 80 テストがパス（13 テストファイル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)