### PR TITLE
feat: spectrace rename — ID リネーム・分割・統合コマンド

### DIFF
--- a/.claude/skills/spectrace-rename.md
+++ b/.claude/skills/spectrace-rename.md
@@ -1,0 +1,64 @@
+---
+name: "spectrace-rename"
+description: "仕様 ID のリネーム・分割・統合の依頼時にトリガー。spectrace rename を使い、spec / @impl / テストタグ / frontmatter / lock を一括で安全に書き換える。破壊的操作のため必ず --dry-run で確認してから適用する。"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## 目的
+
+仕様 ID のライフサイクル（rename / split / merge）を `spectrace rename` で一括処理する。
+5 種類の参照（spec のリスト項目・見出し、`@impl` タグ、テストの `[ID]` / `req:` タグ、
+frontmatter の `depends_on` / `derives_from`、`.trace.lock` のキー）を横断的に書き換える。
+
+## 重要な前提
+
+- **破壊的操作**: git 追跡ファイルを直接書き換える。必ず作業ツリーをコミット済みにしてから実行する。
+- **必ず `--dry-run` で確認**してから本適用する。
+- ターゲット ID は再スキャン可能な形式（`REQ-001` / `auth/FR-2` / `doc:xxx`）のみ受理される。
+  `REQ-COMBINED` や `REQ-001a` のような形式は拒否される。
+
+## 実行手順
+
+### 1. spectrace の存在確認
+
+```bash
+command -v spectrace || npx spectrace --version
+```
+
+### 2. dry-run で影響範囲を確認
+
+```bash
+# リネーム
+spectrace rename --from REQ-001 --to REQ-100 --dry-run
+# 分割（1 → 複数）
+spectrace rename --split REQ-001 --into REQ-101 REQ-102 --dry-run
+# 統合（複数 → 1）
+spectrace rename --merge REQ-001 REQ-002 --into REQ-100 --dry-run
+```
+
+変更予定のファイル・行・lock キー変更が表示される。意図と一致するか確認する。
+
+### 3. 本適用
+
+`--dry-run` を外して実行する。適用後、lock は自動的に再 reconcile され、
+書き換えたノードの contentHash・参照・specFile が最新化される。
+
+### 4. 後処理
+
+- **split**: 新しい ID には `@impl` が自動付与されない（手動割り当てが必要）。
+  CLI が警告した対象ファイルで `@impl` を新 ID に割り当て、scaffold 行（`(TODO: ...)`）を記述する。
+- 統合元の見出し直下にあった子箇条書きは残るため、必要に応じて整理する。
+- 最後に必ず整合性を確認する:
+
+```bash
+spectrace check
+```
+
+rename / merge は後続の `check` がそのままパスする。split は新 ID が `uncovered`
+として残るため、`@impl` 割り当て後に再度 `check` する。
+
+## 出力形式
+
+`--format json` を付けると結果が JSON で出力される（失敗時も `{ "error": "..." }` の JSON）。
+スクリプトから扱う場合に利用する。

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,3 @@
-{"feature_directory": "specs/005-speckit-remaining"}
+{
+  "feature_directory": "specs/004-id-lifecycle"
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,82 @@
 # spectrace
+
+Typed artifact graph for TS/JS — trace specs, docs, code, and tests bidirectionally.
+
+spectrace builds a graph that links requirement IDs in your specs to the code that
+implements them (`@impl` tags) and the tests that verify them (`[ID]` / `req:` tags),
+then detects **drift** (spec changed but code/tests didn't), **orphans**, and
+**uncovered** requirements.
+
+## Install
+
+```bash
+npm install -D spectrace
+npx spectrace init      # writes .spectrace.json
+```
+
+## How references are expressed
+
+| Artifact            | Reference form                                  |
+| ------------------- | ----------------------------------------------- |
+| Spec list item      | `- REQ-001: description`                        |
+| Spec heading (Kiro) | `### Requirement 1: description`                |
+| Implementation      | `// @impl REQ-001`                              |
+| Test                | `it("[REQ-001] …")` or `// req: "REQ-001"`      |
+| Doc relations       | frontmatter `spectrace.depends_on` / `derives_from` |
+
+Custom grammars are configurable via `reqPatterns` in `.spectrace.json`.
+
+## Commands
+
+| Command               | Purpose                                                        |
+| --------------------- | -------------------------------------------------------------- |
+| `spectrace scan`      | Build the artifact graph and report counts                     |
+| `spectrace check`     | Report drift / orphans / uncovered (`--gate` to fail a hook)   |
+| `spectrace coverage`  | Per-requirement coverage status                                |
+| `spectrace impact`    | Impact analysis (`--diff` scopes to the git diff)              |
+| `spectrace reconcile` | Rebuild `.trace.lock` from the current graph                   |
+| `spectrace graph`     | Emit the graph (dot / json)                                    |
+| `spectrace rename`    | Rename / split / merge requirement IDs (see below)             |
+
+## `spectrace rename` — ID lifecycle
+
+Renames, splits or merges a requirement ID and rewrites **every** reference to it
+(spec list items / headings, `@impl` tags, test tags, frontmatter
+`depends_on` / `derives_from`, and `.trace.lock` keys) in one pass, limited to
+git-tracked files.
+
+```bash
+# Rename one ID
+spectrace rename --from REQ-001 --to REQ-100
+
+# Split one ID into several (code @impl tags are flagged for manual re-assignment)
+spectrace rename --split REQ-001 --into REQ-101 REQ-102
+
+# Merge several IDs into one
+spectrace rename --merge REQ-001 REQ-002 --into REQ-100
+
+# Preview without writing
+spectrace rename --from REQ-001 --to REQ-100 --dry-run
+
+# Machine-readable output (errors are emitted as JSON too)
+spectrace rename --from REQ-001 --to REQ-100 --format json
+```
+
+Notes:
+
+- **Always commit first** — rename writes to tracked files in place. Use `--dry-run`
+  to preview.
+- **Target IDs are validated**: they must match the requirement-ID grammar
+  (`REQ-001`, `auth/FR-2`, `Requirement-3`) or the `doc:` prefix, so the renamed ID
+  is guaranteed to be re-discoverable by the next scan.
+- After a non-preview run the lock is automatically reconciled, so `spectrace check`
+  passes immediately for `rename` and `merge`.
+- **split** intentionally does **not** re-assign `@impl` tags (the mapping is
+  ambiguous); the new IDs are reported as `uncovered` until you assign them and fill
+  in their scaffolded spec lines. `check` will flag this until done.
+- IDs inside fenced code blocks are treated as examples and left untouched.
+
+## Claude Code skills
+
+spectrace ships Claude Code skills (`spectrace-plan`, `spectrace-verify`,
+`spectrace-coverage`, `spectrace-rename`). See [docs/skills-guide.md](docs/skills-guide.md).

--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -31,6 +31,7 @@ npx spectrace init
   spectrace-plan.md
   spectrace-verify.md
   spectrace-coverage.md
+  spectrace-rename.md
 ```
 
 これらのファイルは spectrace パッケージに含まれています。
@@ -83,6 +84,21 @@ spectrace check --diff --format text
 使用する CLI コマンド:
 ```bash
 spectrace coverage --format json
+```
+
+### spectrace-rename
+
+トリガー: 仕様 ID のリネーム・分割・統合の依頼時
+
+`spectrace rename` を使い、spec のリスト項目／見出し、`@impl` タグ、テストの `[ID]` / `req:` タグ、
+frontmatter の `depends_on` / `derives_from`、`.trace.lock` のキーを横断的に書き換えます。
+破壊的操作のため、必ず `--dry-run` で影響範囲を確認してから本適用します。
+
+使用する CLI コマンド:
+```bash
+spectrace rename --from REQ-001 --to REQ-100 --dry-run     # リネーム
+spectrace rename --split REQ-001 --into REQ-101 REQ-102    # 分割
+spectrace rename --merge REQ-001 REQ-002 --into REQ-100    # 統合
 ```
 
 ## Skills と Stop Hook の関係

--- a/specs/004-id-lifecycle/checklists/requirements.md
+++ b/specs/004-id-lifecycle/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: rename / split / merge（ID ライフサイクル管理）
+
+Purpose: Validate specification completeness and quality before proceeding to planning
+Created: 2026-06-20
+Feature: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- 3 つのサブコマンド（rename / split / merge）を `spectrace rename` 配下に統合
+- dry-run モードを全操作に適用し、安全性を確保
+- git 追跡ファイルのみ対象とすることで、書き換え範囲を明確に限定
+- 書き換えパターンは 5 種類（spec 見出し・リスト項目、@impl タグ、テストタグ、frontmatter depends_on、.trace.lock キー）に限定し、誤書き換えを防止

--- a/specs/004-id-lifecycle/plan.md
+++ b/specs/004-id-lifecycle/plan.md
@@ -1,0 +1,273 @@
+# Implementation Plan: rename / split / merge（ID ライフサイクル管理）
+
+Branch: `004-id-lifecycle` | Date: 2026-06-22 | Spec: [spec.md](./spec.md)
+
+Input: Feature specification from `specs/004-id-lifecycle/spec.md`
+
+## Summary
+
+`spectrace rename` サブコマンドを新規に追加し、仕様 ID のリネーム・分割・統合を
+プロジェクト全体で一括実行する。対象は 5 種類の参照パターン（spec リスト項目/見出し、
+`@impl` タグ、テスト `[ID]` タグ、frontmatter `depends_on`、`.trace.lock` キー）に限定し、
+無関係なテキストは書き換えない。
+
+書き換え対象は git 追跡ファイルに限定し、`--dry-run` で変更一覧の事前確認が可能。
+`doc:xxx` 形式や名前空間修飾付き ID（`001-auth/FR-001`）にも対応する。
+
+3 つの操作モード:
+- **rename** (`--from <old> --to <new>`) — P1: 全参照を一括置換
+- **split** (`--split <old> --into <new1> <new2> [...]`) — P2: 仕様分割 + impl 警告
+- **merge** (`--merge <id1> <id2> --into <new>`) — P2: 参照統合 + lock 合算
+
+## Technical Context
+
+Language/Version: TypeScript 5.x（Node.js ランタイム）
+
+Primary Dependencies: commander, ts-morph, remark (unified), glob, gray-matter
+
+Storage: `.trace.lock`（JSON ファイル）、`.spectrace.json`（設定ファイル）
+
+Testing: Vitest
+
+Target Platform: Node.js CLI（npm 配布）
+
+Project Type: CLI ツール / ライブラリ
+
+Constraints: 書き換え中の失敗時は `git checkout` で復元する想定（ロールバック機構不要）。
+全バリデーションを書き換え前に完了させる fail-fast 設計とする。
+
+## Constitution Check
+
+GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Deterministic Integrity | Pass | 全処理は決定的。正規表現ベースのパターンマッチ + 文字列置換。LLM 不使用 |
+| II. Declarative Links — SDD ツール ID 直接使用 | Pass | 仕様 ID（REQ-xxx, doc:xxx）をそのまま操作対象とする |
+| III. JS/TS Native | Pass | Node.js CLI として実装。既存の ts-morph + remark を継続使用 |
+| IV. CLI-First Interface | Pass | `spectrace rename` サブコマンドとして公開。`--dry-run`, `--format` オプション |
+| V. Incremental Adoption | Pass | rename は既存コマンド群と独立。他コマンドへの影響なし |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-id-lifecycle/
+├── spec.md
+├── plan.md              # This file
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── cli.ts               # 変更: rename サブコマンド追加
+├── rename.ts            # 新規: rename/split/merge のコアロジック
+│                        #   rewriter（5 種類のパターン書き換え）
+│                        #   lock-updater（lock キー操作）
+│                        #   executor（オーケストレーション）
+├── diff.ts              # 変更: getGitTrackedFiles() 追加
+├── config.ts            # 変更なし
+├── scan.ts              # 変更なし（ID 存在チェックに graph を利用）
+├── graph/
+│   ├── builder.ts       # 変更なし
+│   └── traverse.ts      # 変更なし
+├── parsers/
+│   ├── markdown.ts      # 変更なし（正規表現パターンを参照）
+│   └── typescript.ts    # 変更なし（正規表現パターンを参照）
+├── types.ts             # 変更なし
+├── lock.ts              # 変更なし（readLock/writeLock を利用）
+├── check.ts             # 変更なし
+├── coverage.ts          # 変更なし
+├── init.ts              # 変更なし
+└── hook-pretool.ts      # 変更なし
+
+tests/
+├── rename.test.ts       # 新規: rewriter + lock-updater のユニットテスト
+├── rename-cli.test.ts   # 新規: CLI 統合テスト
+└── fixtures/
+    └── rename/          # 新規: rename テスト用フィクスチャ
+        ├── .spectrace.json
+        ├── .trace.lock
+        ├── specs/
+        │   └── feature.md
+        ├── src/
+        │   └── feature.ts
+        ├── tests/
+        │   └── feature.test.ts
+        └── tsconfig.json
+```
+
+Structure Decision: コアロジックは `src/rename.ts` に集約する。
+モジュールを `src/rename/` ディレクトリに分割する選択肢もあるが、
+既存コードベース（`src/lock.ts`, `src/check.ts` 等）が単一ファイルの慣習なので合わせる。
+ファイルが肥大化した場合のみ分割を検討する。
+
+## Design Decisions
+
+### D1: rewriter は純粋関数として設計
+
+ファイル I/O は executor レイヤーに限定し、rewriter は入力文字列に対して書き換え後の
+文字列と変更一覧を返す純粋関数とする。fixture なしの文字列ベースユニットテストが可能。
+
+### D2: 既存パーサーの正規表現と同等パターンを使用
+
+`markdown.ts` の `LIST_ITEM_RE`, `KIRO_HEADING_RE` および `typescript.ts` の
+`IMPL_RE`, `TEST_REQ_RE`, `TEST_ANNOTATION_RE` と同等の正規表現を rewriter で使い、
+マッチ箇所内で対象 ID を文字列置換する。FR-007（無関係テキスト非書き換え）を満たす。
+
+### D3: frontmatter は行レベル文字列置換
+
+gray-matter で YAML パース → 値置換 → 再シリアライズする方法はフォーマット崩れリスクがある。
+行レベルの文字列置換（`node_id:` 行, `id:` 行の中の対象 ID のみ置換）の方が差分が小さく安全。
+
+### D4: symbol: ノードには触れない
+
+lock に存在する `symbol:src/path#name` キーは rename 対象外。
+コード内の `@impl` タグを書き換えれば、次回 scan 時に正しい implements エッジが再構築される。
+
+### D5: commander.js のオプション設計
+
+`--from/--to` と `--split/--into` と `--merge/--into` は排他的。
+action 内で引数の組み合わせを判定して適切な処理を呼び出す。
+`--into` は variadic option（`.option("--into <ids...>")`）、
+`--merge` も variadic（`.option("--merge <ids...>")`）として定義する。
+
+## Task Breakdown
+
+### Phase 1: P1 rename 実装
+
+#### Task 1-1: rewriter — 5 種類のパターン書き換えエンジン
+
+`src/rename.ts` に以下の関数を実装:
+
+- `rewriteSpecListItem(content, oldId, newId)` — `- REQ-001:` / `- **REQ-001**:` パターン
+- `rewriteSpecHeading(content, oldId, newId)` — `### Requirement N:` パターン
+- `rewriteImplTags(content, oldId, newId)` — `// @impl REQ-001` パターン
+- `rewriteTestTags(content, oldId, newId)` — `[REQ-001]` パターン + `req: "REQ-001"` アノテーション
+- `rewriteFrontmatter(content, oldId, newId)` — frontmatter `depends_on` 内 ID / `node_id` の `doc:xxx`
+- `rewriteFile(filePath, content, oldId, newId)` — 拡張子に応じて上記を組み合わせる統合関数
+
+各関数は `{ content: string; changes: RewriteChange[] }` を返す純粋関数。
+
+見積り: 大 | 依存: なし
+
+#### Task 1-2: lock-updater — lock キー操作
+
+`src/rename.ts` に以下の関数を実装:
+
+- `renameLockKey(lock, oldId, newId)` — キー付け替え + dependsOn 内参照更新
+- `splitLockKey(lock, oldId, newIds)` — 旧キー削除、新キーに空エントリ追加
+- `mergeLockKeys(lock, sourceIds, newId)` — impl/tests 合算して統合
+
+見積り: 中 | 依存: なし
+
+#### Task 1-3: executor — rename オーケストレーション
+
+`src/rename.ts` に `executeRename(options)` を実装:
+
+1. `loadConfig` → `scan` → graph から既存 ID 一覧取得
+2. バリデーション（from の存在確認、to の重複チェック）
+3. `git ls-files` で git 追跡ファイル一覧取得（`src/diff.ts` に `getGitTrackedFiles()` 追加）
+4. 対象ファイルに `rewriteFile()` 適用、変更一覧収集
+5. `readLock` → `renameLockKey()` で lock 更新
+6. dry-run でなければ `writeFileSync` + `writeLock` で実書き換え
+
+見積り: 大 | 依存: Task 1-1, 1-2
+
+#### Task 1-4: CLI — rename サブコマンド登録
+
+`src/cli.ts` に `spectrace rename --from <old> --to <new> [--dry-run] [--format json|text]` を追加。
+text 出力はファイルパス:行番号と変更前後を表示。
+
+見積り: 中 | 依存: Task 1-3
+
+#### Task 1-5: テスト fixture 作成
+
+`tests/fixtures/rename/` に spec.md（REQ-001, REQ-002, frontmatter depends_on）、
+feature.ts（`@impl REQ-001`）、feature.test.ts（`[REQ-001]`）、.trace.lock、tsconfig.json を配置。
+
+見積り: 小 | 依存: なし
+
+#### Task 1-6: ユニットテスト
+
+`tests/rename.test.ts` — rewriter の各パターン書き換え、lock-updater、executor のバリデーション。
+spec の Acceptance Scenarios 1-8 および Edge Cases をカバー。
+
+見積り: 大 | 依存: Task 1-3, 1-5
+
+#### Task 1-7: CLI 統合テスト
+
+`tests/rename-cli.test.ts` — 一時ディレクトリに fixture コピー → CLI 実行 → ファイル内容検証。
+dry-run、json 出力、エラーケースを含む。
+
+見積り: 中 | 依存: Task 1-4, 1-5
+
+### Phase 2: P2 split / merge 実装
+
+#### Task 2-1: split ロジック
+
+`executeSplit(options)` を実装。spec から旧 ID 行削除 + 新 ID 雛形追記、
+`@impl` ファイルへの手動振り分け警告、lock 更新。
+
+見積り: 中 | 依存: Phase 1
+
+#### Task 2-2: merge ロジック
+
+`executeMerge(options)` を実装。全参照を rewriter で一括置換（rename と同じ）、
+spec 行削除 + 新 ID 雛形追記、lock の impl/tests 合算。
+
+見積り: 中 | 依存: Phase 1
+
+#### Task 2-3: CLI — split / merge オプション追加
+
+`--split <old> --into <id1> <id2> [...]` と `--merge <id1> <id2> --into <new>` を
+rename サブコマンドに追加。排他バリデーション。
+
+見積り: 中 | 依存: Task 2-1, 2-2
+
+#### Task 2-4: split / merge テスト
+
+ユニットテスト + CLI 統合テスト。spec の Acceptance Scenarios（US2: 1-5, US3: 1-5）をカバー。
+
+見積り: 中 | 依存: Task 2-3
+
+## Implementation Order
+
+```
+Task 1-1 (rewriter)       ─┐
+Task 1-2 (lock-updater)   ─┼─ 並行可能
+Task 1-5 (fixture)        ─┘
+         │
+Task 1-3 (executor)       ← 1-1, 1-2 に依存
+         │
+Task 1-4 (cli)            ← 1-3 に依存
+Task 1-6 (unit tests)     ← 1-3, 1-5 に依存
+Task 1-7 (cli tests)      ← 1-4, 1-5 に依存
+         │
+    ── P1 完了 ──
+         │
+Task 2-1 (split)          ─┐
+Task 2-2 (merge)          ─┼─ 並行可能
+                          ─┘
+Task 2-3 (cli split/merge)← 2-1, 2-2 に依存
+Task 2-4 (tests)          ← 2-3 に依存
+         │
+    ── P2 完了 ──
+```
+
+## Risks
+
+| リスク | 対策 |
+|---|---|
+| frontmatter 再シリアライズでフォーマット崩れ | D3: 行レベル文字列置換を採用 |
+| `@impl REQ-001 REQ-002` で部分一致の誤置換 | 単語境界を意識した正規表現（ID 後に `[\s\]\,]` または行末） |
+| 大量ファイルのパフォーマンス | git ls-files + 拡張子フィルタで対象を絞る |
+| lock の symbol: ノード破損 | D4: symbol: キーは操作対象外として明示的にスキップ |
+
+## Complexity Tracking
+
+> 違反なし。Constitution Check 全項目パス。

--- a/specs/004-id-lifecycle/spec.md
+++ b/specs/004-id-lifecycle/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: rename / split / merge（ID ライフサイクル管理）
+
+Feature Branch: `004-id-lifecycle`
+
+Created: 2026-06-20
+
+Status: Draft
+
+Input: 仕様 ID のリネーム・分割・統合をプロジェクト全体で一括実行できるコマンドを提供し、ID ライフサイクルを管理する
+
+## User Scenarios & Testing (mandatory)
+
+### User Story 1 - 仕様 ID のリネーム (Priority: P1)
+
+開発者が仕様策定中に ID の命名規則を変更したい、または ID に誤りがあった場合、
+`spectrace rename --from REQ-xxxx --to REQ-yyyy` を実行すると、プロジェクト全体のあらゆる参照箇所
+（仕様ファイルの見出し・リスト項目、コードの `@impl` タグ、テストの `[REQ-xxxx]` タグ、frontmatter の `depends_on`、`.trace.lock` のキー）
+が一括で新しい ID に書き換えられる。`doc:xxx` 形式のドキュメント ID にも同じ操作が適用される。
+
+Why this priority: ID のリネームは仕様策定の初期段階で頻繁に発生する最も基本的なライフサイクル操作であり、手作業での一括書き換えはミスを招きやすい。split / merge の前提となる書き換えメカニズムもここで確立する。
+
+Independent Test: fixture プロジェクトに REQ-001 を含む spec.md, コードファイル (`@impl REQ-001`), テストファイル (`[REQ-001]`), `.trace.lock` を配置し、`spectrace rename --from REQ-001 --to REQ-100` を実行後、全ファイルの参照が REQ-100 に書き換わっていることを確認する。
+
+Acceptance Scenarios:
+
+1. Given spec.md に `- REQ-001: ユーザー認証` というリスト項目がある, When `spectrace rename --from REQ-001 --to REQ-100` を実行する, Then spec.md 内の `REQ-001` が `REQ-100` に書き換わる
+2. Given コードファイルに `// @impl REQ-001` がある, When rename を実行する, Then `// @impl REQ-100` に書き換わる
+3. Given テストファイルに `[REQ-001]` がある, When rename を実行する, Then `[REQ-100]` に書き換わる
+4. Given `.trace.lock` に `"REQ-001"` キーのエントリがある, When rename を実行する, Then キーが `"REQ-100"` に変更され、エントリの内容は保持される
+5. Given frontmatter の `depends_on` に `REQ-001` への参照がある, When rename を実行する, Then 参照が `REQ-100` に書き換わる
+6. Given `--dry-run` オプションを指定する, When rename を実行する, Then 変更箇所の一覧が表示されるが、ファイルは書き換わらない
+7. Given `--to` で指定した ID がプロジェクト内に既に存在する, When rename を実行する, Then エラーを報告し、書き換えは行わない
+8. Given `--from` で指定した ID がプロジェクト内に存在しない, When rename を実行する, Then エラーを報告する
+
+---
+
+### User Story 2 - 仕様 ID の分割 (Priority: P2)
+
+要件の粒度が大きすぎると判断した開発者が、1 つの仕様 ID を 2 つの新しい ID に分割したい。
+`spectrace rename --split REQ-001 --into REQ-001a REQ-001b` を実行すると、
+元の ID が仕様ファイルから削除され、新しい 2 つの ID の見出し雛形が追記される。
+`@impl REQ-001` を持つコードファイルには手動振り分けが必要な旨の警告が出力される。
+`.trace.lock` から元の ID が削除され、新しい ID のエントリが空で追加される。
+
+Why this priority: 仕様の粒度見直しは設計の成熟に伴い発生する。rename（US1）で確立した書き換えメカニズムを前提として、分割ロジックを追加する。merge（US3）より先に対応するのは、分割の方が発生頻度が高いため。
+
+Independent Test: fixture プロジェクトに REQ-001 を含む spec.md とコードファイル（`@impl REQ-001`）を配置し、split 実行後、spec.md に新 ID の雛形が追加されていること、コードファイルに対する警告が出力されること、lock が更新されていることを確認する。
+
+Acceptance Scenarios:
+
+1. Given spec.md に `- REQ-001: ユーザー認証` がある, When `spectrace rename --split REQ-001 --into REQ-001a REQ-001b` を実行する, Then spec.md から REQ-001 の行が削除され、REQ-001a と REQ-001b の見出し雛形が追記される
+2. Given コードファイルに `// @impl REQ-001` がある, When split を実行する, Then 「REQ-001 の impl が以下のファイルに存在します。手動で REQ-001a または REQ-001b に振り分けてください」という警告が出力される
+3. Given `.trace.lock` に `"REQ-001"` のエントリがある, When split を実行する, Then `"REQ-001"` が削除され、`"REQ-001a"` と `"REQ-001b"` の空エントリが追加される
+4. Given `--dry-run` オプションを指定する, When split を実行する, Then 変更予定の一覧が表示されるが、ファイルは変更されない
+5. Given `--into` で指定した ID のいずれかがプロジェクト内に既に存在する, When split を実行する, Then エラーを報告し、操作は行わない
+
+---
+
+### User Story 3 - 仕様 ID の統合 (Priority: P2)
+
+重複する 2 つの要件を 1 つに統合したい開発者が、
+`spectrace rename --merge REQ-001a REQ-001b --into REQ-001` を実行すると、
+プロジェクト全体の両 ID への参照が新しい ID に書き換わる。
+`.trace.lock` では元の 2 つのエントリの impl / tests を合算して新 ID に統合する。
+
+Why this priority: 統合は分割の逆操作であり、分割（US2）と同等の優先度。分割後の調整や要件の重複解消に使用される。
+
+Independent Test: fixture プロジェクトに REQ-001a, REQ-001b を含む spec.md, コードファイル, テストファイル, lock を配置し、merge 実行後、全参照が REQ-001 に統一され、lock の impl / tests が合算されていることを確認する。
+
+Acceptance Scenarios:
+
+1. Given spec.md に `- REQ-001a: ...` と `- REQ-001b: ...` がある, When `spectrace rename --merge REQ-001a REQ-001b --into REQ-001` を実行する, Then spec.md から REQ-001a と REQ-001b が削除され、REQ-001 の見出し雛形が追記される
+2. Given コードファイルに `// @impl REQ-001a` と別ファイルに `// @impl REQ-001b` がある, When merge を実行する, Then 両方とも `// @impl REQ-001` に書き換わる
+3. Given `.trace.lock` に REQ-001a (impl: [a.ts], tests: [a.test.ts]) と REQ-001b (impl: [b.ts], tests: [b.test.ts]) がある, When merge を実行する, Then REQ-001 のエントリが作成され、impl: [a.ts, b.ts], tests: [a.test.ts, b.test.ts] となる
+4. Given `--dry-run` オプションを指定する, When merge を実行する, Then 変更予定の一覧が表示されるが、ファイルは変更されない
+5. Given `--into` で指定した ID がプロジェクト内に既に存在する, When merge を実行する, Then エラーを報告し、操作は行わない
+
+---
+
+### Edge Cases
+
+- 名前空間修飾付き ID（`001-auth/FR-001`）に対する rename / split / merge → 修飾を含めた完全 ID として処理する
+- 同一ファイル内に `--from` の ID が複数箇所で参照されている場合 → 全箇所を書き換える
+- `--from` の ID がコード内の文字列リテラルやコメント（`@impl` 以外）に含まれる場合 → `@impl`、`[ID]`、frontmatter の `depends_on`、lock のキーのみを対象とし、無関係なテキストは書き換えない
+- untracked ファイル（git で追跡されていないファイル）に対象 ID が含まれる場合 → 書き換え対象外とする
+- split で `--into` に 3 つ以上の ID を指定した場合 → 2 つ以上の任意個数を許容する
+- merge で `--into` に指定した ID が merge 元の ID のいずれかと同じ場合 → 許容する（元の ID を残して他方を統合する操作として扱う）
+- `.trace.lock` が存在しない場合 → lock の更新はスキップし、ファイル書き換えのみ実行する
+- dry-run の出力フォーマット → `--format json|text` で制御可能とする
+
+## Requirements (mandatory)
+
+### Functional Requirements
+
+- FR-001: `spectrace rename --from <old-id> --to <new-id>` コマンドは、プロジェクト内の全参照箇所（spec 見出し・リスト項目、`@impl` タグ、テストタグ、frontmatter `depends_on`、`.trace.lock` キー）を一括で書き換える
+- FR-002: `spectrace rename --split <old-id> --into <new-id-1> <new-id-2> [...]` コマンドは、元の ID を仕様ファイルから削除し、新 ID の見出し雛形を追記し、`@impl` を持つコードファイルに対して手動振り分けの警告を出力する
+- FR-003: `spectrace rename --merge <id-1> <id-2> --into <new-id>` コマンドは、全参照を新 ID に書き換え、lock の impl / tests を合算して統合する
+- FR-004: 全サブコマンドは `--dry-run` オプションをサポートし、実際の書き換えを行わずに変更箇所の一覧を表示する
+- FR-005: 全サブコマンドは `--format json|text` オプションをサポートし、出力フォーマットを制御できる
+- FR-006: 書き換え対象は git で追跡中のファイルに限定し、untracked ファイルは無視する
+- FR-007: 書き換え対象の ID パターンは、仕様ファイルの見出し・リスト項目、コードの `@impl` タグ、テストの `[ID]` タグ、frontmatter の `depends_on`、`.trace.lock` のキーに限定する（無関係なテキスト内の偶発的な一致は書き換えない）
+- FR-008: `--to` / `--into` で指定した新 ID がプロジェクト内に既に存在する場合はエラーとする（merge で元 ID と同一の場合を除く）
+- FR-009: `--from` / `--split` で指定した元 ID がプロジェクト内に存在しない場合はエラーとする
+- FR-010: `doc:xxx` 形式のドキュメント ID にも rename / split / merge を適用可能とする
+
+### Key Entities
+
+- 仕様 ID: SDD ツールが付与する ID（REQ-001, FR-001, doc:auth 等）。rename / split / merge の操作対象
+- 参照箇所: 仕様 ID が出現するファイル内の特定パターン。spec の見出し・リスト項目、`@impl` タグ、テストタグ `[ID]`、frontmatter `depends_on`、`.trace.lock` キーの 5 種類
+- dry-run レポート: 書き換え前に表示される変更予定の一覧。ファイルパス、行番号、変更前後のテキストを含む
+- 見出し雛形: split / merge 時に仕様ファイルに追記される新 ID のプレースホルダー行
+
+## Success Criteria (mandatory)
+
+### Measurable Outcomes
+
+- SC-001: rename 実行後、プロジェクト内に旧 ID への参照が 0 件であること（`spectrace scan` + `grep` で検証）
+- SC-002: split 実行後、元 ID の参照が 0 件、新 ID の雛形が仕様ファイルに存在すること
+- SC-003: merge 実行後、元の 2 ID の参照が 0 件、新 ID に全参照が統合されていること
+- SC-004: dry-run モードでは、実行前後でファイルの内容が一切変更されないこと
+- SC-005: rename / split / merge 実行後に `spectrace check` を実行し、ID 不整合が発生しないこと（split 時の手動振り分け警告を除く）
+
+## Assumptions
+
+- 書き換え対象のファイルは全て git で追跡されている（spectrace のスキャン対象と一致する）
+- 仕様 ID のパターンは spectrace のパーサーが認識する形式（PREFIX-NNN, Requirement-N, doc:xxx）に限定される
+- 単一のコマンド実行で書き換えが完結する（トランザクション的な操作は不要。書き換え中に失敗した場合、ユーザーは `git checkout` で復元できる）
+- `.trace.lock` のフォーマットは JSON であり、spectrace の既存の lock 読み書き機構を再利用できる
+- split で生成される見出し雛形は最小限の内容（ID とプレースホルダーテキスト）であり、ユーザーが後から内容を記述する

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -496,7 +496,19 @@ program
   .addOption(new Option("--format <format>", "Output format").choices(["json", "text"]).default("text"))
   .action((opts) => {
     const rootDir = process.cwd();
-    const baseOpts = { dryRun: !!opts.dryRun, format: opts.format, rootDir };
+    const format: "json" | "text" = opts.format;
+    const baseOpts = { dryRun: !!opts.dryRun, format, rootDir };
+
+    const fail = (msg: string): never => {
+      // Honour --format json even on the error path so JSON consumers never
+      // have to parse a plain-text line (F7).
+      if (format === "json") {
+        console.error(JSON.stringify({ error: msg }));
+      } else {
+        console.error(`Error: ${msg}`);
+      }
+      process.exit(1);
+    };
 
     try {
       let result: RenameResult;
@@ -510,24 +522,22 @@ program
       } else if (opts.merge && opts.into) {
         // merge mode
         if (opts.into.length !== 1) {
-          console.error("Error: --merge requires exactly one --into target ID.");
-          process.exit(1);
+          fail("--merge requires exactly one --into target ID.");
         }
         result = executeMerge({ ...baseOpts, mergeIds: opts.merge, intoId: opts.into[0] });
       } else {
-        console.error("Error: Specify --from/--to, --split/--into, or --merge/--into.");
-        process.exit(1);
+        fail("Specify --from/--to, --split/--into, or --merge/--into.");
+        return;
       }
 
-      if (opts.format === "json") {
+      if (format === "json") {
         printRenameJson(result);
       } else {
         printRenameText(result);
       }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      console.error(`Error: ${msg}`);
-      process.exit(1);
+      fail(msg);
     }
   });
 
@@ -538,17 +548,11 @@ function printRenameText(result: RenameResult) {
   }
 
   if (result.operation === "rename") {
-    const from = result.changes[0]?.before?.trim() ?? "";
-    const to = result.changes[0]?.after?.trim() ?? "";
-    console.log(`Renamed ${from} → ${to}`);
+    console.log(`Renamed ${result.from} → ${result.to}`);
   } else if (result.operation === "split") {
-    const oldId = result.changes[0]?.before?.trim() ?? "";
-    const newIds = [...new Set(result.changes.map((c) => c.after.trim()))];
-    console.log(`Split ${oldId} → ${newIds.join(", ")}`);
+    console.log(`Split ${result.from} → ${(result.intoIds ?? []).join(", ")}`);
   } else if (result.operation === "merge") {
-    const oldIds = [...new Set(result.changes.map((c) => c.before.trim()))];
-    const newId = result.changes[0]?.after?.trim() ?? "";
-    console.log(`Merged ${oldIds.join(", ")} → ${newId}`);
+    console.log(`Merged ${(result.sourceIds ?? []).join(", ")} → ${result.to}`);
   }
 
   for (const c of result.changes) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,8 @@ import {
 } from "./hook-pretool.js";
 import type { SpectraceConfig } from "./types.js";
 import { runInit } from "./init.js";
+import { executeRename, executeSplit, executeMerge } from "./rename-executor.js";
+import type { RenameResult } from "./rename-executor.js";
 
 const program = new Command();
 
@@ -480,6 +482,94 @@ function printCheckText(result: any) {
   if (result.pass) {
     console.log("All checks passed.");
   }
+}
+
+program
+  .command("rename")
+  .description("Rename, split, or merge spec IDs across the project")
+  .option("--from <id>", "Source ID to rename")
+  .option("--to <id>", "Target ID for rename")
+  .option("--split <id>", "Source ID to split")
+  .option("--merge <ids...>", "Source IDs to merge")
+  .option("--into <ids...>", "Target ID(s) for split or merge")
+  .option("--dry-run", "Show changes without applying them")
+  .addOption(new Option("--format <format>", "Output format").choices(["json", "text"]).default("text"))
+  .action((opts) => {
+    const rootDir = process.cwd();
+    const baseOpts = { dryRun: !!opts.dryRun, format: opts.format, rootDir };
+
+    try {
+      let result: RenameResult;
+
+      if (opts.from && opts.to) {
+        // rename mode
+        result = executeRename({ ...baseOpts, from: opts.from, to: opts.to });
+      } else if (opts.split && opts.into) {
+        // split mode
+        result = executeSplit({ ...baseOpts, splitId: opts.split, intoIds: opts.into });
+      } else if (opts.merge && opts.into) {
+        // merge mode
+        if (opts.into.length !== 1) {
+          console.error("Error: --merge requires exactly one --into target ID.");
+          process.exit(1);
+        }
+        result = executeMerge({ ...baseOpts, mergeIds: opts.merge, intoId: opts.into[0] });
+      } else {
+        console.error("Error: Specify --from/--to, --split/--into, or --merge/--into.");
+        process.exit(1);
+      }
+
+      if (opts.format === "json") {
+        printRenameJson(result);
+      } else {
+        printRenameText(result);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`Error: ${msg}`);
+      process.exit(1);
+    }
+  });
+
+function printRenameText(result: RenameResult) {
+  if (result.changes.length === 0 && result.lockChanges.length === 0) {
+    console.log("No references found.");
+    return;
+  }
+
+  if (result.operation === "rename") {
+    const from = result.changes[0]?.before?.trim() ?? "";
+    const to = result.changes[0]?.after?.trim() ?? "";
+    console.log(`Renamed ${from} → ${to}`);
+  } else if (result.operation === "split") {
+    const oldId = result.changes[0]?.before?.trim() ?? "";
+    const newIds = [...new Set(result.changes.map((c) => c.after.trim()))];
+    console.log(`Split ${oldId} → ${newIds.join(", ")}`);
+  } else if (result.operation === "merge") {
+    const oldIds = [...new Set(result.changes.map((c) => c.before.trim()))];
+    const newId = result.changes[0]?.after?.trim() ?? "";
+    console.log(`Merged ${oldIds.join(", ")} → ${newId}`);
+  }
+
+  for (const c of result.changes) {
+    const before = c.before.trim().slice(0, 60);
+    const after = c.after.trim().slice(0, 60);
+    console.log(`  ${c.filePath}:${c.line}  ${before} → ${after}`);
+  }
+
+  for (const w of result.warnings) {
+    console.log(
+      `WARNING: ${w.filePath} contains @impl ${w.oldId} — manual assignment to ${w.newIds.join(", ")} needed`,
+    );
+  }
+
+  if (!result.applied) {
+    console.log("(dry-run: no files were modified)");
+  }
+}
+
+function printRenameJson(result: RenameResult) {
+  console.log(JSON.stringify(result));
 }
 
 program.parse();

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -7,13 +7,30 @@ export function parseDiffFiles(output: string): string[] {
     .filter((l) => l.length > 0);
 }
 
+/**
+ * Split a NUL-delimited git output (`-z`) into path entries. NUL-separated
+ * output is never quoted/escaped by git, so paths with non-ASCII characters,
+ * spaces or quotes survive verbatim.
+ */
+export function parseNulSeparated(output: string): string[] {
+  return output.split("\0").filter((l) => l.length > 0);
+}
+
 export function getGitTrackedFiles(rootDir: string): string[] {
   try {
-    const output = execFileSync("git", ["ls-files"], {
-      cwd: rootDir,
-      encoding: "utf-8",
-    });
-    return parseDiffFiles(output);
+    // `-z` emits NUL-separated, unquoted paths and `core.quotePath=false`
+    // is a belt-and-braces guard so non-ASCII paths (e.g. specs/日本語.md)
+    // are never octal-escaped — otherwise `existsSync` on the escaped name
+    // fails and the file is silently skipped.
+    const output = execFileSync(
+      "git",
+      ["-c", "core.quotePath=false", "ls-files", "-z"],
+      {
+        cwd: rootDir,
+        encoding: "utf-8",
+      },
+    );
+    return parseNulSeparated(output);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     throw new Error(`Failed to run git ls-files: ${msg}`);

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -7,6 +7,19 @@ export function parseDiffFiles(output: string): string[] {
     .filter((l) => l.length > 0);
 }
 
+export function getGitTrackedFiles(rootDir: string): string[] {
+  try {
+    const output = execFileSync("git", ["ls-files"], {
+      cwd: rootDir,
+      encoding: "utf-8",
+    });
+    return parseDiffFiles(output);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Failed to run git ls-files: ${msg}`);
+  }
+}
+
 export function getGitDiffFiles(rootDir: string): string[] {
   try {
     const staged = execFileSync("git", ["diff", "--cached", "--name-only"], {

--- a/src/id.ts
+++ b/src/id.ts
@@ -1,0 +1,34 @@
+import { DEFAULT_ID_TOKEN } from "./parsers/typescript.js";
+import type { ReqPatternConfig } from "./types.js";
+
+/**
+ * Validate that a target ID is one the parser could re-discover after the
+ * rename/split/merge writes its references back to disk. Without this guard the
+ * tool happily emits IDs like `REQ-COMBINED` or `REQ-001a` that no parser
+ * regex matches, so the requirement silently vanishes from the next scan.
+ *
+ * Accepted forms:
+ *   - `doc:<path>`           — document node IDs
+ *   - the canonical req-ID token (or a project's custom `reqPatterns.codeId`)
+ *     e.g. `REQ-001`, `auth/FR-2`, `Requirement-3`
+ */
+export function isValidTargetId(id: string, codeId?: string): boolean {
+  if (id.startsWith("doc:")) {
+    return id.length > "doc:".length;
+  }
+  const token = codeId ?? DEFAULT_ID_TOKEN;
+  return new RegExp(`^(?:${token})$`).test(id);
+}
+
+/**
+ * Throw a descriptive error if `id` is not a valid target ID.
+ */
+export function assertValidTargetId(id: string, reqPatterns?: ReqPatternConfig): void {
+  if (!isValidTargetId(id, reqPatterns?.codeId)) {
+    throw new Error(
+      `Invalid target ID "${id}": it does not match the requirement-ID format ` +
+        `(e.g. "REQ-001", "auth/FR-2") or the "doc:" prefix. ` +
+        `A non-conforming ID would not be re-discovered by the next scan.`,
+    );
+  }
+}

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -6,7 +6,9 @@ import type { GraphNode, GraphEdge } from "../types.js";
 
 // Default requirement-ID *token* used when no custom `reqPatterns.codeId` is set.
 // The token matches the whole ID (e.g. `FR-001`, `auth/AUTH-2`, `Requirement-3`).
-const DEFAULT_ID_TOKEN = "(?:[\\w-]+/)?(?:[A-Z][A-Za-z]*-\\d+|Requirement-\\d+)";
+// Exported so the rename rewriter and ID validator track the exact same grammar
+// the parser emits (avoids regex drift between discovery and rewriting).
+export const DEFAULT_ID_TOKEN = "(?:[\\w-]+/)?(?:[A-Z][A-Za-z]*-\\d+|Requirement-\\d+)";
 
 // Regexes that locate requirement IDs in code/test tags. When the project sets a
 // custom `reqPatterns.codeId`, these are rebuilt from that token so that @impl /

--- a/src/rename-executor.ts
+++ b/src/rename-executor.ts
@@ -1,13 +1,26 @@
 import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { rewriteFile, rewriteFrontmatter } from "./rename.js";
-import type { RewriteChange } from "./rename.js";
+import {
+  rewriteFile,
+  rewriteImplTags,
+  rewriteTestTags,
+  rewriteFrontmatter,
+  expandFrontmatterDependsOn,
+  specDefinitionId,
+  fencedLines,
+  extOf,
+  escapeRegExp,
+  type RewriteChange,
+  type RewriteOptions,
+} from "./rename.js";
 import { renameLockKey, splitLockKey, mergeLockKeys } from "./rename-lock.js";
 import type { LockChange } from "./rename-lock.js";
-import { readLock, writeLock } from "./lock.js";
-import { scan } from "./scan.js";
+import { readLock } from "./lock.js";
+import { scan, reconcile } from "./scan.js";
 import { loadConfig } from "./config.js";
 import { getGitTrackedFiles } from "./diff.js";
+import { assertValidTargetId } from "./id.js";
+import type { SpectraceConfig, LockFile } from "./types.js";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -26,27 +39,88 @@ export interface RenameWarning {
 
 export interface RenameResult {
   operation: "rename" | "split" | "merge";
+  // Structured identifiers so consumers/printers never have to reconstruct
+  // them from change text (L1).
+  from?: string;
+  to?: string;
+  sourceIds?: string[];
+  intoIds?: string[];
   changes: RewriteChange[];
   lockChanges: LockChange[];
   warnings: RenameWarning[];
   applied: boolean;
 }
 
+// Scaffold placeholder appended for newly created requirements. Kept in English
+// to match the rest of the CLI output (M6).
+const SCAFFOLD_PLACEHOLDER = "(TODO: describe this requirement)";
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 const RELEVANT_EXTENSIONS = new Set([".md", ".ts", ".tsx", ".js", ".jsx"]);
-
-function extOf(filePath: string): string {
-  const dot = filePath.lastIndexOf(".");
-  return dot === -1 ? "" : filePath.slice(dot).toLowerCase();
-}
 
 function filterRelevantFiles(files: string[]): string[] {
   return files.filter((f) => RELEVANT_EXTENSIONS.has(extOf(f)));
 }
 
-function escapeRegExp(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+function relevantTrackedFiles(rootDir: string): string[] {
+  return filterRelevantFiles(getGitTrackedFiles(rootDir));
+}
+
+/**
+ * Reject IDs that can never be a rename/split/merge *source*: `file:`/`symbol:`
+ * nodes are derived from paths, not authored references, so the rewriter cannot
+ * relocate them (F8).
+ */
+function assertRenameableSource(id: string): void {
+  if (id.startsWith("file:") || id.startsWith("symbol:")) {
+    throw new Error(
+      `ID "${id}" refers to a ${id.startsWith("file:") ? "file" : "symbol"} node, ` +
+        `which is derived from the filesystem and cannot be renamed.`,
+    );
+  }
+}
+
+/**
+ * After files are written, rebuild the lock from a fresh scan so contentHashes,
+ * cross-references and specFile entries reflect the new on-disk state. Without
+ * this, `spectrace check` immediately reports drift for every rewritten node
+ * (F1). Only runs when a lock file already existed.
+ */
+function reconcileAfterWrite(rootDir: string, config: SpectraceConfig): void {
+  const lockFilePath = resolve(rootDir, config.lockFile);
+  if (!existsSync(lockFilePath)) return;
+  const { graph } = scan(rootDir, config);
+  reconcile(rootDir, config, graph);
+}
+
+interface ScanContext {
+  config: SpectraceConfig;
+  existingIds: Set<string>;
+  rewriteOpts: RewriteOptions;
+}
+
+function loadScanContext(rootDir: string): ScanContext {
+  const config = loadConfig(rootDir);
+  const { graph } = scan(rootDir, config);
+  return {
+    config,
+    existingIds: new Set(graph.nodes.keys()),
+    rewriteOpts: { reqPatterns: config.reqPatterns },
+  };
+}
+
+function applyWrites(
+  rootDir: string,
+  config: SpectraceConfig,
+  filesToWrite: Map<string, string>,
+  dryRun: boolean,
+): void {
+  if (dryRun) return;
+  for (const [absPath, content] of filesToWrite) {
+    writeFileSync(absPath, content, "utf-8");
+  }
+  reconcileAfterWrite(rootDir, config);
 }
 
 // ── executeRename ───────────────────────────────────────────────────
@@ -55,13 +129,14 @@ export function executeRename(
   options: RenameOptions & { from: string; to: string },
 ): RenameResult {
   const { rootDir, dryRun, from, to } = options;
+  const { config, existingIds, rewriteOpts } = loadScanContext(rootDir);
 
-  // 1. Load config, scan, extract existing IDs
-  const config = loadConfig(rootDir);
-  const { graph } = scan(rootDir, config);
-  const existingIds = new Set(graph.nodes.keys());
-
-  // 2. Validate
+  // Validate
+  if (from === to) {
+    throw new Error(`Source and target IDs are identical ("${from}"); nothing to rename.`);
+  }
+  assertRenameableSource(from);
+  assertValidTargetId(to, config.reqPatterns);
   if (!existingIds.has(from)) {
     throw new Error(`ID "${from}" does not exist in the project.`);
   }
@@ -69,52 +144,31 @@ export function executeRename(
     throw new Error(`ID "${to}" already exists in the project.`);
   }
 
-  // 3. Get git tracked files, filter to relevant extensions
-  const allFiles = getGitTrackedFiles(rootDir);
-  const files = filterRelevantFiles(allFiles);
-
-  // 4. Rewrite each file
+  // Rewrite each file
   const allChanges: RewriteChange[] = [];
   const filesToWrite = new Map<string, string>();
 
-  for (const relPath of files) {
+  for (const relPath of relevantTrackedFiles(rootDir)) {
     const absPath = resolve(rootDir, relPath);
     if (!existsSync(absPath)) continue;
 
     const content = readFileSync(absPath, "utf-8");
-    const result = rewriteFile(relPath, content, from, to);
-
+    const result = rewriteFile(relPath, content, from, to, rewriteOpts);
     if (result.changes.length > 0) {
       allChanges.push(...result.changes);
       filesToWrite.set(absPath, result.content);
     }
   }
 
-  // 5. Update lock file
-  const lockChanges: LockChange[] = [];
-  const lockFilePath = resolve(rootDir, config.lockFile);
-  let updatedLock;
+  // Project lock changes (also the source of truth for dry-run reporting).
+  const lockChanges = projectLockChanges(rootDir, config, (lock) => renameLockKey(lock, from, to));
 
-  if (existsSync(lockFilePath)) {
-    const lock = readLock(rootDir, config.lockFile);
-    const lockResult = renameLockKey(lock, from, to);
-    updatedLock = lockResult.lock;
-    lockChanges.push(...lockResult.changes);
-  }
+  applyWrites(rootDir, config, filesToWrite, dryRun);
 
-  // 6. Apply changes if not dry run
-  if (!dryRun) {
-    for (const [absPath, content] of filesToWrite) {
-      writeFileSync(absPath, content, "utf-8");
-    }
-    if (updatedLock) {
-      writeLock(rootDir, config.lockFile, updatedLock);
-    }
-  }
-
-  // 7. Return result
   return {
     operation: "rename",
+    from,
+    to,
     changes: allChanges,
     lockChanges,
     warnings: [],
@@ -128,42 +182,35 @@ export function executeSplit(
   options: RenameOptions & { splitId: string; intoIds: string[] },
 ): RenameResult {
   const { rootDir, dryRun, splitId, intoIds } = options;
+  const { config, existingIds, rewriteOpts } = loadScanContext(rootDir);
 
-  // 1. Load config, scan, validate
-  const config = loadConfig(rootDir);
-  const { graph } = scan(rootDir, config);
-  const existingIds = new Set(graph.nodes.keys());
-
+  // Validate
+  assertRenameableSource(splitId);
   if (!existingIds.has(splitId)) {
     throw new Error(`ID "${splitId}" does not exist in the project.`);
   }
+  if (intoIds.length === 0) {
+    throw new Error(`--split requires at least one target ID via --into.`);
+  }
+  const seen = new Set<string>();
   for (const newId of intoIds) {
-    if (existingIds.has(newId)) {
+    assertValidTargetId(newId, config.reqPatterns);
+    if (seen.has(newId)) {
+      throw new Error(`Duplicate target ID "${newId}" in --into.`);
+    }
+    seen.add(newId);
+    if (newId !== splitId && existingIds.has(newId)) {
       throw new Error(`ID "${newId}" already exists in the project.`);
     }
   }
 
-  // 2. Get git tracked files, filter
-  const allFiles = getGitTrackedFiles(rootDir);
-  const files = filterRelevantFiles(allFiles);
-
-  // 3. Process files
   const allChanges: RewriteChange[] = [];
   const warnings: RenameWarning[] = [];
   const filesToWrite = new Map<string, string>();
 
-  const splitIdEscaped = escapeRegExp(splitId);
-  // Pattern for spec list items: `- ID: description` or `- **ID**: description`
-  const specListItemRe = new RegExp(
-    `^(\\s*[-*]\\s+)(\\*\\*)?${splitIdEscaped}(\\*\\*)?(?=[:\\s])`,
-  );
-  // Pattern for @impl tags referencing the splitId
   const implRe = /\/\/[^\S\n]*@impl[^\S\n]+/;
-  const idBoundaryRe = new RegExp(
-    `(?<![A-Za-z0-9_/:-])${splitIdEscaped}(?![A-Za-z0-9_/:-])`,
-  );
 
-  for (const relPath of files) {
+  for (const relPath of relevantTrackedFiles(rootDir)) {
     const absPath = resolve(rootDir, relPath);
     if (!existsSync(absPath)) continue;
 
@@ -171,101 +218,48 @@ export function executeSplit(
     const ext = extOf(relPath);
 
     if (ext === ".md") {
-      // For spec files: remove lines matching splitId, append scaffolds for new IDs,
-      // and update depends_on references
-      const lines = content.split("\n");
-      let changed = false;
-
-      // Remove list items that match the splitId
-      const filteredLines: string[] = [];
-      for (let i = 0; i < lines.length; i++) {
-        if (specListItemRe.test(lines[i])) {
-          allChanges.push({
-            filePath: relPath,
-            line: i + 1,
-            kind: "spec-list-item",
-            before: lines[i],
-            after: "(removed)",
-          });
-          changed = true;
-        } else {
-          filteredLines.push(lines[i]);
-        }
-      }
-
-      // Append scaffold lines for each new ID
-      for (const newId of intoIds) {
-        const scaffoldLine = `- ${newId}: (TODO: 説明を記述)`;
-        filteredLines.push(scaffoldLine);
-        allChanges.push({
-          filePath: relPath,
-          line: filteredLines.length,
-          kind: "spec-list-item",
-          before: "",
-          after: scaffoldLine,
-        });
-        changed = true;
-      }
-
-      // Update depends_on references: expand old ID to all new IDs
-      let updatedContent = filteredLines.join("\n");
-      for (const newId of intoIds) {
-        const fmResult = rewriteFrontmatter(updatedContent, splitId, newId);
-        if (fmResult.changes.length > 0) {
-          updatedContent = fmResult.content;
-          for (const change of fmResult.changes) {
-            change.filePath = relPath;
-          }
-          allChanges.push(...fmResult.changes);
-          changed = true;
-        }
-      }
-
-      if (changed) {
-        filesToWrite.set(absPath, updatedContent);
+      const { content: next, changes } = splitMarkdown(
+        relPath,
+        content,
+        splitId,
+        intoIds,
+        rewriteOpts,
+      );
+      if (changes.length > 0) {
+        allChanges.push(...changes);
+        filesToWrite.set(absPath, next);
       }
     } else {
-      // For code files: DO NOT rewrite @impl tags, only add warnings
+      // Code files: @impl assignment is ambiguous on split, so warn instead of
+      // rewriting (unchanged behaviour).
       const lines = content.split("\n");
+      const fenced = fencedLines(content);
       for (let i = 0; i < lines.length; i++) {
-        if (implRe.test(lines[i]) && idBoundaryRe.test(lines[i])) {
+        if (fenced.has(i)) continue;
+        if (implRe.test(lines[i]) && referencesId(lines[i], splitId)) {
           warnings.push({
             type: "manual-assignment-needed",
             filePath: relPath,
             oldId: splitId,
             newIds: intoIds,
           });
-          break; // One warning per file is sufficient
+          break;
         }
       }
     }
   }
 
-  // 4. Update lock file
-  const lockChanges: LockChange[] = [];
-  const lockFilePath = resolve(rootDir, config.lockFile);
-  let updatedLock;
+  const lockChanges = projectLockChanges(rootDir, config, (lock) =>
+    splitLockKey(lock, splitId, intoIds),
+  );
 
-  if (existsSync(lockFilePath)) {
-    const lock = readLock(rootDir, config.lockFile);
-    const lockResult = splitLockKey(lock, splitId, intoIds);
-    updatedLock = lockResult.lock;
-    lockChanges.push(...lockResult.changes);
-  }
+  applyWrites(rootDir, config, filesToWrite, dryRun);
 
-  // 5. Apply changes if not dry run
-  if (!dryRun) {
-    for (const [absPath, content] of filesToWrite) {
-      writeFileSync(absPath, content, "utf-8");
-    }
-    if (updatedLock) {
-      writeLock(rootDir, config.lockFile, updatedLock);
-    }
-  }
-
-  // 6. Return result
   return {
     operation: "split",
+    from: splitId,
+    sourceIds: [splitId],
+    intoIds,
     changes: allChanges,
     lockChanges,
     warnings,
@@ -279,139 +273,243 @@ export function executeMerge(
   options: RenameOptions & { mergeIds: string[]; intoId: string },
 ): RenameResult {
   const { rootDir, dryRun, mergeIds, intoId } = options;
+  const { config, existingIds, rewriteOpts } = loadScanContext(rootDir);
 
-  // 1. Load config, scan, validate
-  const config = loadConfig(rootDir);
-  const { graph } = scan(rootDir, config);
-  const existingIds = new Set(graph.nodes.keys());
-
+  // Validate
+  if (mergeIds.length < 1) {
+    throw new Error(`--merge requires at least one source ID.`);
+  }
+  assertValidTargetId(intoId, config.reqPatterns);
   for (const id of mergeIds) {
+    assertRenameableSource(id);
     if (!existingIds.has(id)) {
       throw new Error(`ID "${id}" does not exist in the project.`);
     }
   }
-  // intoId must NOT exist UNLESS it equals one of mergeIds
+  // intoId must NOT exist UNLESS it equals one of mergeIds.
   if (existingIds.has(intoId) && !mergeIds.includes(intoId)) {
     throw new Error(
       `ID "${intoId}" already exists in the project and is not one of the merge source IDs.`,
     );
   }
 
-  // 2. Get git tracked files, filter
-  const allFiles = getGitTrackedFiles(rootDir);
-  const files = filterRelevantFiles(allFiles);
+  // IDs whose references/definitions collapse into intoId.
+  const idsToRewrite = mergeIds.filter((id) => id !== intoId);
+  const intoIsExisting = mergeIds.includes(intoId);
 
-  // 3. Process files
   const allChanges: RewriteChange[] = [];
   const filesToWrite = new Map<string, string>();
 
-  // IDs to rewrite: all mergeIds that are NOT the intoId
-  const idsToRewrite = mergeIds.filter((id) => id !== intoId);
-
-  for (const relPath of files) {
+  for (const relPath of relevantTrackedFiles(rootDir)) {
     const absPath = resolve(rootDir, relPath);
     if (!existsSync(absPath)) continue;
 
-    let content = readFileSync(absPath, "utf-8");
-    let changed = false;
+    const content = readFileSync(absPath, "utf-8");
     const ext = extOf(relPath);
 
-    // Rewrite references from each old ID to intoId
-    for (const oldId of idsToRewrite) {
-      const result = rewriteFile(relPath, content, oldId, intoId);
-      if (result.changes.length > 0) {
-        content = result.content;
-        allChanges.push(...result.changes);
-        changed = true;
-      }
-    }
-
-    // For spec files: remove old ID lines for merged IDs and append scaffold for intoId
     if (ext === ".md") {
-      const lines = content.split("\n");
-      const filteredLines: string[] = [];
-      let removedAny = false;
-
-      for (let i = 0; i < lines.length; i++) {
-        let shouldRemove = false;
-        for (const oldId of idsToRewrite) {
-          const escaped = escapeRegExp(oldId);
-          const re = new RegExp(
-            `^(\\s*[-*]\\s+)(\\*\\*)?${escaped}(\\*\\*)?(?=[:\\s])`,
-          );
-          if (re.test(lines[i])) {
-            shouldRemove = true;
-            allChanges.push({
-              filePath: relPath,
-              line: i + 1,
-              kind: "spec-list-item",
-              before: lines[i],
-              after: "(removed)",
-            });
-            break;
-          }
-        }
-        if (shouldRemove) {
-          removedAny = true;
-        } else {
-          filteredLines.push(lines[i]);
+      const { content: next, changes } = mergeMarkdown(
+        relPath,
+        content,
+        idsToRewrite,
+        intoId,
+        intoIsExisting,
+        rewriteOpts,
+      );
+      if (changes.length > 0) {
+        allChanges.push(...changes);
+        filesToWrite.set(absPath, next);
+      }
+    } else {
+      // Code/test files: collapse @impl and test references onto intoId.
+      let next = content;
+      const fileChanges: RewriteChange[] = [];
+      for (const oldId of idsToRewrite) {
+        const implRes = rewriteImplTags(next, oldId, intoId);
+        next = implRes.content;
+        const testRes = rewriteTestTags(next, oldId, intoId);
+        next = testRes.content;
+        for (const c of [...implRes.changes, ...testRes.changes]) {
+          c.filePath = relPath;
+          fileChanges.push(c);
         }
       }
-
-      // Append scaffold for intoId unless it is one of the mergeIds
-      // (in that case the line already exists)
-      if (!mergeIds.includes(intoId)) {
-        const scaffoldLine = `- ${intoId}: (TODO: 説明を記述)`;
-        filteredLines.push(scaffoldLine);
-        allChanges.push({
-          filePath: relPath,
-          line: filteredLines.length,
-          kind: "spec-list-item",
-          before: "",
-          after: scaffoldLine,
-        });
-        removedAny = true; // to trigger write
-      }
-
-      if (removedAny) {
-        content = filteredLines.join("\n");
-        changed = true;
+      if (fileChanges.length > 0) {
+        allChanges.push(...fileChanges);
+        filesToWrite.set(absPath, next);
       }
     }
-
-    if (changed) {
-      filesToWrite.set(absPath, content);
-    }
   }
 
-  // 4. Update lock file
-  const lockChanges: LockChange[] = [];
-  const lockFilePath = resolve(rootDir, config.lockFile);
-  let updatedLock;
+  const lockChanges = projectLockChanges(rootDir, config, (lock) =>
+    mergeLockKeys(lock, mergeIds, intoId),
+  );
 
-  if (existsSync(lockFilePath)) {
-    const lock = readLock(rootDir, config.lockFile);
-    const lockResult = mergeLockKeys(lock, mergeIds, intoId);
-    updatedLock = lockResult.lock;
-    lockChanges.push(...lockResult.changes);
-  }
+  applyWrites(rootDir, config, filesToWrite, dryRun);
 
-  // 5. Apply changes if not dry run
-  if (!dryRun) {
-    for (const [absPath, content] of filesToWrite) {
-      writeFileSync(absPath, content, "utf-8");
-    }
-    if (updatedLock) {
-      writeLock(rootDir, config.lockFile, updatedLock);
-    }
-  }
-
-  // 6. Return result
   return {
     operation: "merge",
+    to: intoId,
+    sourceIds: mergeIds,
+    intoIds: [intoId],
     changes: allChanges,
     lockChanges,
     warnings: [],
     applied: !dryRun,
   };
+}
+
+// ── Markdown split/merge primitives ──────────────────────────────────
+
+/**
+ * Whether `line` references `id` as a standalone token (not as a definition).
+ */
+function referencesId(line: string, id: string): boolean {
+  return new RegExp(`(?<![A-Za-z0-9_/:-])${escapeRegExp(id)}(?![A-Za-z0-9_/:-])`).test(line);
+}
+
+/**
+ * Split a markdown spec: remove the definition line(s) for `splitId`, append a
+ * scaffold list item per new ID, and expand any frontmatter dependency on the
+ * split ID to all new IDs (F5). Fenced code blocks are never touched (F6).
+ */
+function splitMarkdown(
+  relPath: string,
+  content: string,
+  splitId: string,
+  intoIds: string[],
+  opts: RewriteOptions,
+): { content: string; changes: RewriteChange[] } {
+  const lines = content.split("\n");
+  const fenced = fencedLines(content);
+  const changes: RewriteChange[] = [];
+
+  const kept: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!fenced.has(i) && specDefinitionId(lines[i], opts) === splitId) {
+      changes.push({
+        filePath: relPath,
+        line: i + 1,
+        kind: "spec-list-item",
+        before: lines[i],
+        after: "(removed)",
+      });
+      continue;
+    }
+    kept.push(lines[i]);
+  }
+
+  for (const newId of intoIds) {
+    const scaffold = `- ${newId}: ${SCAFFOLD_PLACEHOLDER}`;
+    kept.push(scaffold);
+    changes.push({
+      filePath: relPath,
+      line: kept.length,
+      kind: "spec-list-item",
+      before: "",
+      after: scaffold,
+    });
+  }
+
+  // Expand frontmatter dependency references.
+  let next = kept.join("\n");
+  const fm = expandFrontmatterDependsOn(next, splitId, intoIds);
+  if (fm.changes.length > 0) {
+    next = fm.content;
+    for (const c of fm.changes) {
+      c.filePath = relPath;
+      changes.push(c);
+    }
+  }
+
+  return { content: next, changes };
+}
+
+/**
+ * Merge markdown specs: remove the definition lines for the merged-away IDs,
+ * collapse frontmatter dependency references onto intoId, and append a single
+ * scaffold for intoId only when it is a brand-new requirement. Crucially the
+ * definition lines are removed *instead of* being rewritten, so intoId is never
+ * duplicated (C1).
+ */
+function mergeMarkdown(
+  relPath: string,
+  content: string,
+  idsToRewrite: string[],
+  intoId: string,
+  intoIsExisting: boolean,
+  opts: RewriteOptions,
+): { content: string; changes: RewriteChange[] } {
+  const lines = content.split("\n");
+  const fenced = fencedLines(content);
+  const changes: RewriteChange[] = [];
+  const removeSet = new Set(idsToRewrite);
+
+  const kept: string[] = [];
+  let removedAnyDefinition = false;
+  for (let i = 0; i < lines.length; i++) {
+    const defId = fenced.has(i) ? null : specDefinitionId(lines[i], opts);
+    if (defId != null && removeSet.has(defId)) {
+      changes.push({
+        filePath: relPath,
+        line: i + 1,
+        kind: "spec-list-item",
+        before: lines[i],
+        after: "(removed)",
+      });
+      removedAnyDefinition = true;
+      continue;
+    }
+    kept.push(lines[i]);
+  }
+
+  let next = kept.join("\n");
+
+  // Collapse frontmatter dependency references onto intoId.
+  for (const oldId of idsToRewrite) {
+    const fm = rewriteFrontmatter(next, oldId, intoId);
+    if (fm.changes.length > 0) {
+      next = fm.content;
+      for (const c of fm.changes) {
+        c.filePath = relPath;
+        changes.push(c);
+      }
+    }
+  }
+
+  // Append a scaffold for a brand-new intoId, but only in a file that actually
+  // hosted one of the merged definitions.
+  if (!intoIsExisting && removedAnyDefinition) {
+    const scaffold = `- ${intoId}: ${SCAFFOLD_PLACEHOLDER}`;
+    const outLines = next.split("\n");
+    outLines.push(scaffold);
+    changes.push({
+      filePath: relPath,
+      line: outLines.length,
+      kind: "spec-list-item",
+      before: "",
+      after: scaffold,
+    });
+    next = outLines.join("\n");
+  }
+
+  return { content: next, changes };
+}
+
+// ── Lock projection ──────────────────────────────────────────────────
+
+/**
+ * Compute the projected lock-key changes for reporting / dry-run. The actual
+ * on-disk lock is rebuilt by reconcileAfterWrite, so this only needs the change
+ * log, not the resulting lock.
+ */
+function projectLockChanges(
+  rootDir: string,
+  config: SpectraceConfig,
+  op: (lock: LockFile) => { changes: LockChange[] },
+): LockChange[] {
+  const lockFilePath = resolve(rootDir, config.lockFile);
+  if (!existsSync(lockFilePath)) return [];
+  const lock = readLock(rootDir, config.lockFile);
+  return op(lock).changes;
 }

--- a/src/rename-executor.ts
+++ b/src/rename-executor.ts
@@ -1,0 +1,417 @@
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { rewriteFile, rewriteFrontmatter } from "./rename.js";
+import type { RewriteChange } from "./rename.js";
+import { renameLockKey, splitLockKey, mergeLockKeys } from "./rename-lock.js";
+import type { LockChange } from "./rename-lock.js";
+import { readLock, writeLock } from "./lock.js";
+import { scan } from "./scan.js";
+import { loadConfig } from "./config.js";
+import { getGitTrackedFiles } from "./diff.js";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface RenameOptions {
+  dryRun: boolean;
+  format: "json" | "text";
+  rootDir: string;
+}
+
+export interface RenameWarning {
+  type: "manual-assignment-needed";
+  filePath: string;
+  oldId: string;
+  newIds: string[];
+}
+
+export interface RenameResult {
+  operation: "rename" | "split" | "merge";
+  changes: RewriteChange[];
+  lockChanges: LockChange[];
+  warnings: RenameWarning[];
+  applied: boolean;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const RELEVANT_EXTENSIONS = new Set([".md", ".ts", ".tsx", ".js", ".jsx"]);
+
+function extOf(filePath: string): string {
+  const dot = filePath.lastIndexOf(".");
+  return dot === -1 ? "" : filePath.slice(dot).toLowerCase();
+}
+
+function filterRelevantFiles(files: string[]): string[] {
+  return files.filter((f) => RELEVANT_EXTENSIONS.has(extOf(f)));
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// ── executeRename ───────────────────────────────────────────────────
+
+export function executeRename(
+  options: RenameOptions & { from: string; to: string },
+): RenameResult {
+  const { rootDir, dryRun, from, to } = options;
+
+  // 1. Load config, scan, extract existing IDs
+  const config = loadConfig(rootDir);
+  const { graph } = scan(rootDir, config);
+  const existingIds = new Set(graph.nodes.keys());
+
+  // 2. Validate
+  if (!existingIds.has(from)) {
+    throw new Error(`ID "${from}" does not exist in the project.`);
+  }
+  if (existingIds.has(to)) {
+    throw new Error(`ID "${to}" already exists in the project.`);
+  }
+
+  // 3. Get git tracked files, filter to relevant extensions
+  const allFiles = getGitTrackedFiles(rootDir);
+  const files = filterRelevantFiles(allFiles);
+
+  // 4. Rewrite each file
+  const allChanges: RewriteChange[] = [];
+  const filesToWrite = new Map<string, string>();
+
+  for (const relPath of files) {
+    const absPath = resolve(rootDir, relPath);
+    if (!existsSync(absPath)) continue;
+
+    const content = readFileSync(absPath, "utf-8");
+    const result = rewriteFile(relPath, content, from, to);
+
+    if (result.changes.length > 0) {
+      allChanges.push(...result.changes);
+      filesToWrite.set(absPath, result.content);
+    }
+  }
+
+  // 5. Update lock file
+  const lockChanges: LockChange[] = [];
+  const lockFilePath = resolve(rootDir, config.lockFile);
+  let updatedLock;
+
+  if (existsSync(lockFilePath)) {
+    const lock = readLock(rootDir, config.lockFile);
+    const lockResult = renameLockKey(lock, from, to);
+    updatedLock = lockResult.lock;
+    lockChanges.push(...lockResult.changes);
+  }
+
+  // 6. Apply changes if not dry run
+  if (!dryRun) {
+    for (const [absPath, content] of filesToWrite) {
+      writeFileSync(absPath, content, "utf-8");
+    }
+    if (updatedLock) {
+      writeLock(rootDir, config.lockFile, updatedLock);
+    }
+  }
+
+  // 7. Return result
+  return {
+    operation: "rename",
+    changes: allChanges,
+    lockChanges,
+    warnings: [],
+    applied: !dryRun,
+  };
+}
+
+// ── executeSplit ─────────────────────────────────────────────────────
+
+export function executeSplit(
+  options: RenameOptions & { splitId: string; intoIds: string[] },
+): RenameResult {
+  const { rootDir, dryRun, splitId, intoIds } = options;
+
+  // 1. Load config, scan, validate
+  const config = loadConfig(rootDir);
+  const { graph } = scan(rootDir, config);
+  const existingIds = new Set(graph.nodes.keys());
+
+  if (!existingIds.has(splitId)) {
+    throw new Error(`ID "${splitId}" does not exist in the project.`);
+  }
+  for (const newId of intoIds) {
+    if (existingIds.has(newId)) {
+      throw new Error(`ID "${newId}" already exists in the project.`);
+    }
+  }
+
+  // 2. Get git tracked files, filter
+  const allFiles = getGitTrackedFiles(rootDir);
+  const files = filterRelevantFiles(allFiles);
+
+  // 3. Process files
+  const allChanges: RewriteChange[] = [];
+  const warnings: RenameWarning[] = [];
+  const filesToWrite = new Map<string, string>();
+
+  const splitIdEscaped = escapeRegExp(splitId);
+  // Pattern for spec list items: `- ID: description` or `- **ID**: description`
+  const specListItemRe = new RegExp(
+    `^(\\s*[-*]\\s+)(\\*\\*)?${splitIdEscaped}(\\*\\*)?(?=[:\\s])`,
+  );
+  // Pattern for @impl tags referencing the splitId
+  const implRe = /\/\/[^\S\n]*@impl[^\S\n]+/;
+  const idBoundaryRe = new RegExp(
+    `(?<![A-Za-z0-9_/:-])${splitIdEscaped}(?![A-Za-z0-9_/:-])`,
+  );
+
+  for (const relPath of files) {
+    const absPath = resolve(rootDir, relPath);
+    if (!existsSync(absPath)) continue;
+
+    const content = readFileSync(absPath, "utf-8");
+    const ext = extOf(relPath);
+
+    if (ext === ".md") {
+      // For spec files: remove lines matching splitId, append scaffolds for new IDs,
+      // and update depends_on references
+      const lines = content.split("\n");
+      let changed = false;
+
+      // Remove list items that match the splitId
+      const filteredLines: string[] = [];
+      for (let i = 0; i < lines.length; i++) {
+        if (specListItemRe.test(lines[i])) {
+          allChanges.push({
+            filePath: relPath,
+            line: i + 1,
+            kind: "spec-list-item",
+            before: lines[i],
+            after: "(removed)",
+          });
+          changed = true;
+        } else {
+          filteredLines.push(lines[i]);
+        }
+      }
+
+      // Append scaffold lines for each new ID
+      for (const newId of intoIds) {
+        const scaffoldLine = `- ${newId}: (TODO: 説明を記述)`;
+        filteredLines.push(scaffoldLine);
+        allChanges.push({
+          filePath: relPath,
+          line: filteredLines.length,
+          kind: "spec-list-item",
+          before: "",
+          after: scaffoldLine,
+        });
+        changed = true;
+      }
+
+      // Update depends_on references: expand old ID to all new IDs
+      let updatedContent = filteredLines.join("\n");
+      for (const newId of intoIds) {
+        const fmResult = rewriteFrontmatter(updatedContent, splitId, newId);
+        if (fmResult.changes.length > 0) {
+          updatedContent = fmResult.content;
+          for (const change of fmResult.changes) {
+            change.filePath = relPath;
+          }
+          allChanges.push(...fmResult.changes);
+          changed = true;
+        }
+      }
+
+      if (changed) {
+        filesToWrite.set(absPath, updatedContent);
+      }
+    } else {
+      // For code files: DO NOT rewrite @impl tags, only add warnings
+      const lines = content.split("\n");
+      for (let i = 0; i < lines.length; i++) {
+        if (implRe.test(lines[i]) && idBoundaryRe.test(lines[i])) {
+          warnings.push({
+            type: "manual-assignment-needed",
+            filePath: relPath,
+            oldId: splitId,
+            newIds: intoIds,
+          });
+          break; // One warning per file is sufficient
+        }
+      }
+    }
+  }
+
+  // 4. Update lock file
+  const lockChanges: LockChange[] = [];
+  const lockFilePath = resolve(rootDir, config.lockFile);
+  let updatedLock;
+
+  if (existsSync(lockFilePath)) {
+    const lock = readLock(rootDir, config.lockFile);
+    const lockResult = splitLockKey(lock, splitId, intoIds);
+    updatedLock = lockResult.lock;
+    lockChanges.push(...lockResult.changes);
+  }
+
+  // 5. Apply changes if not dry run
+  if (!dryRun) {
+    for (const [absPath, content] of filesToWrite) {
+      writeFileSync(absPath, content, "utf-8");
+    }
+    if (updatedLock) {
+      writeLock(rootDir, config.lockFile, updatedLock);
+    }
+  }
+
+  // 6. Return result
+  return {
+    operation: "split",
+    changes: allChanges,
+    lockChanges,
+    warnings,
+    applied: !dryRun,
+  };
+}
+
+// ── executeMerge ─────────────────────────────────────────────────────
+
+export function executeMerge(
+  options: RenameOptions & { mergeIds: string[]; intoId: string },
+): RenameResult {
+  const { rootDir, dryRun, mergeIds, intoId } = options;
+
+  // 1. Load config, scan, validate
+  const config = loadConfig(rootDir);
+  const { graph } = scan(rootDir, config);
+  const existingIds = new Set(graph.nodes.keys());
+
+  for (const id of mergeIds) {
+    if (!existingIds.has(id)) {
+      throw new Error(`ID "${id}" does not exist in the project.`);
+    }
+  }
+  // intoId must NOT exist UNLESS it equals one of mergeIds
+  if (existingIds.has(intoId) && !mergeIds.includes(intoId)) {
+    throw new Error(
+      `ID "${intoId}" already exists in the project and is not one of the merge source IDs.`,
+    );
+  }
+
+  // 2. Get git tracked files, filter
+  const allFiles = getGitTrackedFiles(rootDir);
+  const files = filterRelevantFiles(allFiles);
+
+  // 3. Process files
+  const allChanges: RewriteChange[] = [];
+  const filesToWrite = new Map<string, string>();
+
+  // IDs to rewrite: all mergeIds that are NOT the intoId
+  const idsToRewrite = mergeIds.filter((id) => id !== intoId);
+
+  for (const relPath of files) {
+    const absPath = resolve(rootDir, relPath);
+    if (!existsSync(absPath)) continue;
+
+    let content = readFileSync(absPath, "utf-8");
+    let changed = false;
+    const ext = extOf(relPath);
+
+    // Rewrite references from each old ID to intoId
+    for (const oldId of idsToRewrite) {
+      const result = rewriteFile(relPath, content, oldId, intoId);
+      if (result.changes.length > 0) {
+        content = result.content;
+        allChanges.push(...result.changes);
+        changed = true;
+      }
+    }
+
+    // For spec files: remove old ID lines for merged IDs and append scaffold for intoId
+    if (ext === ".md") {
+      const lines = content.split("\n");
+      const filteredLines: string[] = [];
+      let removedAny = false;
+
+      for (let i = 0; i < lines.length; i++) {
+        let shouldRemove = false;
+        for (const oldId of idsToRewrite) {
+          const escaped = escapeRegExp(oldId);
+          const re = new RegExp(
+            `^(\\s*[-*]\\s+)(\\*\\*)?${escaped}(\\*\\*)?(?=[:\\s])`,
+          );
+          if (re.test(lines[i])) {
+            shouldRemove = true;
+            allChanges.push({
+              filePath: relPath,
+              line: i + 1,
+              kind: "spec-list-item",
+              before: lines[i],
+              after: "(removed)",
+            });
+            break;
+          }
+        }
+        if (shouldRemove) {
+          removedAny = true;
+        } else {
+          filteredLines.push(lines[i]);
+        }
+      }
+
+      // Append scaffold for intoId unless it is one of the mergeIds
+      // (in that case the line already exists)
+      if (!mergeIds.includes(intoId)) {
+        const scaffoldLine = `- ${intoId}: (TODO: 説明を記述)`;
+        filteredLines.push(scaffoldLine);
+        allChanges.push({
+          filePath: relPath,
+          line: filteredLines.length,
+          kind: "spec-list-item",
+          before: "",
+          after: scaffoldLine,
+        });
+        removedAny = true; // to trigger write
+      }
+
+      if (removedAny) {
+        content = filteredLines.join("\n");
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      filesToWrite.set(absPath, content);
+    }
+  }
+
+  // 4. Update lock file
+  const lockChanges: LockChange[] = [];
+  const lockFilePath = resolve(rootDir, config.lockFile);
+  let updatedLock;
+
+  if (existsSync(lockFilePath)) {
+    const lock = readLock(rootDir, config.lockFile);
+    const lockResult = mergeLockKeys(lock, mergeIds, intoId);
+    updatedLock = lockResult.lock;
+    lockChanges.push(...lockResult.changes);
+  }
+
+  // 5. Apply changes if not dry run
+  if (!dryRun) {
+    for (const [absPath, content] of filesToWrite) {
+      writeFileSync(absPath, content, "utf-8");
+    }
+    if (updatedLock) {
+      writeLock(rootDir, config.lockFile, updatedLock);
+    }
+  }
+
+  // 6. Return result
+  return {
+    operation: "merge",
+    changes: allChanges,
+    lockChanges,
+    warnings: [],
+    applied: !dryRun,
+  };
+}

--- a/src/rename-lock.ts
+++ b/src/rename-lock.ts
@@ -18,6 +18,24 @@ function deepCopyEntry(entry: LockEntry): LockEntry {
   return JSON.parse(JSON.stringify(entry));
 }
 
+function dedupe(arr: string[]): string[] {
+  return [...new Set(arr)];
+}
+
+/**
+ * Replace each `oldId` element of `arr` with every entry of `newIds`
+ * (one-to-many expansion), preserving order and de-duplicating.
+ */
+function expandRef(arr: string[] | undefined, oldId: string, newIds: string[]): string[] | undefined {
+  if (!arr) return arr;
+  const out: string[] = [];
+  for (const ref of arr) {
+    if (ref === oldId) out.push(...newIds);
+    else out.push(ref);
+  }
+  return dedupe(out);
+}
+
 /**
  * Replace references to oldId with newId in an entry's impl, tests, and dependsOn arrays.
  * Returns a new entry (does not mutate).
@@ -26,15 +44,26 @@ function updateReferences(entry: LockEntry, oldId: string, newId: string): LockE
   const updated = deepCopyEntry(entry);
 
   if (updated.impl) {
-    updated.impl = updated.impl.map((ref) => (ref === oldId ? newId : ref));
+    updated.impl = dedupe(updated.impl.map((ref) => (ref === oldId ? newId : ref)));
   }
   if (updated.tests) {
-    updated.tests = updated.tests.map((ref) => (ref === oldId ? newId : ref));
+    updated.tests = dedupe(updated.tests.map((ref) => (ref === oldId ? newId : ref)));
   }
   if (updated.dependsOn) {
-    updated.dependsOn = updated.dependsOn.map((ref) => (ref === oldId ? newId : ref));
+    updated.dependsOn = dedupe(updated.dependsOn.map((ref) => (ref === oldId ? newId : ref)));
   }
 
+  return updated;
+}
+
+/**
+ * Expand references to oldId into newIds across an entry's reference arrays.
+ */
+function expandReferences(entry: LockEntry, oldId: string, newIds: string[]): LockEntry {
+  const updated = deepCopyEntry(entry);
+  updated.impl = expandRef(updated.impl, oldId, newIds);
+  updated.tests = expandRef(updated.tests, oldId, newIds);
+  updated.dependsOn = expandRef(updated.dependsOn, oldId, newIds);
   return updated;
 }
 
@@ -69,7 +98,8 @@ export function renameLockKey(
 }
 
 /**
- * Delete oldId and create empty entries for each newId.
+ * Delete oldId and create empty entries for each newId. References to oldId in
+ * *other* entries are expanded to all newIds so the graph stays valid (C2).
  * Returns a deep copy — the input lock is not mutated.
  */
 export function splitLockKey(
@@ -80,27 +110,39 @@ export function splitLockKey(
   const result = deepCopyLock(lock);
   const changes: LockChange[] = [];
 
+  const sourceSpecFile = result[oldId]?.specFile;
+
   if (oldId in result) {
     delete result[oldId];
     changes.push({ kind: "delete", oldKey: oldId });
   }
 
   for (const newId of newIds) {
-    result[newId] = {
+    const entry: LockEntry = {
       contentHash: "",
       impl: [],
       tests: [],
       lastReconciled: new Date().toISOString(),
     };
+    if (sourceSpecFile) entry.specFile = sourceSpecFile;
+    result[newId] = entry;
     changes.push({ kind: "create", newKey: newId });
+  }
+
+  // Expand references to the split ID across every other entry.
+  for (const key of Object.keys(result)) {
+    if (isSymbolKey(key) || newIds.includes(key)) continue;
+    result[key] = expandReferences(result[key], oldId, newIds);
   }
 
   return { lock: result, changes };
 }
 
 /**
- * Merge multiple source entries into a single new entry.
- * Combines and deduplicates impl, tests, and dependsOn arrays.
+ * Merge multiple source entries into a single new entry. Combines and
+ * deduplicates impl, tests and dependsOn, preserves specFile (H5), updates
+ * references to any source ID in *other* entries to point at newId (C2), and
+ * drops self-references in the merged entry.
  * Returns a deep copy — the input lock is not mutated.
  */
 export function mergeLockKeys(
@@ -115,6 +157,7 @@ export function mergeLockKeys(
   const allTests: string[] = [];
   const allDependsOn: string[] = [];
   let contentHash = "";
+  let specFile: string | undefined;
   let firstFound = false;
 
   for (const sourceId of sourceIds) {
@@ -123,8 +166,10 @@ export function mergeLockKeys(
 
       if (!firstFound) {
         contentHash = entry.contentHash;
+        specFile = entry.specFile;
         firstFound = true;
       }
+      if (specFile === undefined && entry.specFile) specFile = entry.specFile;
 
       if (entry.impl) allImpl.push(...entry.impl);
       if (entry.tests) allTests.push(...entry.tests);
@@ -135,16 +180,17 @@ export function mergeLockKeys(
     changes.push({ kind: "delete", oldKey: sourceId });
   }
 
-  const dedupe = (arr: string[]): string[] => [...new Set(arr)];
-
+  const sourceSet = new Set(sourceIds);
   const merged: LockEntry = {
     contentHash,
     lastReconciled: new Date().toISOString(),
   };
+  if (specFile) merged.specFile = specFile;
 
   const dedupedImpl = dedupe(allImpl);
   const dedupedTests = dedupe(allTests);
-  const dedupedDeps = dedupe(allDependsOn);
+  // A merged requirement must not depend on its own former parts or on itself.
+  const dedupedDeps = dedupe(allDependsOn).filter((d) => !sourceSet.has(d) && d !== newId);
 
   if (dedupedImpl.length > 0) merged.impl = dedupedImpl;
   if (dedupedTests.length > 0) merged.tests = dedupedTests;
@@ -152,6 +198,17 @@ export function mergeLockKeys(
 
   result[newId] = merged;
   changes.push({ kind: "create", newKey: newId });
+
+  // Repoint references to any source ID in other entries to newId.
+  for (const key of Object.keys(result)) {
+    if (isSymbolKey(key) || key === newId) continue;
+    let entry = result[key];
+    for (const sourceId of sourceIds) {
+      if (sourceId === newId) continue;
+      entry = updateReferences(entry, sourceId, newId);
+    }
+    result[key] = entry;
+  }
 
   return { lock: result, changes };
 }

--- a/src/rename-lock.ts
+++ b/src/rename-lock.ts
@@ -1,0 +1,157 @@
+import type { LockFile, LockEntry } from "./types.js";
+
+export interface LockChange {
+  kind: "rename" | "delete" | "create";
+  oldKey?: string;
+  newKey?: string;
+}
+
+function isSymbolKey(key: string): boolean {
+  return key.startsWith("symbol:");
+}
+
+function deepCopyLock(lock: LockFile): LockFile {
+  return JSON.parse(JSON.stringify(lock));
+}
+
+function deepCopyEntry(entry: LockEntry): LockEntry {
+  return JSON.parse(JSON.stringify(entry));
+}
+
+/**
+ * Replace references to oldId with newId in an entry's impl, tests, and dependsOn arrays.
+ * Returns a new entry (does not mutate).
+ */
+function updateReferences(entry: LockEntry, oldId: string, newId: string): LockEntry {
+  const updated = deepCopyEntry(entry);
+
+  if (updated.impl) {
+    updated.impl = updated.impl.map((ref) => (ref === oldId ? newId : ref));
+  }
+  if (updated.tests) {
+    updated.tests = updated.tests.map((ref) => (ref === oldId ? newId : ref));
+  }
+  if (updated.dependsOn) {
+    updated.dependsOn = updated.dependsOn.map((ref) => (ref === oldId ? newId : ref));
+  }
+
+  return updated;
+}
+
+/**
+ * Move a lock entry from oldId to newId, updating all cross-references.
+ * Returns a deep copy — the input lock is not mutated.
+ */
+export function renameLockKey(
+  lock: LockFile,
+  oldId: string,
+  newId: string,
+): { lock: LockFile; changes: LockChange[] } {
+  if (!(oldId in lock)) {
+    return { lock: deepCopyLock(lock), changes: [] };
+  }
+
+  const result = deepCopyLock(lock);
+  const changes: LockChange[] = [];
+
+  // Move the entry from oldId to newId
+  result[newId] = result[oldId];
+  delete result[oldId];
+  changes.push({ kind: "rename", oldKey: oldId, newKey: newId });
+
+  // Scan all non-symbol entries and update cross-references
+  for (const key of Object.keys(result)) {
+    if (isSymbolKey(key)) continue;
+    result[key] = updateReferences(result[key], oldId, newId);
+  }
+
+  return { lock: result, changes };
+}
+
+/**
+ * Delete oldId and create empty entries for each newId.
+ * Returns a deep copy — the input lock is not mutated.
+ */
+export function splitLockKey(
+  lock: LockFile,
+  oldId: string,
+  newIds: string[],
+): { lock: LockFile; changes: LockChange[] } {
+  const result = deepCopyLock(lock);
+  const changes: LockChange[] = [];
+
+  if (oldId in result) {
+    delete result[oldId];
+    changes.push({ kind: "delete", oldKey: oldId });
+  }
+
+  for (const newId of newIds) {
+    result[newId] = {
+      contentHash: "",
+      impl: [],
+      tests: [],
+      lastReconciled: new Date().toISOString(),
+    };
+    changes.push({ kind: "create", newKey: newId });
+  }
+
+  return { lock: result, changes };
+}
+
+/**
+ * Merge multiple source entries into a single new entry.
+ * Combines and deduplicates impl, tests, and dependsOn arrays.
+ * Returns a deep copy — the input lock is not mutated.
+ */
+export function mergeLockKeys(
+  lock: LockFile,
+  sourceIds: string[],
+  newId: string,
+): { lock: LockFile; changes: LockChange[] } {
+  const result = deepCopyLock(lock);
+  const changes: LockChange[] = [];
+
+  const allImpl: string[] = [];
+  const allTests: string[] = [];
+  const allDependsOn: string[] = [];
+  let contentHash = "";
+  let firstFound = false;
+
+  for (const sourceId of sourceIds) {
+    if (sourceId in result) {
+      const entry = result[sourceId];
+
+      if (!firstFound) {
+        contentHash = entry.contentHash;
+        firstFound = true;
+      }
+
+      if (entry.impl) allImpl.push(...entry.impl);
+      if (entry.tests) allTests.push(...entry.tests);
+      if (entry.dependsOn) allDependsOn.push(...entry.dependsOn);
+
+      delete result[sourceId];
+    }
+    changes.push({ kind: "delete", oldKey: sourceId });
+  }
+
+  const dedupe = (arr: string[]): string[] => [...new Set(arr)];
+
+  const merged: LockEntry = {
+    contentHash,
+    lastReconciled: new Date().toISOString(),
+  };
+
+  const dedupedImpl = dedupe(allImpl);
+  const dedupedTests = dedupe(allTests);
+  const dedupedDeps = dedupe(allDependsOn);
+
+  if (dedupedImpl.length > 0) merged.impl = dedupedImpl;
+  if (dedupedTests.length > 0) merged.tests = dedupedTests;
+  if (dedupedDeps.length > 0) merged.dependsOn = dedupedDeps;
+
+  result[newId] = merged;
+  changes.push({ kind: "create", newKey: newId });
+
+  return { lock: result, changes };
+}

--- a/src/rename.ts
+++ b/src/rename.ts
@@ -1,3 +1,5 @@
+import type { ReqPatternConfig } from "./types.js";
+
 // ── Types ────────────────────────────────────────────────────────────
 
 export type ReferenceKind =
@@ -21,13 +23,30 @@ interface RewriteResult {
   changes: RewriteChange[];
 }
 
+export interface RewriteOptions {
+  reqPatterns?: ReqPatternConfig;
+}
+
+// Mirror the parser defaults (src/parsers/markdown.ts) so discovery and
+// rewriting use the exact same grammar.
+const DEFAULT_LIST_ITEM_RE = /^(?:\*\*)?([A-Z][A-Za-z]*-\d+)(?:\*\*)?[:\s]/;
+const DEFAULT_KIRO_HEADING_RE = /^Requirement\s+(\d+)\s*:/;
+
 // ── Helpers ──────────────────────────────────────────────────────────
 
 /**
  * Escape a string for use inside a RegExp.
  */
-function escapeRegExp(s: string): string {
+export function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * The file extension, lower-cased, including the leading dot ("" if none).
+ */
+export function extOf(filePath: string): string {
+  const dot = filePath.lastIndexOf(".");
+  return dot === -1 ? "" : filePath.slice(dot).toLowerCase();
 }
 
 /**
@@ -35,9 +54,6 @@ function escapeRegExp(s: string): string {
  * ID tokens.  The ID may contain `/` (namespace-qualified) or `:` (doc:xxx),
  * so we cannot simply use `\b`.  Instead we assert that the character
  * immediately before/after the ID is NOT alphanumeric, `-`, `/`, or `:`.
- *
- * When the ID appears at the start/end of the string the assertion is
- * trivially satisfied.
  */
 function idBoundaryRegex(id: string, flags: string = "g"): RegExp {
   const escaped = escapeRegExp(id);
@@ -47,6 +63,75 @@ function idBoundaryRegex(id: string, flags: string = "g"): RegExp {
   );
 }
 
+/**
+ * Return the set of 0-based line indices that fall *inside* fenced code
+ * blocks (``` or ~~~), including the fence lines themselves. The markdown
+ * parser treats fenced blocks as opaque `code` nodes, so IDs appearing in
+ * examples must not be rewritten (F6).
+ */
+function fencedLineSet(lines: string[]): Set<number> {
+  const set = new Set<number>();
+  let fenceChar: string | null = null;
+  for (let i = 0; i < lines.length; i++) {
+    const t = lines[i].trim();
+    const m = t.match(/^(`{3,}|~{3,})/);
+    if (fenceChar === null) {
+      if (m) {
+        fenceChar = m[1][0];
+        set.add(i);
+      }
+    } else {
+      set.add(i);
+      if (m && m[1][0] === fenceChar) {
+        fenceChar = null;
+      }
+    }
+  }
+  return set;
+}
+
+function listItemRegex(opts?: RewriteOptions): RegExp {
+  return opts?.reqPatterns?.listItem
+    ? new RegExp(opts.reqPatterns.listItem)
+    : DEFAULT_LIST_ITEM_RE;
+}
+
+function headingRegex(opts?: RewriteOptions): RegExp {
+  return opts?.reqPatterns?.heading
+    ? new RegExp(opts.reqPatterns.heading)
+    : DEFAULT_KIRO_HEADING_RE;
+}
+
+/**
+ * Content-based wrapper for the fenced-code line index set (see fencedLineSet).
+ */
+export function fencedLines(content: string): Set<number> {
+  return fencedLineSet(content.split("\n"));
+}
+
+/**
+ * If `line` *defines* a requirement (a markdown list item or a heading the
+ * parser would turn into a req node), return that requirement's ID; otherwise
+ * null. Mirrors the parser's list-item / heading grammar so split/merge can
+ * remove the exact lines the parser treats as definitions.
+ */
+export function specDefinitionId(line: string, opts?: RewriteOptions): string | null {
+  const pm = line.match(/^(\s*[-*]\s+)/);
+  if (pm) {
+    const m = line.slice(pm[0].length).match(listItemRegex(opts));
+    if (m && m[1] != null) return m[1];
+  }
+  const hm = line.match(/^(#+\s+)(.*)$/);
+  if (hm) {
+    const headRe = headingRegex(opts);
+    const m = hm[2].match(headRe);
+    if (m && m[1] != null) {
+      return headRe.source === DEFAULT_KIRO_HEADING_RE.source ? `Requirement-${m[1]}` : m[1];
+    }
+  }
+  return null;
+}
+
 // ── Rewriters ────────────────────────────────────────────────────────
 
 /**
@@ -54,39 +139,41 @@ function idBoundaryRegex(id: string, flags: string = "g"): RegExp {
  *   - REQ-001: description
  *   - **REQ-001**: description
  *
- * Matches the same patterns as the parser's LIST_ITEM_RE.
+ * Honours a custom `reqPatterns.listItem` by locating the ID via the active
+ * regex's capture group (the same the parser uses) and replacing only that
+ * span. Lines inside fenced code blocks are skipped (F6).
  */
 export function rewriteSpecListItem(
   content: string,
   oldId: string,
   newId: string,
+  opts?: RewriteOptions,
 ): RewriteResult {
   const lines = content.split("\n");
   const changes: RewriteChange[] = [];
-
-  // Pattern mirrors LIST_ITEM_RE = /^(?:\*\*)?([A-Z][A-Za-z]*-\d+)(?:\*\*)?[:\s]/
-  // but anchored to a markdown list prefix (`- ` or `* `) and targeting a
-  // specific oldId.
-  const escaped = escapeRegExp(oldId);
-  const re = new RegExp(
-    `^(\\s*[-*]\\s+)(\\*\\*)?${escaped}(\\*\\*)?(?=[:\\s])`,
-  );
+  const fenced = fencedLineSet(lines);
+  const itemRe = listItemRegex(opts);
+  // Markdown list prefix (`- ` / `* `). The parser matches its list-item
+  // regex against the AST label text, which already excludes this marker.
+  const prefixRe = /^(\s*[-*]\s+)/;
 
   for (let i = 0; i < lines.length; i++) {
-    const match = lines[i].match(re);
-    if (!match) continue;
+    if (fenced.has(i)) continue;
+    const pm = lines[i].match(prefixRe);
+    if (!pm) continue;
+
+    const rest = lines[i].slice(pm[0].length);
+    const m = rest.match(itemRe);
+    if (!m || m[1] !== oldId) continue;
+
+    // Locate the captured ID within the match so bold markers / prefixes are
+    // preserved, then splice in newId.
+    const idOffsetInMatch = m[0].indexOf(m[1]);
+    if (idOffsetInMatch === -1) continue;
+    const idStart = pm[0].length + (m.index ?? 0) + idOffsetInMatch;
 
     const before = lines[i];
-    // Reconstruct with newId, preserving bold markers and prefix.
-    const prefix = match[1];
-    const boldOpen = match[2] ?? "";
-    const boldClose = match[3] ?? "";
-    lines[i] =
-      prefix +
-      boldOpen +
-      newId +
-      boldClose +
-      lines[i].slice(match[0].length);
+    lines[i] = lines[i].slice(0, idStart) + newId + lines[i].slice(idStart + oldId.length);
 
     changes.push({
       filePath: "",
@@ -102,42 +189,65 @@ export function rewriteSpecListItem(
 
 /**
  * Rewrite Kiro-style headings:
- *   ### Requirement 1: description
+ *   ### Requirement 1: description     (ID form: Requirement-1)
  *
- * Only applies when `oldId` is in the `Requirement-N` format.  The heading
- * text uses `Requirement N:` (space, not dash), so the rewriter converts
- * between the two representations.
+ * For the default heading grammar the `Requirement-N` ↔ `Requirement N`
+ * representation is converted. For a custom `reqPatterns.heading` whose
+ * capture group is the verbatim ID, the captured span is replaced directly.
  */
 export function rewriteSpecHeading(
   content: string,
   oldId: string,
   newId: string,
+  opts?: RewriteOptions,
 ): RewriteResult {
   const lines = content.split("\n");
   const changes: RewriteChange[] = [];
+  const fenced = fencedLineSet(lines);
+  const headRe = headingRegex(opts);
 
-  // Extract the numeric part from `Requirement-N`.
-  const oldMatch = oldId.match(/^Requirement-(\d+)$/);
-  if (!oldMatch) return { content, changes };
-  const oldNum = oldMatch[1];
+  const usingDefault = headRe.source === DEFAULT_KIRO_HEADING_RE.source;
 
-  // The new ID must also be Requirement-N for a heading rewrite to make sense.
-  const newMatch = newId.match(/^Requirement-(\d+)$/);
-  if (!newMatch) return { content, changes };
-  const newNum = newMatch[1];
+  if (usingDefault) {
+    const oldMatch = oldId.match(/^Requirement-(\d+)$/);
+    const newMatch = newId.match(/^Requirement-(\d+)$/);
+    if (!oldMatch || !newMatch) return { content, changes };
+    const oldNum = oldMatch[1];
+    const newNum = newMatch[1];
 
-  // Matches `Requirement N:` inside a heading line (preceded by `#`s).
-  const re = new RegExp(
-    `^(#+\\s+)Requirement\\s+${escapeRegExp(oldNum)}(\\s*:)`,
-  );
+    const re = new RegExp(`^(#+\\s+)Requirement\\s+${escapeRegExp(oldNum)}(\\s*:)`);
+    for (let i = 0; i < lines.length; i++) {
+      if (fenced.has(i)) continue;
+      const match = lines[i].match(re);
+      if (!match) continue;
+      const before = lines[i];
+      lines[i] =
+        match[1] + "Requirement " + newNum + match[2] + lines[i].slice(match[0].length);
+      changes.push({
+        filePath: "",
+        line: i + 1,
+        kind: "spec-heading",
+        before,
+        after: lines[i],
+      });
+    }
+    return { content: lines.join("\n"), changes };
+  }
 
+  // Custom heading grammar: heading text after the leading `#`s is matched by
+  // headRe; capture group 1 holds the verbatim ID.
+  const headingLineRe = /^(#+\s+)(.*)$/;
   for (let i = 0; i < lines.length; i++) {
-    const match = lines[i].match(re);
-    if (!match) continue;
-
+    if (fenced.has(i)) continue;
+    const hm = lines[i].match(headingLineRe);
+    if (!hm) continue;
+    const m = hm[2].match(headRe);
+    if (!m || m[1] !== oldId) continue;
+    const idOffsetInMatch = m[0].indexOf(m[1]);
+    if (idOffsetInMatch === -1) continue;
+    const idStart = hm[1].length + (m.index ?? 0) + idOffsetInMatch;
     const before = lines[i];
-    lines[i] = match[1] + "Requirement " + newNum + match[2] + lines[i].slice(match[0].length);
-
+    lines[i] = lines[i].slice(0, idStart) + newId + lines[i].slice(idStart + oldId.length);
     changes.push({
       filePath: "",
       line: i + 1,
@@ -146,16 +256,12 @@ export function rewriteSpecHeading(
       after: lines[i],
     });
   }
-
   return { content: lines.join("\n"), changes };
 }
 
 /**
  * Rewrite `// @impl REQ-001` and multi-ID variants like
- * `// @impl REQ-001 REQ-002`.
- *
- * Only the target `oldId` is replaced; other IDs on the same line are left
- * untouched.  Also handles `doc:xxx` IDs.
+ * `// @impl REQ-001 REQ-002`. Only the target `oldId` is replaced.
  */
 export function rewriteImplTags(
   content: string,
@@ -165,20 +271,16 @@ export function rewriteImplTags(
   const lines = content.split("\n");
   const changes: RewriteChange[] = [];
 
-  // Detect @impl lines (mirrors IMPL_RE).
   const implLineRe = /\/\/[^\S\n]*@impl[^\S\n]+/;
   const idRe = idBoundaryRegex(oldId);
 
   for (let i = 0; i < lines.length; i++) {
     if (!implLineRe.test(lines[i])) continue;
 
-    // Reset the regex (it has the `g` flag).
     idRe.lastIndex = 0;
     if (!idRe.test(lines[i])) continue;
 
     const before = lines[i];
-    // Replace all occurrences of oldId on this line (there should normally
-    // be at most one, but handle duplicates defensively).
     idRe.lastIndex = 0;
     lines[i] = lines[i].replace(idRe, newId);
 
@@ -195,11 +297,13 @@ export function rewriteImplTags(
 }
 
 /**
- * Rewrite test tags:
- *   - `[REQ-001]` inside test description strings
- *   - `req: "REQ-001"` annotation patterns
+ * Rewrite test tags, mirroring the parser's TEST_REQ_RE and TEST_ANNOTATION_RE:
+ *   - `[REQ-001]` bracket-wrapped ID
+ *   - `req: "REQ-001"` / `req: REQ-001` — case-sensitive `req:` only
  *
- * Mirrors TEST_REQ_RE and TEST_ANNOTATION_RE from the parser.
+ * The parser tracks `req:` exclusively (not `requirement:`/`spec:` and not
+ * case-insensitively), so the rewriter matches the same to avoid touching text
+ * the tooling does not treat as a reference (M1).
  */
 export function rewriteTestTags(
   content: string,
@@ -211,14 +315,10 @@ export function rewriteTestTags(
 
   const escaped = escapeRegExp(oldId);
 
-  // Pattern 1: [REQ-001] — bracket-wrapped ID.
+  // [REQ-001]
   const bracketRe = new RegExp(`\\[${escaped}\\]`, "g");
-
-  // Pattern 2: req: "REQ-001" (or 'REQ-001').
-  const annotationRe = new RegExp(
-    `((?:req|requirement|spec):\\s*["'])${escaped}(["'])`,
-    "gi",
-  );
+  // req: "REQ-001" | req: 'REQ-001' | req: REQ-001  (case-sensitive `req:`)
+  const annotationRe = new RegExp(`(req:\\s*["']?)${escaped}(["']?)`, "g");
 
   for (let i = 0; i < lines.length; i++) {
     bracketRe.lastIndex = 0;
@@ -226,20 +326,14 @@ export function rewriteTestTags(
 
     const hasBracket = bracketRe.test(lines[i]);
     const hasAnnotation = annotationRe.test(lines[i]);
-
     if (!hasBracket && !hasAnnotation) continue;
 
     const before = lines[i];
-
     bracketRe.lastIndex = 0;
     annotationRe.lastIndex = 0;
 
-    if (hasBracket) {
-      lines[i] = lines[i].replace(bracketRe, `[${newId}]`);
-    }
-    if (hasAnnotation) {
-      lines[i] = lines[i].replace(annotationRe, `$1${newId}$2`);
-    }
+    if (hasBracket) lines[i] = lines[i].replace(bracketRe, `[${newId}]`);
+    if (hasAnnotation) lines[i] = lines[i].replace(annotationRe, `$1${newId}$2`);
 
     changes.push({
       filePath: "",
@@ -253,13 +347,49 @@ export function rewriteTestTags(
   return { content: lines.join("\n"), changes };
 }
 
+// ── Frontmatter ──────────────────────────────────────────────────────
+
+const FM_BLOCK_KEY_RE = /^(\s*)(depends_on|derives_from)\s*:(.*)$/;
+const FM_NODE_ID_RE = /^(\s*node_id:\s*["']?)(.+?)(["']?\s*)$/;
+
+interface FrontmatterBounds {
+  start: number;
+  end: number;
+}
+
+function frontmatterBounds(lines: string[]): FrontmatterBounds | null {
+  let start = -1;
+  let end = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === "---") {
+      if (start === -1) start = i;
+      else {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (start === -1 || end === -1) return null;
+  return { start, end };
+}
+
 /**
- * Rewrite IDs inside YAML frontmatter (delimited by `---` lines):
+ * True for a line that is part of an active `depends_on`/`derives_from` block
+ * sequence (a `- …` list item or a blank continuation line).
+ */
+function isBlockItemLine(line: string): boolean {
+  const t = line.trim();
+  return t === "" || t.startsWith("-");
+}
+
+/**
+ * Rewrite a single ID reference inside YAML frontmatter:
  *   - `node_id: "doc:xxx"`
- *   - `id: "doc:xxx"` or `id: "REQ-001"` inside `depends_on` arrays
+ *   - any reference to `oldId` within `depends_on:` / `derives_from:` blocks
+ *     (string items, `id:` objects, inline `{ id: … }` flow maps and inline
+ *     `[ … ]` arrays)
  *
- * Uses line-level string replacement to avoid YAML re-serialization and
- * the format changes it would introduce.
+ * Body content outside the frontmatter delimiters is never touched.
  */
 export function rewriteFrontmatter(
   content: string,
@@ -269,54 +399,119 @@ export function rewriteFrontmatter(
   const lines = content.split("\n");
   const changes: RewriteChange[] = [];
 
-  // Locate frontmatter boundaries.
-  let fmStart = -1;
-  let fmEnd = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].trim() === "---") {
-      if (fmStart === -1) {
-        fmStart = i;
-      } else {
-        fmEnd = i;
-        break;
+  const bounds = frontmatterBounds(lines);
+  if (!bounds) return { content, changes };
+
+  const idRe = idBoundaryRegex(oldId);
+  let inBlock = false;
+
+  for (let i = bounds.start + 1; i < bounds.end; i++) {
+    const line = lines[i];
+
+    // node_id: "<id>"
+    const nm = line.match(FM_NODE_ID_RE);
+    if (nm && nm[2] === oldId) {
+      const before = line;
+      lines[i] = nm[1] + newId + nm[3];
+      changes.push({ filePath: "", line: i + 1, kind: "frontmatter-depends-on", before, after: lines[i] });
+      inBlock = false;
+      continue;
+    }
+
+    // depends_on: / derives_from: key (with optional inline value)
+    const bm = line.match(FM_BLOCK_KEY_RE);
+    if (bm) {
+      inBlock = true;
+      if (bm[3].trim() !== "") {
+        idRe.lastIndex = 0;
+        if (idRe.test(line)) {
+          const before = line;
+          idRe.lastIndex = 0;
+          lines[i] = line.replace(idRe, newId);
+          changes.push({ filePath: "", line: i + 1, kind: "frontmatter-depends-on", before, after: lines[i] });
+        }
+      }
+      continue;
+    }
+
+    if (inBlock) {
+      if (!isBlockItemLine(line)) {
+        inBlock = false;
+        continue;
+      }
+      idRe.lastIndex = 0;
+      if (idRe.test(line)) {
+        const before = line;
+        idRe.lastIndex = 0;
+        lines[i] = line.replace(idRe, newId);
+        changes.push({ filePath: "", line: i + 1, kind: "frontmatter-depends-on", before, after: lines[i] });
       }
     }
   }
 
-  if (fmStart === -1 || fmEnd === -1) return { content, changes };
+  return { content: lines.join("\n"), changes };
+}
 
-  const escaped = escapeRegExp(oldId);
+/**
+ * Split-aware frontmatter rewrite: a single reference to `oldId` inside a
+ * `depends_on`/`derives_from` block is *expanded* into one entry per newId,
+ * preserving the original item's indentation and style. Fixes the iterative
+ * single-replace bug where only the first new ID survived (F5).
+ */
+export function expandFrontmatterDependsOn(
+  content: string,
+  oldId: string,
+  newIds: string[],
+): RewriteResult {
+  const lines = content.split("\n");
+  const changes: RewriteChange[] = [];
 
-  // Patterns to match inside frontmatter lines:
-  //   node_id: "doc:xxx"  or  node_id: doc:xxx
-  //   id: "REQ-001"       or  id: REQ-001
-  const nodeIdRe = new RegExp(
-    `^(\\s*node_id:\\s*["']?)${escaped}(["']?\\s*)$`,
-  );
-  const idRe = new RegExp(
-    `^(\\s*(?:-\\s+)?id:\\s*["']?)${escaped}(["']?\\s*)$`,
-  );
+  const bounds = frontmatterBounds(lines);
+  if (!bounds || newIds.length === 0) return { content, changes };
 
-  for (let i = fmStart + 1; i < fmEnd; i++) {
-    const nodeIdMatch = lines[i].match(nodeIdRe);
-    const idMatch = lines[i].match(idRe);
+  const idRe = idBoundaryRegex(oldId);
+  const out: string[] = [];
+  let inBlock = false;
 
-    if (!nodeIdMatch && !idMatch) continue;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
 
-    const before = lines[i];
-    const m = (nodeIdMatch ?? idMatch)!;
-    lines[i] = m[1] + newId + m[2];
+    if (i <= bounds.start || i >= bounds.end) {
+      out.push(line);
+      continue;
+    }
 
-    changes.push({
-      filePath: "",
-      line: i + 1,
-      kind: "frontmatter-depends-on",
-      before,
-      after: lines[i],
-    });
+    const bm = line.match(FM_BLOCK_KEY_RE);
+    if (bm) {
+      // Only block sequences expand line-by-line; an inline array stays inline.
+      inBlock = bm[3].trim() === "";
+      out.push(line);
+      continue;
+    }
+
+    idRe.lastIndex = 0;
+    if (inBlock && line.trim().startsWith("-") && idRe.test(line)) {
+      // Expand: emit one list item per newId, cloning this line's template.
+      for (const newId of newIds) {
+        idRe.lastIndex = 0;
+        const expanded = line.replace(idRe, newId);
+        out.push(expanded);
+        changes.push({
+          filePath: "",
+          line: i + 1,
+          kind: "frontmatter-depends-on",
+          before: line,
+          after: expanded,
+        });
+      }
+      continue;
+    }
+
+    if (inBlock && !isBlockItemLine(line)) inBlock = false;
+    out.push(line);
   }
 
-  return { content: lines.join("\n"), changes };
+  return { content: out.join("\n"), changes };
 }
 
 // ── Orchestrator ─────────────────────────────────────────────────────
@@ -330,40 +525,30 @@ export function rewriteFile(
   content: string,
   oldId: string,
   newId: string,
+  opts?: RewriteOptions,
 ): RewriteResult {
   const ext = extOf(filePath);
   const allChanges: RewriteChange[] = [];
   let current = content;
 
-  const apply = (fn: (c: string, o: string, n: string) => RewriteResult) => {
-    const result = fn(current, oldId, newId);
+  const apply = (fn: (c: string) => RewriteResult) => {
+    const result = fn(current);
     current = result.content;
     allChanges.push(...result.changes);
   };
 
   if (ext === ".md") {
-    apply(rewriteSpecListItem);
-    apply(rewriteSpecHeading);
-    apply(rewriteFrontmatter);
-  } else if (
-    ext === ".ts" ||
-    ext === ".tsx" ||
-    ext === ".js" ||
-    ext === ".jsx"
-  ) {
-    apply(rewriteImplTags);
-    apply(rewriteTestTags);
+    apply((c) => rewriteSpecListItem(c, oldId, newId, opts));
+    apply((c) => rewriteSpecHeading(c, oldId, newId, opts));
+    apply((c) => rewriteFrontmatter(c, oldId, newId));
+  } else if (ext === ".ts" || ext === ".tsx" || ext === ".js" || ext === ".jsx") {
+    apply((c) => rewriteImplTags(c, oldId, newId));
+    apply((c) => rewriteTestTags(c, oldId, newId));
   }
 
-  // Stamp filePath on every change.
   for (const change of allChanges) {
     change.filePath = filePath;
   }
 
   return { content: current, changes: allChanges };
-}
-
-function extOf(filePath: string): string {
-  const dot = filePath.lastIndexOf(".");
-  return dot === -1 ? "" : filePath.slice(dot).toLowerCase();
 }

--- a/src/rename.ts
+++ b/src/rename.ts
@@ -1,0 +1,369 @@
+// ── Types ────────────────────────────────────────────────────────────
+
+export type ReferenceKind =
+  | "spec-list-item"
+  | "spec-heading"
+  | "impl-tag"
+  | "test-tag"
+  | "frontmatter-depends-on"
+  | "lock-key";
+
+export interface RewriteChange {
+  filePath: string;
+  line: number;
+  kind: ReferenceKind;
+  before: string;
+  after: string;
+}
+
+interface RewriteResult {
+  content: string;
+  changes: RewriteChange[];
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Escape a string for use inside a RegExp.
+ */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Build a regex that matches `id` at a word-like boundary suitable for
+ * ID tokens.  The ID may contain `/` (namespace-qualified) or `:` (doc:xxx),
+ * so we cannot simply use `\b`.  Instead we assert that the character
+ * immediately before/after the ID is NOT alphanumeric, `-`, `/`, or `:`.
+ *
+ * When the ID appears at the start/end of the string the assertion is
+ * trivially satisfied.
+ */
+function idBoundaryRegex(id: string, flags: string = "g"): RegExp {
+  const escaped = escapeRegExp(id);
+  return new RegExp(
+    `(?<![A-Za-z0-9_/:-])${escaped}(?![A-Za-z0-9_/:-])`,
+    flags,
+  );
+}
+
+// ── Rewriters ────────────────────────────────────────────────────────
+
+/**
+ * Rewrite spec list items such as:
+ *   - REQ-001: description
+ *   - **REQ-001**: description
+ *
+ * Matches the same patterns as the parser's LIST_ITEM_RE.
+ */
+export function rewriteSpecListItem(
+  content: string,
+  oldId: string,
+  newId: string,
+): RewriteResult {
+  const lines = content.split("\n");
+  const changes: RewriteChange[] = [];
+
+  // Pattern mirrors LIST_ITEM_RE = /^(?:\*\*)?([A-Z][A-Za-z]*-\d+)(?:\*\*)?[:\s]/
+  // but anchored to a markdown list prefix (`- ` or `* `) and targeting a
+  // specific oldId.
+  const escaped = escapeRegExp(oldId);
+  const re = new RegExp(
+    `^(\\s*[-*]\\s+)(\\*\\*)?${escaped}(\\*\\*)?(?=[:\\s])`,
+  );
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(re);
+    if (!match) continue;
+
+    const before = lines[i];
+    // Reconstruct with newId, preserving bold markers and prefix.
+    const prefix = match[1];
+    const boldOpen = match[2] ?? "";
+    const boldClose = match[3] ?? "";
+    lines[i] =
+      prefix +
+      boldOpen +
+      newId +
+      boldClose +
+      lines[i].slice(match[0].length);
+
+    changes.push({
+      filePath: "",
+      line: i + 1,
+      kind: "spec-list-item",
+      before,
+      after: lines[i],
+    });
+  }
+
+  return { content: lines.join("\n"), changes };
+}
+
+/**
+ * Rewrite Kiro-style headings:
+ *   ### Requirement 1: description
+ *
+ * Only applies when `oldId` is in the `Requirement-N` format.  The heading
+ * text uses `Requirement N:` (space, not dash), so the rewriter converts
+ * between the two representations.
+ */
+export function rewriteSpecHeading(
+  content: string,
+  oldId: string,
+  newId: string,
+): RewriteResult {
+  const lines = content.split("\n");
+  const changes: RewriteChange[] = [];
+
+  // Extract the numeric part from `Requirement-N`.
+  const oldMatch = oldId.match(/^Requirement-(\d+)$/);
+  if (!oldMatch) return { content, changes };
+  const oldNum = oldMatch[1];
+
+  // The new ID must also be Requirement-N for a heading rewrite to make sense.
+  const newMatch = newId.match(/^Requirement-(\d+)$/);
+  if (!newMatch) return { content, changes };
+  const newNum = newMatch[1];
+
+  // Matches `Requirement N:` inside a heading line (preceded by `#`s).
+  const re = new RegExp(
+    `^(#+\\s+)Requirement\\s+${escapeRegExp(oldNum)}(\\s*:)`,
+  );
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(re);
+    if (!match) continue;
+
+    const before = lines[i];
+    lines[i] = match[1] + "Requirement " + newNum + match[2] + lines[i].slice(match[0].length);
+
+    changes.push({
+      filePath: "",
+      line: i + 1,
+      kind: "spec-heading",
+      before,
+      after: lines[i],
+    });
+  }
+
+  return { content: lines.join("\n"), changes };
+}
+
+/**
+ * Rewrite `// @impl REQ-001` and multi-ID variants like
+ * `// @impl REQ-001 REQ-002`.
+ *
+ * Only the target `oldId` is replaced; other IDs on the same line are left
+ * untouched.  Also handles `doc:xxx` IDs.
+ */
+export function rewriteImplTags(
+  content: string,
+  oldId: string,
+  newId: string,
+): RewriteResult {
+  const lines = content.split("\n");
+  const changes: RewriteChange[] = [];
+
+  // Detect @impl lines (mirrors IMPL_RE).
+  const implLineRe = /\/\/[^\S\n]*@impl[^\S\n]+/;
+  const idRe = idBoundaryRegex(oldId);
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!implLineRe.test(lines[i])) continue;
+
+    // Reset the regex (it has the `g` flag).
+    idRe.lastIndex = 0;
+    if (!idRe.test(lines[i])) continue;
+
+    const before = lines[i];
+    // Replace all occurrences of oldId on this line (there should normally
+    // be at most one, but handle duplicates defensively).
+    idRe.lastIndex = 0;
+    lines[i] = lines[i].replace(idRe, newId);
+
+    changes.push({
+      filePath: "",
+      line: i + 1,
+      kind: "impl-tag",
+      before,
+      after: lines[i],
+    });
+  }
+
+  return { content: lines.join("\n"), changes };
+}
+
+/**
+ * Rewrite test tags:
+ *   - `[REQ-001]` inside test description strings
+ *   - `req: "REQ-001"` annotation patterns
+ *
+ * Mirrors TEST_REQ_RE and TEST_ANNOTATION_RE from the parser.
+ */
+export function rewriteTestTags(
+  content: string,
+  oldId: string,
+  newId: string,
+): RewriteResult {
+  const lines = content.split("\n");
+  const changes: RewriteChange[] = [];
+
+  const escaped = escapeRegExp(oldId);
+
+  // Pattern 1: [REQ-001] — bracket-wrapped ID.
+  const bracketRe = new RegExp(`\\[${escaped}\\]`, "g");
+
+  // Pattern 2: req: "REQ-001" (or 'REQ-001').
+  const annotationRe = new RegExp(
+    `((?:req|requirement|spec):\\s*["'])${escaped}(["'])`,
+    "gi",
+  );
+
+  for (let i = 0; i < lines.length; i++) {
+    bracketRe.lastIndex = 0;
+    annotationRe.lastIndex = 0;
+
+    const hasBracket = bracketRe.test(lines[i]);
+    const hasAnnotation = annotationRe.test(lines[i]);
+
+    if (!hasBracket && !hasAnnotation) continue;
+
+    const before = lines[i];
+
+    bracketRe.lastIndex = 0;
+    annotationRe.lastIndex = 0;
+
+    if (hasBracket) {
+      lines[i] = lines[i].replace(bracketRe, `[${newId}]`);
+    }
+    if (hasAnnotation) {
+      lines[i] = lines[i].replace(annotationRe, `$1${newId}$2`);
+    }
+
+    changes.push({
+      filePath: "",
+      line: i + 1,
+      kind: "test-tag",
+      before,
+      after: lines[i],
+    });
+  }
+
+  return { content: lines.join("\n"), changes };
+}
+
+/**
+ * Rewrite IDs inside YAML frontmatter (delimited by `---` lines):
+ *   - `node_id: "doc:xxx"`
+ *   - `id: "doc:xxx"` or `id: "REQ-001"` inside `depends_on` arrays
+ *
+ * Uses line-level string replacement to avoid YAML re-serialization and
+ * the format changes it would introduce.
+ */
+export function rewriteFrontmatter(
+  content: string,
+  oldId: string,
+  newId: string,
+): RewriteResult {
+  const lines = content.split("\n");
+  const changes: RewriteChange[] = [];
+
+  // Locate frontmatter boundaries.
+  let fmStart = -1;
+  let fmEnd = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].trim() === "---") {
+      if (fmStart === -1) {
+        fmStart = i;
+      } else {
+        fmEnd = i;
+        break;
+      }
+    }
+  }
+
+  if (fmStart === -1 || fmEnd === -1) return { content, changes };
+
+  const escaped = escapeRegExp(oldId);
+
+  // Patterns to match inside frontmatter lines:
+  //   node_id: "doc:xxx"  or  node_id: doc:xxx
+  //   id: "REQ-001"       or  id: REQ-001
+  const nodeIdRe = new RegExp(
+    `^(\\s*node_id:\\s*["']?)${escaped}(["']?\\s*)$`,
+  );
+  const idRe = new RegExp(
+    `^(\\s*(?:-\\s+)?id:\\s*["']?)${escaped}(["']?\\s*)$`,
+  );
+
+  for (let i = fmStart + 1; i < fmEnd; i++) {
+    const nodeIdMatch = lines[i].match(nodeIdRe);
+    const idMatch = lines[i].match(idRe);
+
+    if (!nodeIdMatch && !idMatch) continue;
+
+    const before = lines[i];
+    const m = (nodeIdMatch ?? idMatch)!;
+    lines[i] = m[1] + newId + m[2];
+
+    changes.push({
+      filePath: "",
+      line: i + 1,
+      kind: "frontmatter-depends-on",
+      before,
+      after: lines[i],
+    });
+  }
+
+  return { content: lines.join("\n"), changes };
+}
+
+// ── Orchestrator ─────────────────────────────────────────────────────
+
+/**
+ * Apply the appropriate rewriters for the given file type and stamp each
+ * returned `RewriteChange` with the provided `filePath`.
+ */
+export function rewriteFile(
+  filePath: string,
+  content: string,
+  oldId: string,
+  newId: string,
+): RewriteResult {
+  const ext = extOf(filePath);
+  const allChanges: RewriteChange[] = [];
+  let current = content;
+
+  const apply = (fn: (c: string, o: string, n: string) => RewriteResult) => {
+    const result = fn(current, oldId, newId);
+    current = result.content;
+    allChanges.push(...result.changes);
+  };
+
+  if (ext === ".md") {
+    apply(rewriteSpecListItem);
+    apply(rewriteSpecHeading);
+    apply(rewriteFrontmatter);
+  } else if (
+    ext === ".ts" ||
+    ext === ".tsx" ||
+    ext === ".js" ||
+    ext === ".jsx"
+  ) {
+    apply(rewriteImplTags);
+    apply(rewriteTestTags);
+  }
+
+  // Stamp filePath on every change.
+  for (const change of allChanges) {
+    change.filePath = filePath;
+  }
+
+  return { content: current, changes: allChanges };
+}
+
+function extOf(filePath: string): string {
+  const dot = filePath.lastIndexOf(".");
+  return dot === -1 ? "" : filePath.slice(dot).toLowerCase();
+}

--- a/tests/fixtures/rename/.spectrace.json
+++ b/tests/fixtures/rename/.spectrace.json
@@ -1,0 +1,6 @@
+{
+  "include": ["src/**/*.ts"],
+  "specDirs": ["specs"],
+  "testPatterns": ["tests/**/*.test.ts"],
+  "lockFile": ".trace.lock"
+}

--- a/tests/fixtures/rename/.trace.lock
+++ b/tests/fixtures/rename/.trace.lock
@@ -1,0 +1,35 @@
+{
+  "REQ-001": {
+    "specFile": "specs/feature.md",
+    "contentHash": "abc123def456",
+    "impl": [
+      "src/feature.ts"
+    ],
+    "tests": [
+      "tests/feature.test.ts"
+    ],
+    "lastReconciled": "2025-01-01T00:00:00.000Z"
+  },
+  "REQ-002": {
+    "specFile": "specs/feature.md",
+    "contentHash": "789ghi012jkl",
+    "impl": [
+      "src/feature.ts"
+    ],
+    "tests": [
+      "tests/feature.test.ts"
+    ],
+    "dependsOn": [
+      "REQ-001"
+    ],
+    "lastReconciled": "2025-01-01T00:00:00.000Z"
+  },
+  "doc:feature-overview": {
+    "specFile": "specs/feature.md",
+    "contentHash": "mno345pqr678",
+    "dependsOn": [
+      "REQ-002"
+    ],
+    "lastReconciled": "2025-01-01T00:00:00.000Z"
+  }
+}

--- a/tests/fixtures/rename/specs/feature.md
+++ b/tests/fixtures/rename/specs/feature.md
@@ -1,0 +1,21 @@
+---
+spectrace:
+  node_id: "doc:feature-overview"
+  depends_on:
+    - { id: "REQ-002", relation: implements }
+---
+
+# Feature Overview
+
+## Requirements
+
+- REQ-001: ユーザー認証
+  - メールとパスワードで認証できること
+  - 認証失敗時にエラーを返すこと
+
+- REQ-002: ユーザー登録
+  - メールアドレスで新規登録できること
+
+## Notes
+
+REQ-001 は認証基盤の中核要件として最初に策定された。

--- a/tests/fixtures/rename/src/feature.ts
+++ b/tests/fixtures/rename/src/feature.ts
@@ -1,0 +1,14 @@
+// @impl REQ-001
+export function authenticate(email: string, password: string): boolean {
+  return email.length > 0 && password.length > 0;
+}
+
+// @impl REQ-001 REQ-002
+export function registerAndLogin(email: string, password: string): string {
+  return `session_${email}`;
+}
+
+// This relates to REQ-001 but is not an impl tag
+export function helperUtil(): void {
+  // no-op
+}

--- a/tests/fixtures/rename/tests/feature.test.ts
+++ b/tests/fixtures/rename/tests/feature.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+
+describe("[REQ-001] ユーザー認証", () => {
+  it("should verify [REQ-001]", () => {
+    expect(true).toBe(true);
+  });
+});
+
+// req: "REQ-002"
+describe("[REQ-002] ユーザー登録", () => {
+  it("should register user", () => {
+    expect(true).toBe(true);
+  });
+});

--- a/tests/fixtures/rename/tsconfig.json
+++ b/tests/fixtures/rename/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/tests/fixtures/specs/metadata-coerce.md
+++ b/tests/fixtures/specs/metadata-coerce.md
@@ -1,0 +1,13 @@
+---
+title: 123
+status: true
+priority: 2
+spectrace:
+  node_id: "doc:meta-coerce"
+---
+
+# Metadata Coercion
+
+## Requirements
+
+- COERCE-001: non-string frontmatter values are coerced to strings

--- a/tests/rename-cli.test.ts
+++ b/tests/rename-cli.test.ts
@@ -16,19 +16,26 @@ const RENAME_FIXTURE = resolve(import.meta.dirname, "fixtures/rename");
 /** Temp dirs created during tests — cleaned up in afterEach. */
 const tempDirs: string[] = [];
 
+function gitCommit(cwd: string, message: string): void {
+  execFileSync("git", ["add", "-A"], { cwd, stdio: "pipe" });
+  execFileSync(
+    "git",
+    ["-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", message],
+    { cwd, stdio: "pipe" },
+  );
+}
+
 /**
- * Copy the rename fixture into a fresh temp directory,
- * seed a .spectrace.json, generate .trace.lock via reconcile,
- * and initialise a git repo so `git ls-files` works.
+ * Copy the rename fixture into a fresh temp directory, seed a .spectrace.json,
+ * generate .trace.lock via reconcile, and initialise a git repo so
+ * `git ls-files` works.
  */
 function prepareTempDir(): string {
   const tmp = mkdtempSync(resolve(tmpdir(), "spectrace-rename-cli-"));
   tempDirs.push(tmp);
 
-  // Copy fixture files
   cpSync(RENAME_FIXTURE, tmp, { recursive: true });
 
-  // Create .spectrace.json
   writeFileSync(
     resolve(tmp, ".spectrace.json"),
     JSON.stringify({
@@ -39,29 +46,12 @@ function prepareTempDir(): string {
     }),
   );
 
-  // Initialise git repo so git ls-files works
   execFileSync("git", ["init"], { cwd: tmp, stdio: "pipe" });
-  execFileSync("git", ["add", "."], { cwd: tmp, stdio: "pipe" });
-  execFileSync(
-    "git",
-    ["-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", "init"],
-    { cwd: tmp, stdio: "pipe" },
-  );
+  gitCommit(tmp, "init");
 
-  // Generate .trace.lock via reconcile
-  execFileSync("node", [CLI, "reconcile"], {
-    cwd: tmp,
-    encoding: "utf-8",
-    timeout: 30000,
-  });
-
-  // Commit the lock file so it is tracked
-  execFileSync("git", ["add", ".trace.lock"], { cwd: tmp, stdio: "pipe" });
-  execFileSync(
-    "git",
-    ["-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", "add lock"],
-    { cwd: tmp, stdio: "pipe" },
-  );
+  // Generate .trace.lock via reconcile, then commit it so it is tracked.
+  execFileSync("node", [CLI, "reconcile"], { cwd: tmp, encoding: "utf-8", timeout: 30000 });
+  gitCommit(tmp, "add lock");
 
   return tmp;
 }
@@ -86,6 +76,23 @@ function runCli(
   }
 }
 
+/** Run `spectrace check --format json` and return the parsed result. */
+function runCheck(cwd: string): {
+  drifted: unknown[];
+  orphans: unknown[];
+  uncovered: unknown[];
+  pass: boolean;
+} {
+  const { stdout } = runCli(["check", "--format", "json"], cwd);
+  return JSON.parse(stdout);
+}
+
+function snapshot(tmp: string, files: string[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const f of files) out[f] = readFileSync(resolve(tmp, f), "utf-8");
+  return out;
+}
+
 afterEach(() => {
   for (const dir of tempDirs) {
     rmSync(dir, { recursive: true, force: true });
@@ -103,38 +110,45 @@ describe("CLI: rename --from/--to", () => {
     const { exitCode } = runCli(["rename", "--from", "REQ-001", "--to", "REQ-100"], tmp);
     expect(exitCode).toBe(0);
 
-    // specs/feature.md: list item rewritten
     const spec = readFileSync(resolve(tmp, "specs/feature.md"), "utf-8");
     expect(spec).toContain("REQ-100: ユーザー認証");
     expect(spec).not.toMatch(/^- REQ-001:/m);
 
-    // src/feature.ts: @impl tags rewritten
     const src = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
     expect(src).toContain("@impl REQ-100");
     expect(src).not.toContain("@impl REQ-001");
 
-    // tests/feature.test.ts: test tags rewritten
     const test = readFileSync(resolve(tmp, "tests/feature.test.ts"), "utf-8");
     expect(test).toContain("[REQ-100]");
     expect(test).not.toContain("[REQ-001]");
 
-    // .trace.lock: key renamed, dependsOn updated
     const lock = JSON.parse(readFileSync(resolve(tmp, ".trace.lock"), "utf-8"));
     expect(lock["REQ-100"]).toBeDefined();
     expect(lock["REQ-001"]).toBeUndefined();
 
-    // FR-007: normal sentence mention should NOT be changed
+    // Non-target references must be preserved: REQ-002 untouched and a prose
+    // mention of REQ-001 (not a tracked reference) is left as-is.
+    expect(spec).toContain("- REQ-002: ユーザー登録");
     expect(spec).toContain("REQ-001 は認証基盤の中核要件として");
+  });
+
+  it("leaves the lock drift-free so `check` passes afterwards (F1)", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+    const before = runCheck(tmp);
+    expect(before.pass).toBe(true);
+
+    const { exitCode } = runCli(["rename", "--from", "REQ-001", "--to", "REQ-100"], tmp);
+    expect(exitCode).toBe(0);
+
+    const after = runCheck(tmp);
+    expect(after.drifted).toEqual([]);
+    expect(after.pass).toBe(true);
   });
 
   it("should not modify files when --dry-run is used", { timeout: 30000 }, () => {
     const tmp = prepareTempDir();
-
-    // Snapshot originals
-    const origSpec = readFileSync(resolve(tmp, "specs/feature.md"), "utf-8");
-    const origSrc = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
-    const origTest = readFileSync(resolve(tmp, "tests/feature.test.ts"), "utf-8");
-    const origLock = readFileSync(resolve(tmp, ".trace.lock"), "utf-8");
+    const files = ["specs/feature.md", "src/feature.ts", "tests/feature.test.ts", ".trace.lock"];
+    const orig = snapshot(tmp, files);
 
     const { exitCode, stdout } = runCli(
       ["rename", "--from", "REQ-001", "--to", "REQ-100", "--dry-run"],
@@ -143,11 +157,7 @@ describe("CLI: rename --from/--to", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("dry-run");
 
-    // All files must remain unchanged
-    expect(readFileSync(resolve(tmp, "specs/feature.md"), "utf-8")).toBe(origSpec);
-    expect(readFileSync(resolve(tmp, "src/feature.ts"), "utf-8")).toBe(origSrc);
-    expect(readFileSync(resolve(tmp, "tests/feature.test.ts"), "utf-8")).toBe(origTest);
-    expect(readFileSync(resolve(tmp, ".trace.lock"), "utf-8")).toBe(origLock);
+    expect(snapshot(tmp, files)).toEqual(orig);
   });
 
   it("should output valid JSON with --format json", { timeout: 30000 }, () => {
@@ -161,32 +171,50 @@ describe("CLI: rename --from/--to", () => {
 
     const result = JSON.parse(stdout);
     expect(result.operation).toBe("rename");
-    expect(result.changes).toBeDefined();
+    expect(result.from).toBe("REQ-001");
+    expect(result.to).toBe("REQ-100");
     expect(Array.isArray(result.changes)).toBe(true);
     expect(result.changes.length).toBeGreaterThan(0);
     expect(result.applied).toBe(true);
   });
 
-  it("should fail when source ID does not exist", { timeout: 30000 }, () => {
+  it("emits JSON on the error path with --format json (F7)", { timeout: 30000 }, () => {
     const tmp = prepareTempDir();
-
     const { exitCode, stderr } = runCli(
-      ["rename", "--from", "NONEXISTENT", "--to", "REQ-100"],
+      ["rename", "--from", "NONEXISTENT", "--to", "REQ-100", "--format", "json"],
       tmp,
     );
+    expect(exitCode).not.toBe(0);
+    expect(() => JSON.parse(stderr)).not.toThrow();
+    expect(JSON.parse(stderr).error).toContain("NONEXISTENT");
+  });
+
+  it("should fail when source ID does not exist", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+    const { exitCode, stderr } = runCli(["rename", "--from", "NONEXISTENT", "--to", "REQ-100"], tmp);
     expect(exitCode).not.toBe(0);
     expect(stderr).toContain("NONEXISTENT");
   });
 
   it("should fail when target ID already exists", { timeout: 30000 }, () => {
     const tmp = prepareTempDir();
-
-    const { exitCode, stderr } = runCli(
-      ["rename", "--from", "REQ-001", "--to", "REQ-002"],
-      tmp,
-    );
+    const { exitCode, stderr } = runCli(["rename", "--from", "REQ-001", "--to", "REQ-002"], tmp);
     expect(exitCode).not.toBe(0);
     expect(stderr).toContain("REQ-002");
+  });
+
+  it("rejects an invalid target ID (F2)", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+    const { exitCode, stderr } = runCli(["rename", "--from", "REQ-001", "--to", "REQ-001a"], tmp);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/invalid target id/i);
+  });
+
+  it("rejects a self-rename (F9)", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+    const { exitCode, stderr } = runCli(["rename", "--from", "REQ-001", "--to", "REQ-001"], tmp);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/identical/i);
   });
 });
 
@@ -194,34 +222,79 @@ describe("CLI: rename --from/--to", () => {
 // split
 // ---------------------------------------------------------------------------
 describe("CLI: rename --split/--into", () => {
-  it("should split REQ-001 into REQ-001a and REQ-001b", { timeout: 30000 }, () => {
+  it("should split REQ-001 into REQ-101 and REQ-102", { timeout: 30000 }, () => {
     const tmp = prepareTempDir();
 
     const { exitCode, stdout, stderr } = runCli(
-      ["rename", "--split", "REQ-001", "--into", "REQ-001a", "REQ-001b"],
+      ["rename", "--split", "REQ-001", "--into", "REQ-101", "REQ-102"],
       tmp,
     );
     expect(exitCode).toBe(0);
 
-    // specs/feature.md: old list item removed, scaffolds appended
     const spec = readFileSync(resolve(tmp, "specs/feature.md"), "utf-8");
     expect(spec).not.toMatch(/^- REQ-001:/m);
-    expect(spec).toContain("REQ-001a");
-    expect(spec).toContain("REQ-001b");
+    expect(spec).toContain("REQ-101");
+    expect(spec).toContain("REQ-102");
 
-    // src/feature.ts: @impl REQ-001 should NOT be rewritten (manual assignment needed)
+    // @impl REQ-001 should NOT be rewritten (manual assignment needed).
     const src = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
     expect(src).toContain("@impl REQ-001");
+    expect(stdout + stderr).toMatch(/manual.*assignment|WARNING/i);
 
-    // Warning about manual assignment in stdout or stderr
-    const combined = stdout + stderr;
-    expect(combined).toMatch(/manual.*assignment|WARNING/i);
-
-    // .trace.lock: REQ-001 deleted, new IDs created
     const lock = JSON.parse(readFileSync(resolve(tmp, ".trace.lock"), "utf-8"));
     expect(lock["REQ-001"]).toBeUndefined();
-    expect(lock["REQ-001a"]).toBeDefined();
-    expect(lock["REQ-001b"]).toBeDefined();
+    expect(lock["REQ-101"]).toBeDefined();
+    expect(lock["REQ-102"]).toBeDefined();
+  });
+
+  it("leaves no drift after split (new IDs are uncovered, not drifted)", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+    const { exitCode } = runCli(
+      ["rename", "--split", "REQ-001", "--into", "REQ-101", "REQ-102"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+
+    const after = runCheck(tmp);
+    // contentHash drift must be gone …
+    expect(after.drifted).toEqual([]);
+    // … but the freshly-scaffolded IDs are legitimately uncovered until @impl
+    // tags are assigned manually.
+    expect(after.uncovered).toContain("REQ-101");
+    expect(after.uncovered).toContain("REQ-102");
+  });
+
+  it("does not modify files with --dry-run", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+    const files = ["specs/feature.md", "src/feature.ts", "tests/feature.test.ts", ".trace.lock"];
+    const orig = snapshot(tmp, files);
+
+    const { exitCode } = runCli(
+      ["rename", "--split", "REQ-001", "--into", "REQ-101", "REQ-102", "--dry-run"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+    expect(snapshot(tmp, files)).toEqual(orig);
+  });
+
+  it("rejects duplicate --into targets (M2)", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+    const { exitCode, stderr } = runCli(
+      ["rename", "--split", "REQ-001", "--into", "REQ-101", "REQ-101"],
+      tmp,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/duplicate/i);
+  });
+
+  it("rejects an invalid split target (F2)", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+    const { exitCode, stderr } = runCli(
+      ["rename", "--split", "REQ-001", "--into", "REQ-001a", "REQ-001b"],
+      tmp,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/invalid target id/i);
   });
 });
 
@@ -229,31 +302,97 @@ describe("CLI: rename --split/--into", () => {
 // merge
 // ---------------------------------------------------------------------------
 describe("CLI: rename --merge/--into", () => {
-  it("should merge REQ-001 and REQ-002 into REQ-COMBINED", { timeout: 30000 }, () => {
+  it("should merge REQ-001 and REQ-002 into REQ-100 without duplicating it (C1)", { timeout: 30000 }, () => {
     const tmp = prepareTempDir();
 
     const { exitCode } = runCli(
-      ["rename", "--merge", "REQ-001", "REQ-002", "--into", "REQ-COMBINED"],
+      ["rename", "--merge", "REQ-001", "REQ-002", "--into", "REQ-100"],
       tmp,
     );
     expect(exitCode).toBe(0);
 
-    // All references replaced with REQ-COMBINED
+    const spec = readFileSync(resolve(tmp, "specs/feature.md"), "utf-8");
     const src = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
     const test = readFileSync(resolve(tmp, "tests/feature.test.ts"), "utf-8");
 
-    // Source files should have REQ-COMBINED
-    expect(src).toContain("@impl REQ-COMBINED");
-    expect(test).toContain("[REQ-COMBINED]");
-
-    // Old IDs should no longer appear in @impl or test tags
+    expect(src).toContain("@impl REQ-100");
+    expect(test).toContain("[REQ-100]");
     expect(src).not.toContain("@impl REQ-001");
     expect(src).not.toContain("@impl REQ-002");
 
-    // .trace.lock: old IDs deleted, REQ-COMBINED created
+    // C1: the merge target must appear exactly once as a definition list item.
+    const defLines = spec.split("\n").filter((l) => /^- REQ-100:/.test(l));
+    expect(defLines).toHaveLength(1);
+    // Old definitions are gone.
+    expect(spec).not.toMatch(/^- REQ-001:/m);
+    expect(spec).not.toMatch(/^- REQ-002:/m);
+
     const lock = JSON.parse(readFileSync(resolve(tmp, ".trace.lock"), "utf-8"));
     expect(lock["REQ-001"]).toBeUndefined();
     expect(lock["REQ-002"]).toBeUndefined();
-    expect(lock["REQ-COMBINED"]).toBeDefined();
+    expect(lock["REQ-100"]).toBeDefined();
+  });
+
+  it("leaves the lock drift-free so `check` passes after merge (F1/C2/H5)", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+    const { exitCode } = runCli(
+      ["rename", "--merge", "REQ-001", "REQ-002", "--into", "REQ-100"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+
+    const after = runCheck(tmp);
+    expect(after.drifted).toEqual([]);
+    expect(after.pass).toBe(true);
+  });
+
+  it("does not modify files with --dry-run", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+    const files = ["specs/feature.md", "src/feature.ts", "tests/feature.test.ts", ".trace.lock"];
+    const orig = snapshot(tmp, files);
+
+    const { exitCode } = runCli(
+      ["rename", "--merge", "REQ-001", "REQ-002", "--into", "REQ-100", "--dry-run"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+    expect(snapshot(tmp, files)).toEqual(orig);
+  });
+
+  it("rejects an invalid merge target (F2)", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+    const { exitCode, stderr } = runCli(
+      ["rename", "--merge", "REQ-001", "REQ-002", "--into", "REQ-COMBINED"],
+      tmp,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/invalid target id/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// non-ASCII paths (H4)
+// ---------------------------------------------------------------------------
+describe("CLI: rename across non-ASCII paths", () => {
+  it("rewrites references inside files with non-ASCII names", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+
+    // Add a second spec file whose name is non-ASCII; git ls-files would
+    // octal-quote it without the -z / core.quotePath=false guard.
+    writeFileSync(
+      resolve(tmp, "specs/要件.md"),
+      ["# 追加仕様", "", "- REQ-003: 追加要件", ""].join("\n"),
+      "utf-8",
+    );
+    gitCommit(tmp, "add non-ascii spec");
+    execFileSync("node", [CLI, "reconcile"], { cwd: tmp, encoding: "utf-8", timeout: 30000 });
+    gitCommit(tmp, "reconcile");
+
+    const { exitCode } = runCli(["rename", "--from", "REQ-003", "--to", "REQ-300"], tmp);
+    expect(exitCode).toBe(0);
+
+    const spec = readFileSync(resolve(tmp, "specs/要件.md"), "utf-8");
+    expect(spec).toContain("- REQ-300: 追加要件");
+    expect(spec).not.toContain("REQ-003");
   });
 });

--- a/tests/rename-cli.test.ts
+++ b/tests/rename-cli.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import {
+  mkdtempSync,
+  cpSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { CLI } from "./helpers.js";
+
+const RENAME_FIXTURE = resolve(import.meta.dirname, "fixtures/rename");
+
+/** Temp dirs created during tests — cleaned up in afterEach. */
+const tempDirs: string[] = [];
+
+/**
+ * Copy the rename fixture into a fresh temp directory,
+ * seed a .spectrace.json, generate .trace.lock via reconcile,
+ * and initialise a git repo so `git ls-files` works.
+ */
+function prepareTempDir(): string {
+  const tmp = mkdtempSync(resolve(tmpdir(), "spectrace-rename-cli-"));
+  tempDirs.push(tmp);
+
+  // Copy fixture files
+  cpSync(RENAME_FIXTURE, tmp, { recursive: true });
+
+  // Create .spectrace.json
+  writeFileSync(
+    resolve(tmp, ".spectrace.json"),
+    JSON.stringify({
+      include: ["src/**/*.ts"],
+      specDirs: ["specs"],
+      testPatterns: ["tests/**/*.test.ts"],
+      lockFile: ".trace.lock",
+    }),
+  );
+
+  // Initialise git repo so git ls-files works
+  execFileSync("git", ["init"], { cwd: tmp, stdio: "pipe" });
+  execFileSync("git", ["add", "."], { cwd: tmp, stdio: "pipe" });
+  execFileSync(
+    "git",
+    ["-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", "init"],
+    { cwd: tmp, stdio: "pipe" },
+  );
+
+  // Generate .trace.lock via reconcile
+  execFileSync("node", [CLI, "reconcile"], {
+    cwd: tmp,
+    encoding: "utf-8",
+    timeout: 30000,
+  });
+
+  // Commit the lock file so it is tracked
+  execFileSync("git", ["add", ".trace.lock"], { cwd: tmp, stdio: "pipe" });
+  execFileSync(
+    "git",
+    ["-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", "add lock"],
+    { cwd: tmp, stdio: "pipe" },
+  );
+
+  return tmp;
+}
+
+function runCli(
+  args: string[],
+  cwd: string,
+): { stdout: string; stderr: string; exitCode: number } {
+  try {
+    const stdout = execFileSync("node", [CLI, ...args], {
+      encoding: "utf-8",
+      cwd,
+      timeout: 30000,
+    });
+    return { stdout, stderr: "", exitCode: 0 };
+  } catch (e: any) {
+    return {
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? "",
+      exitCode: e.status ?? 1,
+    };
+  }
+}
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs.length = 0;
+});
+
+// ---------------------------------------------------------------------------
+// rename
+// ---------------------------------------------------------------------------
+describe("CLI: rename --from/--to", () => {
+  it("should rename REQ-001 to REQ-100 across all files", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+
+    const { exitCode } = runCli(["rename", "--from", "REQ-001", "--to", "REQ-100"], tmp);
+    expect(exitCode).toBe(0);
+
+    // specs/feature.md: list item rewritten
+    const spec = readFileSync(resolve(tmp, "specs/feature.md"), "utf-8");
+    expect(spec).toContain("REQ-100: ユーザー認証");
+    expect(spec).not.toMatch(/^- REQ-001:/m);
+
+    // src/feature.ts: @impl tags rewritten
+    const src = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
+    expect(src).toContain("@impl REQ-100");
+    expect(src).not.toContain("@impl REQ-001");
+
+    // tests/feature.test.ts: test tags rewritten
+    const test = readFileSync(resolve(tmp, "tests/feature.test.ts"), "utf-8");
+    expect(test).toContain("[REQ-100]");
+    expect(test).not.toContain("[REQ-001]");
+
+    // .trace.lock: key renamed, dependsOn updated
+    const lock = JSON.parse(readFileSync(resolve(tmp, ".trace.lock"), "utf-8"));
+    expect(lock["REQ-100"]).toBeDefined();
+    expect(lock["REQ-001"]).toBeUndefined();
+
+    // FR-007: normal sentence mention should NOT be changed
+    expect(spec).toContain("REQ-001 は認証基盤の中核要件として");
+  });
+
+  it("should not modify files when --dry-run is used", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+
+    // Snapshot originals
+    const origSpec = readFileSync(resolve(tmp, "specs/feature.md"), "utf-8");
+    const origSrc = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
+    const origTest = readFileSync(resolve(tmp, "tests/feature.test.ts"), "utf-8");
+    const origLock = readFileSync(resolve(tmp, ".trace.lock"), "utf-8");
+
+    const { exitCode, stdout } = runCli(
+      ["rename", "--from", "REQ-001", "--to", "REQ-100", "--dry-run"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("dry-run");
+
+    // All files must remain unchanged
+    expect(readFileSync(resolve(tmp, "specs/feature.md"), "utf-8")).toBe(origSpec);
+    expect(readFileSync(resolve(tmp, "src/feature.ts"), "utf-8")).toBe(origSrc);
+    expect(readFileSync(resolve(tmp, "tests/feature.test.ts"), "utf-8")).toBe(origTest);
+    expect(readFileSync(resolve(tmp, ".trace.lock"), "utf-8")).toBe(origLock);
+  });
+
+  it("should output valid JSON with --format json", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+
+    const { exitCode, stdout } = runCli(
+      ["rename", "--from", "REQ-001", "--to", "REQ-100", "--format", "json"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+
+    const result = JSON.parse(stdout);
+    expect(result.operation).toBe("rename");
+    expect(result.changes).toBeDefined();
+    expect(Array.isArray(result.changes)).toBe(true);
+    expect(result.changes.length).toBeGreaterThan(0);
+    expect(result.applied).toBe(true);
+  });
+
+  it("should fail when source ID does not exist", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+
+    const { exitCode, stderr } = runCli(
+      ["rename", "--from", "NONEXISTENT", "--to", "REQ-100"],
+      tmp,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("NONEXISTENT");
+  });
+
+  it("should fail when target ID already exists", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+
+    const { exitCode, stderr } = runCli(
+      ["rename", "--from", "REQ-001", "--to", "REQ-002"],
+      tmp,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("REQ-002");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// split
+// ---------------------------------------------------------------------------
+describe("CLI: rename --split/--into", () => {
+  it("should split REQ-001 into REQ-001a and REQ-001b", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+
+    const { exitCode, stdout, stderr } = runCli(
+      ["rename", "--split", "REQ-001", "--into", "REQ-001a", "REQ-001b"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+
+    // specs/feature.md: old list item removed, scaffolds appended
+    const spec = readFileSync(resolve(tmp, "specs/feature.md"), "utf-8");
+    expect(spec).not.toMatch(/^- REQ-001:/m);
+    expect(spec).toContain("REQ-001a");
+    expect(spec).toContain("REQ-001b");
+
+    // src/feature.ts: @impl REQ-001 should NOT be rewritten (manual assignment needed)
+    const src = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
+    expect(src).toContain("@impl REQ-001");
+
+    // Warning about manual assignment in stdout or stderr
+    const combined = stdout + stderr;
+    expect(combined).toMatch(/manual.*assignment|WARNING/i);
+
+    // .trace.lock: REQ-001 deleted, new IDs created
+    const lock = JSON.parse(readFileSync(resolve(tmp, ".trace.lock"), "utf-8"));
+    expect(lock["REQ-001"]).toBeUndefined();
+    expect(lock["REQ-001a"]).toBeDefined();
+    expect(lock["REQ-001b"]).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// merge
+// ---------------------------------------------------------------------------
+describe("CLI: rename --merge/--into", () => {
+  it("should merge REQ-001 and REQ-002 into REQ-COMBINED", { timeout: 30000 }, () => {
+    const tmp = prepareTempDir();
+
+    const { exitCode } = runCli(
+      ["rename", "--merge", "REQ-001", "REQ-002", "--into", "REQ-COMBINED"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+
+    // All references replaced with REQ-COMBINED
+    const src = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
+    const test = readFileSync(resolve(tmp, "tests/feature.test.ts"), "utf-8");
+
+    // Source files should have REQ-COMBINED
+    expect(src).toContain("@impl REQ-COMBINED");
+    expect(test).toContain("[REQ-COMBINED]");
+
+    // Old IDs should no longer appear in @impl or test tags
+    expect(src).not.toContain("@impl REQ-001");
+    expect(src).not.toContain("@impl REQ-002");
+
+    // .trace.lock: old IDs deleted, REQ-COMBINED created
+    const lock = JSON.parse(readFileSync(resolve(tmp, ".trace.lock"), "utf-8"));
+    expect(lock["REQ-001"]).toBeUndefined();
+    expect(lock["REQ-002"]).toBeUndefined();
+    expect(lock["REQ-COMBINED"]).toBeDefined();
+  });
+});

--- a/tests/rename.test.ts
+++ b/tests/rename.test.ts
@@ -1,0 +1,480 @@
+import { describe, it, expect } from "vitest";
+import {
+  rewriteSpecListItem,
+  rewriteSpecHeading,
+  rewriteImplTags,
+  rewriteTestTags,
+  rewriteFrontmatter,
+  rewriteFile,
+} from "../src/rename.js";
+import {
+  renameLockKey,
+  splitLockKey,
+  mergeLockKeys,
+} from "../src/rename-lock.js";
+import type { LockFile } from "../src/types.js";
+
+// ── rewriteSpecListItem ─────────────────────────────────────────────
+
+describe("rewriteSpecListItem", () => {
+  it("rewrites plain list item ID", () => {
+    const input = "- REQ-001: user login flow";
+    const { content, changes } = rewriteSpecListItem(input, "REQ-001", "REQ-100");
+    expect(content).toBe("- REQ-100: user login flow");
+    expect(changes).toHaveLength(1);
+    expect(changes[0].kind).toBe("spec-list-item");
+  });
+
+  it("rewrites bold-formatted list item ID", () => {
+    const input = "- **REQ-001**: user login flow";
+    const { content, changes } = rewriteSpecListItem(input, "REQ-001", "REQ-100");
+    expect(content).toBe("- **REQ-100**: user login flow");
+    expect(changes).toHaveLength(1);
+  });
+
+  it("does NOT rewrite ID in normal text (not a list item)", () => {
+    const input = "This paragraph references REQ-001 for context.";
+    const { content, changes } = rewriteSpecListItem(input, "REQ-001", "REQ-100");
+    expect(content).toBe(input);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("rewrites multiple occurrences in the same file", () => {
+    const input = [
+      "- REQ-001: first item",
+      "Some text in between",
+      "- REQ-001: second item",
+    ].join("\n");
+    const { content, changes } = rewriteSpecListItem(input, "REQ-001", "REQ-100");
+    expect(content).toBe(
+      [
+        "- REQ-100: first item",
+        "Some text in between",
+        "- REQ-100: second item",
+      ].join("\n"),
+    );
+    expect(changes).toHaveLength(2);
+  });
+
+  it("handles namespace-qualified ID", () => {
+    const input = "- 001-auth/FR-001: auth feature";
+    const { content, changes } = rewriteSpecListItem(
+      input,
+      "001-auth/FR-001",
+      "001-auth/FR-010",
+    );
+    expect(content).toBe("- 001-auth/FR-010: auth feature");
+    expect(changes).toHaveLength(1);
+  });
+});
+
+// ── rewriteSpecHeading ──────────────────────────────────────────────
+
+describe("rewriteSpecHeading", () => {
+  it("rewrites Requirement N heading", () => {
+    const input = "### Requirement 1: Login must use OAuth";
+    const { content, changes } = rewriteSpecHeading(
+      input,
+      "Requirement-1",
+      "Requirement-10",
+    );
+    expect(content).toBe("### Requirement 10: Login must use OAuth");
+    expect(changes).toHaveLength(1);
+    expect(changes[0].kind).toBe("spec-heading");
+  });
+
+  it("returns unchanged content when oldId is not Requirement-N format", () => {
+    const input = "### Some Heading";
+    const { content, changes } = rewriteSpecHeading(input, "REQ-001", "REQ-100");
+    expect(content).toBe(input);
+    expect(changes).toHaveLength(0);
+  });
+});
+
+// ── rewriteImplTags ─────────────────────────────────────────────────
+
+describe("rewriteImplTags", () => {
+  it("rewrites single @impl tag", () => {
+    const input = "// @impl REQ-001";
+    const { content, changes } = rewriteImplTags(input, "REQ-001", "REQ-100");
+    expect(content).toBe("// @impl REQ-100");
+    expect(changes).toHaveLength(1);
+    expect(changes[0].kind).toBe("impl-tag");
+  });
+
+  it("replaces only the target ID in a multi-ID @impl line", () => {
+    const input = "// @impl REQ-001 REQ-002";
+    const { content, changes } = rewriteImplTags(input, "REQ-001", "REQ-100");
+    expect(content).toBe("// @impl REQ-100 REQ-002");
+    expect(changes).toHaveLength(1);
+  });
+
+  it("does NOT rewrite non-@impl comments", () => {
+    const input = "// This relates to REQ-001";
+    const { content, changes } = rewriteImplTags(input, "REQ-001", "REQ-100");
+    expect(content).toBe(input);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("handles doc:auth format ID", () => {
+    const input = "// @impl doc:auth";
+    const { content, changes } = rewriteImplTags(input, "doc:auth", "doc:auth-v2");
+    expect(content).toBe("// @impl doc:auth-v2");
+    expect(changes).toHaveLength(1);
+  });
+});
+
+// ── rewriteTestTags ─────────────────────────────────────────────────
+
+describe("rewriteTestTags", () => {
+  it("rewrites bracket-wrapped ID", () => {
+    const input = 'it("[REQ-001] should validate email", () => {});';
+    const { content, changes } = rewriteTestTags(input, "REQ-001", "REQ-100");
+    expect(content).toBe('it("[REQ-100] should validate email", () => {});');
+    expect(changes).toHaveLength(1);
+    expect(changes[0].kind).toBe("test-tag");
+  });
+
+  it("rewrites req annotation pattern", () => {
+    const input = 'req: "REQ-001"';
+    const { content, changes } = rewriteTestTags(input, "REQ-001", "REQ-100");
+    expect(content).toBe('req: "REQ-100"');
+    expect(changes).toHaveLength(1);
+  });
+
+  it("handles case-insensitive prefixes", () => {
+    const input1 = 'Req: "REQ-001"';
+    const input2 = 'requirement: "REQ-001"';
+    const input3 = 'spec: "REQ-001"';
+
+    expect(rewriteTestTags(input1, "REQ-001", "REQ-100").content).toBe(
+      'Req: "REQ-100"',
+    );
+    expect(rewriteTestTags(input2, "REQ-001", "REQ-100").content).toBe(
+      'requirement: "REQ-100"',
+    );
+    expect(rewriteTestTags(input3, "REQ-001", "REQ-100").content).toBe(
+      'spec: "REQ-100"',
+    );
+  });
+});
+
+// ── rewriteFrontmatter ──────────────────────────────────────────────
+
+describe("rewriteFrontmatter", () => {
+  it("rewrites node_id inside frontmatter", () => {
+    const input = [
+      "---",
+      'node_id: "doc:old"',
+      "---",
+      "# Body content",
+    ].join("\n");
+    const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
+    expect(content).toBe(
+      [
+        "---",
+        'node_id: "doc:new"',
+        "---",
+        "# Body content",
+      ].join("\n"),
+    );
+    expect(changes).toHaveLength(1);
+    expect(changes[0].kind).toBe("frontmatter-depends-on");
+  });
+
+  it("rewrites id inside depends_on in frontmatter", () => {
+    const input = [
+      "---",
+      "depends_on:",
+      '  - id: "REQ-001"',
+      "---",
+      "# Body",
+    ].join("\n");
+    const { content, changes } = rewriteFrontmatter(input, "REQ-001", "REQ-100");
+    expect(content).toBe(
+      [
+        "---",
+        "depends_on:",
+        '  - id: "REQ-100"',
+        "---",
+        "# Body",
+      ].join("\n"),
+    );
+    expect(changes).toHaveLength(1);
+  });
+
+  it("does NOT modify content outside frontmatter delimiters", () => {
+    const input = [
+      "---",
+      'node_id: "doc:keep"',
+      "---",
+      'node_id: "doc:old"',
+    ].join("\n");
+    const { content } = rewriteFrontmatter(input, "doc:old", "doc:new");
+    // Only the body line has doc:old, and it should remain untouched
+    expect(content).toBe(input);
+  });
+});
+
+// ── rewriteFile ─────────────────────────────────────────────────────
+
+describe("rewriteFile", () => {
+  it("applies list item + heading + frontmatter rewriters for .md files", () => {
+    const input = [
+      "---",
+      'node_id: "doc:old"',
+      "---",
+      "### Requirement 1: description",
+      "- REQ-001: some requirement",
+    ].join("\n");
+
+    const { content, changes } = rewriteFile(
+      "specs/auth.md",
+      input,
+      "REQ-001",
+      "REQ-100",
+    );
+
+    // List item should be rewritten
+    expect(content).toContain("- REQ-100: some requirement");
+    // The REQ-001 heading won't match because oldId is REQ-001 not Requirement-1
+    // but the list item and frontmatter paths are tested
+    expect(changes.length).toBeGreaterThanOrEqual(1);
+    expect(changes.every((c) => c.filePath === "specs/auth.md")).toBe(true);
+  });
+
+  it("applies impl + test tag rewriters for .ts files", () => {
+    const input = [
+      "// @impl REQ-001",
+      'it("[REQ-001] test", () => {});',
+    ].join("\n");
+
+    const { content, changes } = rewriteFile(
+      "src/auth.ts",
+      input,
+      "REQ-001",
+      "REQ-100",
+    );
+
+    expect(content).toContain("// @impl REQ-100");
+    expect(content).toContain("[REQ-100]");
+    expect(changes).toHaveLength(2);
+    expect(changes.every((c) => c.filePath === "src/auth.ts")).toBe(true);
+  });
+
+  it("returns unchanged content for unknown extensions", () => {
+    const input = "REQ-001 appears here";
+    const { content, changes } = rewriteFile(
+      "data/config.yaml",
+      input,
+      "REQ-001",
+      "REQ-100",
+    );
+    expect(content).toBe(input);
+    expect(changes).toHaveLength(0);
+  });
+});
+
+// ── renameLockKey ───────────────────────────────────────────────────
+
+describe("renameLockKey", () => {
+  it("renames the key, preserving entry content", () => {
+    const lock: LockFile = {
+      "REQ-001": {
+        contentHash: "abc123",
+        impl: ["src/foo.ts"],
+        tests: ["tests/foo.test.ts"],
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+    };
+
+    const { lock: result, changes } = renameLockKey(lock, "REQ-001", "REQ-100");
+
+    expect(result["REQ-100"]).toBeDefined();
+    expect(result["REQ-001"]).toBeUndefined();
+    expect(result["REQ-100"].contentHash).toBe("abc123");
+    expect(result["REQ-100"].impl).toEqual(["src/foo.ts"]);
+    expect(result["REQ-100"].tests).toEqual(["tests/foo.test.ts"]);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].kind).toBe("rename");
+  });
+
+  it("updates dependsOn references in other entries", () => {
+    const lock: LockFile = {
+      "REQ-001": {
+        contentHash: "abc",
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+      "REQ-002": {
+        contentHash: "def",
+        dependsOn: ["REQ-001"],
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+    };
+
+    const { lock: result } = renameLockKey(lock, "REQ-001", "REQ-100");
+    expect(result["REQ-002"].dependsOn).toEqual(["REQ-100"]);
+  });
+
+  it("returns unchanged lock when oldId does not exist", () => {
+    const lock: LockFile = {
+      "REQ-001": {
+        contentHash: "abc",
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+    };
+
+    const { lock: result, changes } = renameLockKey(lock, "REQ-999", "REQ-100");
+    expect(result["REQ-001"]).toBeDefined();
+    expect(result["REQ-999"]).toBeUndefined();
+    expect(result["REQ-100"]).toBeUndefined();
+    expect(changes).toHaveLength(0);
+  });
+
+  it("does not touch symbol: keys", () => {
+    const lock: LockFile = {
+      "REQ-001": {
+        contentHash: "abc",
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+      "symbol:auth": {
+        contentHash: "sym",
+        dependsOn: ["REQ-001"],
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+    };
+
+    const { lock: result } = renameLockKey(lock, "REQ-001", "REQ-100");
+    // symbol: keys are skipped during reference updates
+    expect(result["symbol:auth"].dependsOn).toEqual(["REQ-001"]);
+  });
+});
+
+// ── splitLockKey ────────────────────────────────────────────────────
+
+describe("splitLockKey", () => {
+  it("deletes old key and creates empty entries for new IDs", () => {
+    const lock: LockFile = {
+      "REQ-001": {
+        contentHash: "abc",
+        impl: ["src/foo.ts"],
+        tests: ["tests/foo.test.ts"],
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+    };
+
+    const { lock: result, changes } = splitLockKey(lock, "REQ-001", [
+      "REQ-001a",
+      "REQ-001b",
+    ]);
+
+    expect(result["REQ-001"]).toBeUndefined();
+    expect(result["REQ-001a"]).toBeDefined();
+    expect(result["REQ-001b"]).toBeDefined();
+    expect(result["REQ-001a"].contentHash).toBe("");
+    expect(result["REQ-001a"].impl).toEqual([]);
+    expect(result["REQ-001a"].tests).toEqual([]);
+    expect(result["REQ-001b"].contentHash).toBe("");
+    expect(changes).toHaveLength(3); // 1 delete + 2 creates
+  });
+
+  it("creates new entries even if old key does not exist", () => {
+    const lock: LockFile = {};
+
+    const { lock: result, changes } = splitLockKey(lock, "REQ-999", [
+      "REQ-100",
+      "REQ-101",
+    ]);
+
+    expect(result["REQ-100"]).toBeDefined();
+    expect(result["REQ-101"]).toBeDefined();
+    // No delete change because oldId didn't exist
+    expect(changes).toHaveLength(2); // 2 creates only
+  });
+});
+
+// ── mergeLockKeys ───────────────────────────────────────────────────
+
+describe("mergeLockKeys", () => {
+  it("combines impl and tests arrays with deduplication", () => {
+    const lock: LockFile = {
+      "REQ-001": {
+        contentHash: "hash-a",
+        impl: ["src/a.ts", "src/shared.ts"],
+        tests: ["tests/a.test.ts"],
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+      "REQ-002": {
+        contentHash: "hash-b",
+        impl: ["src/b.ts", "src/shared.ts"],
+        tests: ["tests/b.test.ts", "tests/a.test.ts"],
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+    };
+
+    const { lock: result } = mergeLockKeys(lock, ["REQ-001", "REQ-002"], "REQ-MERGED");
+
+    expect(result["REQ-MERGED"]).toBeDefined();
+    expect(result["REQ-MERGED"].impl).toEqual([
+      "src/a.ts",
+      "src/shared.ts",
+      "src/b.ts",
+    ]);
+    expect(result["REQ-MERGED"].tests).toEqual([
+      "tests/a.test.ts",
+      "tests/b.test.ts",
+    ]);
+  });
+
+  it("deletes all source keys and creates new key", () => {
+    const lock: LockFile = {
+      "REQ-001": {
+        contentHash: "hash-a",
+        impl: ["src/a.ts"],
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+      "REQ-002": {
+        contentHash: "hash-b",
+        impl: ["src/b.ts"],
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+      "REQ-003": {
+        contentHash: "hash-c",
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+    };
+
+    const { lock: result, changes } = mergeLockKeys(
+      lock,
+      ["REQ-001", "REQ-002"],
+      "REQ-MERGED",
+    );
+
+    expect(result["REQ-001"]).toBeUndefined();
+    expect(result["REQ-002"]).toBeUndefined();
+    expect(result["REQ-003"]).toBeDefined(); // untouched
+    expect(result["REQ-MERGED"]).toBeDefined();
+    expect(changes).toHaveLength(3); // 2 deletes + 1 create
+  });
+
+  it("uses first source's contentHash", () => {
+    const lock: LockFile = {
+      "REQ-001": {
+        contentHash: "first-hash",
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+      "REQ-002": {
+        contentHash: "second-hash",
+        lastReconciled: "2025-01-01T00:00:00Z",
+      },
+    };
+
+    const { lock: result } = mergeLockKeys(
+      lock,
+      ["REQ-001", "REQ-002"],
+      "REQ-MERGED",
+    );
+
+    expect(result["REQ-MERGED"].contentHash).toBe("first-hash");
+  });
+});

--- a/tests/rename.test.ts
+++ b/tests/rename.test.ts
@@ -5,6 +5,7 @@ import {
   rewriteImplTags,
   rewriteTestTags,
   rewriteFrontmatter,
+  expandFrontmatterDependsOn,
   rewriteFile,
 } from "../src/rename.js";
 import {
@@ -12,6 +13,7 @@ import {
   splitLockKey,
   mergeLockKeys,
 } from "../src/rename-lock.js";
+import { isValidTargetId } from "../src/id.js";
 import type { LockFile } from "../src/types.js";
 
 // ── rewriteSpecListItem ─────────────────────────────────────────────
@@ -56,15 +58,25 @@ describe("rewriteSpecListItem", () => {
     expect(changes).toHaveLength(2);
   });
 
-  it("handles namespace-qualified ID", () => {
+  it("does not touch a prefix-colliding ID (REQ-1 vs REQ-10)", () => {
+    const input = ["- REQ-1: first", "- REQ-10: tenth"].join("\n");
+    const { content, changes } = rewriteSpecListItem(input, "REQ-1", "REQ-2");
+    expect(content).toBe(["- REQ-2: first", "- REQ-10: tenth"].join("\n"));
+    expect(changes).toHaveLength(1);
+  });
+
+  it("ignores list items the parser does not treat as req IDs", () => {
+    // The parser's LIST_ITEM_RE only captures `[A-Z][A-Za-z]*-\\d+`, so a
+    // namespace-qualified token in a list item is not a tracked req and must
+    // not be rewritten (rewriter/parser parity).
     const input = "- 001-auth/FR-001: auth feature";
     const { content, changes } = rewriteSpecListItem(
       input,
       "001-auth/FR-001",
       "001-auth/FR-010",
     );
-    expect(content).toBe("- 001-auth/FR-010: auth feature");
-    expect(changes).toHaveLength(1);
+    expect(content).toBe(input);
+    expect(changes).toHaveLength(0);
   });
 });
 
@@ -142,19 +154,25 @@ describe("rewriteTestTags", () => {
     expect(changes).toHaveLength(1);
   });
 
-  it("handles case-insensitive prefixes", () => {
-    const input1 = 'Req: "REQ-001"';
-    const input2 = 'requirement: "REQ-001"';
-    const input3 = 'spec: "REQ-001"';
+  it("rewrites an unquoted req: annotation", () => {
+    const input = "req: REQ-001";
+    const { content, changes } = rewriteTestTags(input, "REQ-001", "REQ-100");
+    expect(content).toBe("req: REQ-100");
+    expect(changes).toHaveLength(1);
+  });
 
-    expect(rewriteTestTags(input1, "REQ-001", "REQ-100").content).toBe(
-      'Req: "REQ-100"',
+  it("only rewrites the parser-tracked `req:` key (case-sensitive)", () => {
+    // The parser's TEST_ANNOTATION_RE tracks `req:` exclusively and
+    // case-sensitively, so `Req:`/`requirement:`/`spec:` must be left alone to
+    // avoid rewriting text the tooling never treated as a reference (M1).
+    expect(rewriteTestTags('Req: "REQ-001"', "REQ-001", "REQ-100").content).toBe(
+      'Req: "REQ-001"',
     );
-    expect(rewriteTestTags(input2, "REQ-001", "REQ-100").content).toBe(
-      'requirement: "REQ-100"',
-    );
-    expect(rewriteTestTags(input3, "REQ-001", "REQ-100").content).toBe(
-      'spec: "REQ-100"',
+    expect(
+      rewriteTestTags('requirement: "REQ-001"', "REQ-001", "REQ-100").content,
+    ).toBe('requirement: "REQ-001"');
+    expect(rewriteTestTags('spec: "REQ-001"', "REQ-001", "REQ-100").content).toBe(
+      'spec: "REQ-001"',
     );
   });
 });
@@ -214,6 +232,49 @@ describe("rewriteFrontmatter", () => {
     // Only the body line has doc:old, and it should remain untouched
     expect(content).toBe(input);
   });
+
+  it("rewrites a plain-string depends_on item", () => {
+    const input = ["---", "depends_on:", '  - "REQ-001"', "---", "# Body"].join("\n");
+    const { content, changes } = rewriteFrontmatter(input, "REQ-001", "REQ-100");
+    expect(content).toContain('  - "REQ-100"');
+    expect(changes).toHaveLength(1);
+  });
+
+  it("rewrites an inline flow-map depends_on item", () => {
+    const input = [
+      "---",
+      "spectrace:",
+      "  depends_on:",
+      '    - { id: "REQ-002", relation: implements }',
+      "---",
+    ].join("\n");
+    const { content } = rewriteFrontmatter(input, "REQ-002", "REQ-200");
+    expect(content).toContain('{ id: "REQ-200", relation: implements }');
+  });
+});
+
+// ── expandFrontmatterDependsOn (F5) ─────────────────────────────────
+
+describe("expandFrontmatterDependsOn", () => {
+  it("expands a single dependency into one item per new ID", () => {
+    const input = [
+      "---",
+      "depends_on:",
+      '  - "REQ-001"',
+      '  - "REQ-009"',
+      "---",
+    ].join("\n");
+    const { content, changes } = expandFrontmatterDependsOn(input, "REQ-001", [
+      "REQ-101",
+      "REQ-102",
+    ]);
+    expect(content).toContain('  - "REQ-101"');
+    expect(content).toContain('  - "REQ-102"');
+    // The unrelated dependency survives, and the split ID is gone.
+    expect(content).toContain('  - "REQ-009"');
+    expect(content).not.toContain('"REQ-001"');
+    expect(changes).toHaveLength(2);
+  });
 });
 
 // ── rewriteFile ─────────────────────────────────────────────────────
@@ -260,6 +321,21 @@ describe("rewriteFile", () => {
     expect(content).toContain("[REQ-100]");
     expect(changes).toHaveLength(2);
     expect(changes.every((c) => c.filePath === "src/auth.ts")).toBe(true);
+  });
+
+  it("does NOT rewrite IDs inside fenced code blocks (F6)", () => {
+    const input = [
+      "- REQ-001: real requirement",
+      "",
+      "```md",
+      "- REQ-001: just an example in docs",
+      "```",
+    ].join("\n");
+
+    const { content } = rewriteFile("specs/auth.md", input, "REQ-001", "REQ-100");
+    expect(content).toContain("- REQ-100: real requirement");
+    // The fenced example must be preserved verbatim.
+    expect(content).toContain("- REQ-001: just an example in docs");
   });
 
   it("returns unchanged content for unknown extensions", () => {
@@ -391,6 +467,30 @@ describe("splitLockKey", () => {
     // No delete change because oldId didn't exist
     expect(changes).toHaveLength(2); // 2 creates only
   });
+
+  it("expands references to the split ID in other entries (C2)", () => {
+    const lock: LockFile = {
+      "REQ-001": { contentHash: "a", lastReconciled: "t" },
+      "REQ-003": {
+        contentHash: "c",
+        dependsOn: ["REQ-001", "REQ-002"],
+        lastReconciled: "t",
+      },
+    };
+
+    const { lock: result } = splitLockKey(lock, "REQ-001", ["REQ-101", "REQ-102"]);
+    // No dangling reference to the removed REQ-001 — it expands to both new IDs.
+    expect(result["REQ-003"].dependsOn).toEqual(["REQ-101", "REQ-102", "REQ-002"]);
+  });
+
+  it("carries the split source's specFile onto the new entries (H5)", () => {
+    const lock: LockFile = {
+      "REQ-001": { specFile: "specs/a.md", contentHash: "a", lastReconciled: "t" },
+    };
+    const { lock: result } = splitLockKey(lock, "REQ-001", ["REQ-101", "REQ-102"]);
+    expect(result["REQ-101"].specFile).toBe("specs/a.md");
+    expect(result["REQ-102"].specFile).toBe("specs/a.md");
+  });
 });
 
 // ── mergeLockKeys ───────────────────────────────────────────────────
@@ -476,5 +576,57 @@ describe("mergeLockKeys", () => {
     );
 
     expect(result["REQ-MERGED"].contentHash).toBe("first-hash");
+  });
+
+  it("repoints references to merged sources in other entries (C2)", () => {
+    const lock: LockFile = {
+      "REQ-001": { contentHash: "a", lastReconciled: "t" },
+      "REQ-002": { contentHash: "b", lastReconciled: "t" },
+      "REQ-003": {
+        contentHash: "c",
+        dependsOn: ["REQ-001", "REQ-002"],
+        lastReconciled: "t",
+      },
+    };
+
+    const { lock: result } = mergeLockKeys(lock, ["REQ-001", "REQ-002"], "REQ-100");
+    // Both former references collapse onto the merge target, de-duplicated.
+    expect(result["REQ-003"].dependsOn).toEqual(["REQ-100"]);
+  });
+
+  it("preserves specFile and drops self-references (H5)", () => {
+    const lock: LockFile = {
+      "REQ-001": {
+        specFile: "specs/a.md",
+        contentHash: "a",
+        dependsOn: ["REQ-002"],
+        lastReconciled: "t",
+      },
+      "REQ-002": { specFile: "specs/a.md", contentHash: "b", lastReconciled: "t" },
+    };
+
+    const { lock: result } = mergeLockKeys(lock, ["REQ-001", "REQ-002"], "REQ-100");
+    expect(result["REQ-100"].specFile).toBe("specs/a.md");
+    // The merged entry must not depend on its own former parts.
+    expect(result["REQ-100"].dependsOn).toBeUndefined();
+  });
+});
+
+// ── ID validation (F2) ──────────────────────────────────────────────
+
+describe("isValidTargetId", () => {
+  it("accepts canonical requirement IDs and doc: IDs", () => {
+    expect(isValidTargetId("REQ-001")).toBe(true);
+    expect(isValidTargetId("FR-42")).toBe(true);
+    expect(isValidTargetId("auth/AUTH-2")).toBe(true);
+    expect(isValidTargetId("Requirement-3")).toBe(true);
+    expect(isValidTargetId("doc:feature")).toBe(true);
+  });
+
+  it("rejects IDs the parser could not re-discover", () => {
+    expect(isValidTargetId("REQ-COMBINED")).toBe(false);
+    expect(isValidTargetId("REQ-001a")).toBe(false);
+    expect(isValidTargetId("req-1")).toBe(false);
+    expect(isValidTargetId("doc:")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- `spectrace rename` サブコマンドを新規追加し、仕様 ID のライフサイクル管理（rename / split / merge）を実現
- 5 種類の参照パターン（spec リスト項目/見出し、`@impl` タグ、テスト `[ID]` タグ、frontmatter `depends_on`、`.trace.lock` キー）を一括書き換え
- `--dry-run` / `--format json|text` / git 追跡ファイル限定 / エラーバリデーション対応

## Changes

### New files
- `src/rename.ts` — 5 種類のパターン書き換えエンジン (rewriter)
- `src/rename-lock.ts` — lock キー操作 (rename/split/merge)
- `src/rename-executor.ts` — オーケストレーター (executor)
- `tests/rename.test.ts` — ユニットテスト 29 件
- `tests/rename-cli.test.ts` — CLI 統合テスト 7 件
- `tests/fixtures/rename/` — テスト用 fixture 一式
- `specs/004-id-lifecycle/plan.md` — 実装計画

### Modified files
- `src/cli.ts` — rename サブコマンド登録
- `src/diff.ts` — `getGitTrackedFiles()` 追加

## Test plan

- [x] ユニットテスト 29 件パス（rewriter 全パターン + lock-updater）
- [x] CLI 統合テスト 7 件パス（rename/split/merge + dry-run/json/error）
- [x] 既存テスト 207 件全パス（リグレッションなし）
- [x] `tsc --noEmit` 型チェッククリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)