### PR TITLE
fix: 003-skills レビュー指摘対応

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,7 +50,9 @@ program
         }
 
         if (result.scanSummary) {
-          console.log(`\nNodes: ${result.scanSummary.nodeCount}  Edges: ${result.scanSummary.edgeCount}`);
+          console.log(
+            `\nNodes: ${result.scanSummary.nodeCount}  Edges: ${result.scanSummary.edgeCount}`,
+          );
           console.log(
             `  req: ${result.scanSummary.reqCount}  doc: ${result.scanSummary.docCount}  file: ${result.scanSummary.fileCount}  test: ${result.scanSummary.testCount}`,
           );
@@ -225,7 +227,11 @@ program
 program
   .command("coverage")
   .description("Show coverage status for each requirement")
-  .option("--format <format>", "Output format: json | text", "text")
+  .addOption(
+    new Option("--format <format>", "Output format: json | text")
+      .choices(["json", "text"])
+      .default("text"),
+  )
   .action((opts) => {
     const rootDir = process.cwd();
     const config = loadConfig(rootDir);
@@ -233,25 +239,9 @@ program
     const entries = computeCoverage(graph);
 
     if (opts.format === "json") {
-      const items = entries.map((e) => ({ reqId: e.reqId, status: e.status }));
-      const summary = {
-        total: entries.length,
-        verified: entries.filter((e) => e.status === "verified").length,
-        implOnly: entries.filter((e) => e.status === "impl-only").length,
-        untagged: entries.filter((e) => e.status === "untagged").length,
-      };
-      console.log(JSON.stringify({ items, summary }));
+      printCoverageJson(entries);
     } else {
-      console.log("COVERAGE:");
-      for (const e of entries) {
-        console.log(`  ${e.reqId}: ${e.status}`);
-      }
-      const verified = entries.filter((e) => e.status === "verified").length;
-      const implOnly = entries.filter((e) => e.status === "impl-only").length;
-      const untagged = entries.filter((e) => e.status === "untagged").length;
-      console.log(
-        `\nSummary: total=${entries.length} verified=${verified} impl-only=${implOnly} untagged=${untagged}`,
-      );
+      printCoverageText(entries);
     }
   });
 
@@ -284,6 +274,30 @@ function printImpactText(result: any) {
     console.log("Drifted:");
     for (const d of result.drifted) console.log(`  ${d.nodeId} (${d.kind})`);
   }
+}
+
+function printCoverageJson(entries: { reqId: string; status: string }[]) {
+  const items = entries.map((e) => ({ reqId: e.reqId, status: e.status }));
+  const summary = {
+    total: entries.length,
+    verified: entries.filter((e) => e.status === "verified").length,
+    implOnly: entries.filter((e) => e.status === "impl-only").length,
+    untagged: entries.filter((e) => e.status === "untagged").length,
+  };
+  console.log(JSON.stringify({ items, summary }));
+}
+
+function printCoverageText(entries: { reqId: string; status: string }[]) {
+  console.log("COVERAGE:");
+  for (const e of entries) {
+    console.log(`  ${e.reqId}: ${e.status}`);
+  }
+  const verified = entries.filter((e) => e.status === "verified").length;
+  const implOnly = entries.filter((e) => e.status === "impl-only").length;
+  const untagged = entries.filter((e) => e.status === "untagged").length;
+  console.log(
+    `\nSummary: total=${entries.length} verified=${verified} impl-only=${implOnly} untagged=${untagged}`,
+  );
 }
 
 function printCheckText(result: any) {

--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -13,7 +13,11 @@ export function impact(graph: ArtifactGraph, startIds: string[], lock: LockFile)
     const node = graph.nodes.get(id);
     if (node && node.kind === "file") {
       for (const [symId, symNode] of graph.nodes) {
-        if (symNode.kind === "symbol" && symNode.filePath === node.filePath && !visited.has(symId)) {
+        if (
+          symNode.kind === "symbol" &&
+          symNode.filePath === node.filePath &&
+          !visited.has(symId)
+        ) {
           queue.push(symId);
         }
       }

--- a/src/init.ts
+++ b/src/init.ts
@@ -39,9 +39,7 @@ export function detectProject(rootDir: string): DetectionResult {
 }
 
 export function generateConfig(detection: DetectionResult): SpectraceConfig {
-  const include = detection.hasSrc
-    ? [...DEFAULT_CONFIG.include]
-    : ["**/*.ts", "**/*.tsx"];
+  const include = detection.hasSrc ? [...DEFAULT_CONFIG.include] : ["**/*.ts", "**/*.tsx"];
 
   const specDirs: string[] = [];
   if (detection.hasSpecs) specDirs.push("specs");

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -23,7 +23,11 @@ interface SymbolRange {
   endLine: number;
 }
 
-export function createTSParser(rootDir: string, patterns: string[], mode: "file" | "symbol" = "file") {
+export function createTSParser(
+  rootDir: string,
+  patterns: string[],
+  mode: "file" | "symbol" = "file",
+) {
   const tsconfigPath = resolve(rootDir, "tsconfig.json");
   const projectOpts = existsSync(tsconfigPath)
     ? { tsConfigFilePath: tsconfigPath, skipAddingFilesFromTsConfig: true }
@@ -139,10 +143,12 @@ function extractImports(
           edges.push({ source: sourceId, target: `symbol:${targetRel}#default`, kind: "imports" });
         }
         for (const named of namedImports) {
-          const importName = named.getAliasNode()
-            ? named.getNameNode().getText()
-            : named.getName();
-          edges.push({ source: sourceId, target: `symbol:${targetRel}#${importName}`, kind: "imports" });
+          const importName = named.getAliasNode() ? named.getNameNode().getText() : named.getName();
+          edges.push({
+            source: sourceId,
+            target: `symbol:${targetRel}#${importName}`,
+            kind: "imports",
+          });
         }
         if (!defaultImport && namedImports.length === 0 && !namespaceImport) {
           edges.push({ source: sourceId, target: `file:${targetRel}`, kind: "imports" });
@@ -236,7 +242,7 @@ function resolveSymbolAtLine(ranges: SymbolRange[], line: number): string | null
   let best: SymbolRange | null = null;
   for (const range of ranges) {
     if (line >= range.startLine && line <= range.endLine) {
-      if (!best || (range.endLine - range.startLine) < (best.endLine - best.startLine)) {
+      if (!best || range.endLine - range.startLine < best.endLine - best.startLine) {
         best = range;
       }
     }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -2,27 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 import { existsSync, unlinkSync } from "node:fs";
-
-const CLI = resolve(import.meta.dirname, "../dist/cli.js");
-const FIXTURE_DIR = resolve(import.meta.dirname, "fixtures");
-const LOCK_PATH = resolve(FIXTURE_DIR, ".trace.lock");
-
-function run(args: string[]): { stdout: string; stderr: string; exitCode: number } {
-  try {
-    const stdout = execFileSync("node", [CLI, ...args], {
-      encoding: "utf-8",
-      cwd: FIXTURE_DIR,
-      timeout: 30000,
-    });
-    return { stdout, stderr: "", exitCode: 0 };
-  } catch (e: any) {
-    return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", exitCode: e.status ?? 1 };
-  }
-}
-
-function cleanup() {
-  if (existsSync(LOCK_PATH)) unlinkSync(LOCK_PATH);
-}
+import { run, cleanup, CLI, LOCK_PATH } from "./helpers.js";
 
 afterEach(cleanup);
 

--- a/tests/coverage-cli.test.ts
+++ b/tests/coverage-cli.test.ts
@@ -1,30 +1,11 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
-import { existsSync, unlinkSync } from "node:fs";
-
-const CLI = resolve(import.meta.dirname, "../dist/cli.js");
-const FIXTURE_DIR = resolve(import.meta.dirname, "fixtures");
-const LOCK_PATH = resolve(FIXTURE_DIR, ".trace.lock");
-
-function run(args: string[]): { stdout: string; stderr: string; exitCode: number } {
-  try {
-    const stdout = execFileSync("node", [CLI, ...args], {
-      encoding: "utf-8",
-      cwd: FIXTURE_DIR,
-      timeout: 30000,
-    });
-    return { stdout, stderr: "", exitCode: 0 };
-  } catch (e: any) {
-    return { stdout: e.stdout ?? "", stderr: e.stderr ?? "", exitCode: e.status ?? 1 };
-  }
-}
-
-function cleanup() {
-  if (existsSync(LOCK_PATH)) unlinkSync(LOCK_PATH);
-}
+import { run, runAt, cleanup } from "./helpers.js";
 
 afterEach(cleanup);
+
+const EMPTY_FIXTURE = resolve(import.meta.dirname, "fixtures/empty-graph");
+const ALL_VERIFIED_FIXTURE = resolve(import.meta.dirname, "fixtures/all-verified");
 
 // ---------------------------------------------------------------------------
 // coverage
@@ -103,6 +84,18 @@ describe("CLI: coverage", () => {
     expect(stdout).toMatch(/total/i);
   });
 
+  it("should show correct status in text output for each REQ", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = run(["coverage", "--format", "text"]);
+    expect(exitCode).toBe(0);
+
+    // AUTH-001 should be verified in text output
+    expect(stdout).toMatch(/AUTH-001:\s*verified/);
+    // AUTH-002 should be impl-only in text output
+    expect(stdout).toMatch(/AUTH-002:\s*impl-only/);
+    // AUTH-003 should be untagged in text output
+    expect(stdout).toMatch(/AUTH-003:\s*untagged/);
+  });
+
   it("should always exit 0 (no gating)", { timeout: 30000 }, () => {
     // Even with uncovered items, coverage should exit 0
     const { exitCode } = run(["coverage"]);
@@ -113,5 +106,85 @@ describe("CLI: coverage", () => {
     const { stdout, exitCode } = run(["--help"]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("coverage");
+  });
+
+  it("should reject invalid --format value", { timeout: 30000 }, () => {
+    const { exitCode, stderr } = run(["coverage", "--format", "invalid"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/invalid|allowed|choices/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// coverage: empty graph (0 req nodes)
+// ---------------------------------------------------------------------------
+describe("CLI: coverage (empty graph)", () => {
+  it(
+    "should return empty items and zero summary for empty graph in JSON",
+    { timeout: 30000 },
+    () => {
+      const { stdout, exitCode } = runAt(EMPTY_FIXTURE, ["coverage", "--format", "json"]);
+      expect(exitCode).toBe(0);
+
+      const result = JSON.parse(stdout);
+      expect(result.items).toEqual([]);
+      expect(result.summary).toEqual({
+        total: 0,
+        verified: 0,
+        implOnly: 0,
+        untagged: 0,
+      });
+    },
+  );
+
+  it("should output text without errors for empty graph", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = runAt(EMPTY_FIXTURE, ["coverage", "--format", "text"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("COVERAGE:");
+    expect(stdout).toMatch(/total=0/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// coverage: all-verified fixture (all reqs have impl + test)
+// ---------------------------------------------------------------------------
+describe("CLI: coverage (all verified)", () => {
+  it(
+    "should show all items as verified when every req has impl and test",
+    { timeout: 30000 },
+    () => {
+      const { stdout, exitCode } = runAt(ALL_VERIFIED_FIXTURE, ["coverage", "--format", "json"]);
+      expect(exitCode).toBe(0);
+
+      const result = JSON.parse(stdout);
+      expect(result.items.length).toBeGreaterThan(0);
+
+      for (const item of result.items) {
+        expect(item.status).toBe("verified");
+      }
+
+      expect(result.summary.verified).toBe(result.summary.total);
+      expect(result.summary.implOnly).toBe(0);
+      expect(result.summary.untagged).toBe(0);
+    },
+  );
+
+  it("should show all verified in text output", { timeout: 30000 }, () => {
+    const { stdout, exitCode } = runAt(ALL_VERIFIED_FIXTURE, ["coverage", "--format", "text"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("COVERAGE:");
+    expect(stdout).toMatch(/VER-001:\s*verified/);
+    expect(stdout).toMatch(/VER-002:\s*verified/);
+    // No item line should show impl-only or untagged as a status
+    const lines = stdout.split("\n").filter((l: string) => l.match(/VER-\d+:/));
+    for (const line of lines) {
+      expect(line).toContain("verified");
+      expect(line).not.toContain("impl-only");
+      expect(line).not.toContain("untagged");
+    }
+    // Summary should show all verified
+    expect(stdout).toMatch(/verified=2/);
+    expect(stdout).toMatch(/impl-only=0/);
+    expect(stdout).toMatch(/untagged=0/);
   });
 });

--- a/tests/fixtures/.spectrace.json
+++ b/tests/fixtures/.spectrace.json
@@ -1,0 +1,6 @@
+{
+  "include": ["src/**/*.ts"],
+  "specDirs": ["specs"],
+  "testPatterns": ["tests/**/*.test.ts"],
+  "lockFile": ".trace.lock"
+}

--- a/tests/fixtures/all-verified/.spectrace.json
+++ b/tests/fixtures/all-verified/.spectrace.json
@@ -1,0 +1,6 @@
+{
+  "include": ["src/**/*.ts"],
+  "specDirs": ["requirements"],
+  "testPatterns": ["tests/**/*.test.ts"],
+  "lockFile": ".trace.lock"
+}

--- a/tests/fixtures/all-verified/requirements/feature.md
+++ b/tests/fixtures/all-verified/requirements/feature.md
@@ -1,0 +1,16 @@
+---
+spectrace:
+  node_id: "doc:feature-design"
+  depends_on:
+    - { id: "VER-001", relation: implements }
+---
+
+# Feature Design
+
+## Requirements
+
+- VER-001: ユーザー登録機能
+  - メールアドレスで登録できること
+
+- VER-002: プロフィール編集機能
+  - 名前を変更できること

--- a/tests/fixtures/all-verified/src/profile.ts
+++ b/tests/fixtures/all-verified/src/profile.ts
@@ -1,0 +1,4 @@
+// @impl VER-002
+export function updateProfile(name: string): string {
+  return `profile_${name}`;
+}

--- a/tests/fixtures/all-verified/src/register.ts
+++ b/tests/fixtures/all-verified/src/register.ts
@@ -1,0 +1,4 @@
+// @impl VER-001
+export function register(email: string): string {
+  return `user_${email}`;
+}

--- a/tests/fixtures/all-verified/tests/profile.test.ts
+++ b/tests/fixtures/all-verified/tests/profile.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from "vitest";
+
+describe("[VER-002] profile", () => {
+  it("should update profile", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/tests/fixtures/all-verified/tests/register.test.ts
+++ b/tests/fixtures/all-verified/tests/register.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from "vitest";
+
+describe("[VER-001] register", () => {
+  it("should register user", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,35 @@
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { existsSync, unlinkSync } from "node:fs";
+
+export const CLI = resolve(import.meta.dirname, "../dist/cli.js");
+export const FIXTURE_DIR = resolve(import.meta.dirname, "fixtures");
+export const LOCK_PATH = resolve(FIXTURE_DIR, ".trace.lock");
+
+export function run(args: string[]): { stdout: string; stderr: string; exitCode: number } {
+  return runAt(FIXTURE_DIR, args);
+}
+
+export function runAt(
+  cwd: string,
+  args: string[],
+): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execFileSync("node", [CLI, ...args], {
+      encoding: "utf-8",
+      cwd,
+      timeout: 30000,
+    });
+    return { stdout, stderr: "", exitCode: 0 };
+  } catch (e: any) {
+    return {
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? "",
+      exitCode: e.status ?? 1,
+    };
+  }
+}
+
+export function cleanup() {
+  if (existsSync(LOCK_PATH)) unlinkSync(LOCK_PATH);
+}

--- a/tests/typescript.test.ts
+++ b/tests/typescript.test.ts
@@ -194,9 +194,7 @@ describe("createTSParser (symbol mode)", () => {
   });
 
   it("should fallback @impl at top-level to file source", () => {
-    const implEdges = result.edges.filter(
-      (e) => e.kind === "implements" && e.target === "SC-001",
-    );
+    const implEdges = result.edges.filter((e) => e.kind === "implements" && e.target === "SC-001");
 
     expect(implEdges).toHaveLength(1);
     expect(implEdges[0].source).toBe("file:src/toplevel-impl.ts");


### PR DESCRIPTION
## Summary

- coverage コマンドの JSON/text 整形ロジックを `printCoverageJson` / `printCoverageText` ヘルパー関数に抽出（`printCheckText` パターンに統一）
- coverage `--format` オプションに `.choices(["json", "text"])` を追加し、無効値をコマンドレベルで拒否するように変更
- `cli.test.ts` と `coverage-cli.test.ts` で重複していた `run()` / `cleanup()` を `tests/helpers.ts` に共通化
- all-verified フィクスチャ（全 req が impl + test を持つ）を追加し、全 verified ケースのテストを追加
- empty-graph フィクスチャに `.gitkeep` を追加（git 追跡可能に）
- text 出力で各ステータス文字列（verified / impl-only / untagged）を検証するテストを追加
- メインフィクスチャに `.spectrace.json` を追加し、サブフィクスチャとの glob 干渉を防止

## Test plan

- [x] `pnpm test` で全 132 テストがパス
- [x] `coverage --format invalid` が commander のエラーで拒否されることを確認
- [x] 空グラフ（req 0 件）で `{ items: [], summary: { total: 0, ... } }` が返ることを確認
- [x] all-verified フィクスチャで全アイテムが verified であることを確認
- [x] text 出力で AUTH-001: verified, AUTH-002: impl-only, AUTH-003: untagged のステータス文字列を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)