### PR TITLE
feat: artgraph init --with-skills で Claude Code Skills を配置 (#17)

### DIFF
--- a/packages/artgraph/package.json
+++ b/packages/artgraph/package.json
@@ -7,7 +7,8 @@
     "artgraph": "./dist/cli.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "templates"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/artgraph/package.json
+++ b/packages/artgraph/package.json
@@ -17,7 +17,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "knip": "knip",
-    "prepublishOnly": "tsc"
+    "prepublishOnly": "rm -rf dist && tsc"
   },
   "keywords": [
     "traceability",

--- a/packages/artgraph/src/cli.ts
+++ b/packages/artgraph/src/cli.ts
@@ -58,7 +58,10 @@ program
   .description("Initialize artgraph for this project")
   .option("--force", "Overwrite existing .artgraph.json")
   .option("--no-scan", "Generate config only, skip scan and reconcile")
-  .option("--with-skills", "Install Claude Code skills into .claude/skills/")
+  .option(
+    "--with-skills",
+    "Install Claude Code skills (plan, verify, coverage, rename) into .claude/skills/",
+  )
   .option("--format <format>", "Output format: json | text", "text")
   .action((opts) => {
     const rootDir = process.cwd();

--- a/packages/artgraph/src/cli.ts
+++ b/packages/artgraph/src/cli.ts
@@ -58,11 +58,16 @@ program
   .description("Initialize artgraph for this project")
   .option("--force", "Overwrite existing .artgraph.json")
   .option("--no-scan", "Generate config only, skip scan and reconcile")
+  .option("--with-skills", "Install Claude Code skills into .claude/skills/")
   .option("--format <format>", "Output format: json | text", "text")
   .action((opts) => {
     const rootDir = process.cwd();
     try {
-      const result = runInit(rootDir, { force: opts.force, noScan: !opts.scan });
+      const result = runInit(rootDir, {
+        force: opts.force,
+        noScan: !opts.scan,
+        withSkills: opts.withSkills,
+      });
 
       if (opts.format === "json") {
         console.log(
@@ -73,6 +78,7 @@ program
             scanSummary: result.scanSummary ?? null,
             warnings: result.warnings,
             lockPath: result.lockPath ?? null,
+            skillsInstalled: result.skillsInstalled ?? null,
           }),
         );
       } else {
@@ -103,6 +109,10 @@ program
           console.log(`Created .artgraph.json (scan skipped)`);
           console.log(`\nTo scan later, run: artgraph scan && artgraph reconcile`);
         }
+        if (result.skillsInstalled && result.skillsInstalled.length > 0) {
+          console.log(`\nInstalled ${result.skillsInstalled.length} Claude Code skills:`);
+          for (const path of result.skillsInstalled) console.log(`  ${path}`);
+        }
       }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
@@ -123,7 +133,9 @@ program
     const result = scan(rootDir, config);
 
     const testResults = resolveTestResults(opts, config, rootDir);
-    let testResultStats: { totalTests: number; passedTests: number; failedTests: number } | undefined;
+    let testResultStats:
+      | { totalTests: number; passedTests: number; failedTests: number }
+      | undefined;
     if (testResults) {
       let totalTests = 0;
       let passedTests = 0;
@@ -545,7 +557,9 @@ program
   .option("--merge <ids...>", "Source IDs to merge")
   .option("--into <ids...>", "Target ID(s) for split or merge")
   .option("--dry-run", "Show changes without applying them")
-  .addOption(new Option("--format <format>", "Output format").choices(["json", "text"]).default("text"))
+  .addOption(
+    new Option("--format <format>", "Output format").choices(["json", "text"]).default("text"),
+  )
   .action((opts) => {
     const rootDir = process.cwd();
     const format: "json" | "text" = opts.format;

--- a/packages/artgraph/src/init.ts
+++ b/packages/artgraph/src/init.ts
@@ -1,5 +1,5 @@
-import { existsSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 import {
   DEFAULT_CONFIG,
   type ArtgraphConfig,
@@ -11,6 +11,9 @@ import {
 import { scan, reconcile } from "./scan.js";
 import type { BuildWarning } from "./graph/builder.js";
 
+const SKILLS_TEMPLATE_DIR = resolve(import.meta.dirname, "../templates/skills");
+const SKILLS_DEST_SUBDIR = join(".claude", "skills");
+
 export interface InitResult {
   configPath: string;
   config: ArtgraphConfig;
@@ -18,6 +21,7 @@ export interface InitResult {
   scanSummary?: ScanSummary;
   warnings: BuildWarning[];
   lockPath?: string;
+  skillsInstalled?: string[];
 }
 
 export function detectProject(rootDir: string): DetectionResult {
@@ -54,6 +58,29 @@ export function generateConfig(detection: DetectionResult): ArtgraphConfig {
   };
 }
 
+export function installSkills(rootDir: string, options: { force?: boolean } = {}): string[] {
+  const abs = resolve(rootDir);
+  const destDir = resolve(abs, SKILLS_DEST_SUBDIR);
+  const templates = readdirSync(SKILLS_TEMPLATE_DIR).filter((f) => f.endsWith(".md"));
+
+  if (!options.force) {
+    const conflicts = templates.filter((f) => existsSync(join(destDir, f)));
+    if (conflicts.length > 0) {
+      throw new Error(
+        `Skill file(s) already exist in ${SKILLS_DEST_SUBDIR}: ${conflicts.join(", ")}. Use --force to overwrite.`,
+      );
+    }
+  }
+
+  mkdirSync(destDir, { recursive: true });
+  const installed: string[] = [];
+  for (const name of templates) {
+    copyFileSync(join(SKILLS_TEMPLATE_DIR, name), join(destDir, name));
+    installed.push(join(SKILLS_DEST_SUBDIR, name));
+  }
+  return installed;
+}
+
 export function runInit(rootDir: string, options: InitOptions = {}): InitResult {
   const abs = resolve(rootDir);
   const configPath = resolve(abs, ".artgraph.json");
@@ -65,9 +92,13 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
   const detection = detectProject(abs);
   const config = generateConfig(detection);
 
+  const skillsInstalled = options.withSkills
+    ? installSkills(abs, { force: options.force })
+    : undefined;
+
   if (options.noScan) {
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
-    return { configPath, config, sddTools: detection.sddTools, warnings: [] };
+    return { configPath, config, sddTools: detection.sddTools, warnings: [], skillsInstalled };
   }
 
   const result = scan(abs, config);
@@ -90,5 +121,6 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
     },
     warnings: result.warnings,
     lockPath,
+    skillsInstalled,
   };
 }

--- a/packages/artgraph/src/init.ts
+++ b/packages/artgraph/src/init.ts
@@ -14,6 +14,15 @@ import type { BuildWarning } from "./graph/builder.js";
 const SKILLS_TEMPLATE_DIR = resolve(import.meta.dirname, "../templates/skills");
 const SKILLS_DEST_SUBDIR = join(".claude", "skills");
 
+export class SkillsInstallError extends Error {
+  readonly partiallyInstalled: string[];
+  constructor(message: string, partiallyInstalled: string[] = []) {
+    super(message);
+    this.name = "SkillsInstallError";
+    this.partiallyInstalled = partiallyInstalled;
+  }
+}
+
 export interface InitResult {
   configPath: string;
   config: ArtgraphConfig;
@@ -58,15 +67,57 @@ export function generateConfig(detection: DetectionResult): ArtgraphConfig {
   };
 }
 
-export function installSkills(rootDir: string, options: { force?: boolean } = {}): string[] {
+function readSkillTemplates(templateDir: string): string[] {
+  if (!existsSync(templateDir)) {
+    throw new SkillsInstallError(
+      `Skills template directory not found at ${templateDir}. This is likely a packaging issue.`,
+    );
+  }
+  const templates = readdirSync(templateDir).filter((f) => f.endsWith(".md"));
+  if (templates.length === 0) {
+    throw new SkillsInstallError(
+      `No skill templates (*.md) found in ${templateDir}. This is likely a packaging issue.`,
+    );
+  }
+  return templates;
+}
+
+// `templateDir` is for test injection only; production callers omit it and the
+// constant `SKILLS_TEMPLATE_DIR` (resolved relative to dist/) is used.
+export interface SkillsInstallOptions {
+  force?: boolean;
+  templateDir?: string;
+}
+
+// Throws if installation cannot proceed cleanly. Mirrors installSkills's
+// validation (templates available, no conflicts unless --force) without writing.
+// Use this as a pre-flight check before any other side effects.
+export function validateSkillsInstall(rootDir: string, options: SkillsInstallOptions = {}): void {
   const abs = resolve(rootDir);
   const destDir = resolve(abs, SKILLS_DEST_SUBDIR);
-  const templates = readdirSync(SKILLS_TEMPLATE_DIR).filter((f) => f.endsWith(".md"));
+  const templateDir = options.templateDir ?? SKILLS_TEMPLATE_DIR;
+  const templates = readSkillTemplates(templateDir);
 
   if (!options.force) {
     const conflicts = templates.filter((f) => existsSync(join(destDir, f)));
     if (conflicts.length > 0) {
-      throw new Error(
+      throw new SkillsInstallError(
+        `Skill file(s) already exist in ${SKILLS_DEST_SUBDIR}: ${conflicts.join(", ")}. Use --force to overwrite.`,
+      );
+    }
+  }
+}
+
+export function installSkills(rootDir: string, options: SkillsInstallOptions = {}): string[] {
+  const abs = resolve(rootDir);
+  const destDir = resolve(abs, SKILLS_DEST_SUBDIR);
+  const templateDir = options.templateDir ?? SKILLS_TEMPLATE_DIR;
+  const templates = readSkillTemplates(templateDir);
+
+  if (!options.force) {
+    const conflicts = templates.filter((f) => existsSync(join(destDir, f)));
+    if (conflicts.length > 0) {
+      throw new SkillsInstallError(
         `Skill file(s) already exist in ${SKILLS_DEST_SUBDIR}: ${conflicts.join(", ")}. Use --force to overwrite.`,
       );
     }
@@ -75,8 +126,16 @@ export function installSkills(rootDir: string, options: { force?: boolean } = {}
   mkdirSync(destDir, { recursive: true });
   const installed: string[] = [];
   for (const name of templates) {
-    copyFileSync(join(SKILLS_TEMPLATE_DIR, name), join(destDir, name));
-    installed.push(join(SKILLS_DEST_SUBDIR, name));
+    try {
+      copyFileSync(join(templateDir, name), join(destDir, name));
+      installed.push(join(SKILLS_DEST_SUBDIR, name));
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new SkillsInstallError(
+        `Failed to copy ${name} into ${SKILLS_DEST_SUBDIR}: ${msg}`,
+        installed,
+      );
+    }
   }
   return installed;
 }
@@ -89,21 +148,30 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
     throw new Error(".artgraph.json already exists. Use --force to overwrite.");
   }
 
+  // Pre-flight: fail before any write if --with-skills cannot proceed cleanly
+  // (templates missing, conflicts without --force). Keeps partial-state windows
+  // closed: validation failure leaves disk untouched.
+  if (options.withSkills) {
+    validateSkillsInstall(abs, { force: options.force });
+  }
+
   const detection = detectProject(abs);
   const config = generateConfig(detection);
 
-  const skillsInstalled = options.withSkills
-    ? installSkills(abs, { force: options.force })
-    : undefined;
-
   if (options.noScan) {
     writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+    const skillsInstalled = options.withSkills
+      ? installSkills(abs, { force: options.force })
+      : undefined;
     return { configPath, config, sddTools: detection.sddTools, warnings: [], skillsInstalled };
   }
 
   const result = scan(abs, config);
   reconcile(abs, config, result.graph);
   writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+  const skillsInstalled = options.withSkills
+    ? installSkills(abs, { force: options.force })
+    : undefined;
 
   const lockPath = resolve(abs, config.lockFile);
 

--- a/packages/artgraph/src/types.ts
+++ b/packages/artgraph/src/types.ts
@@ -97,6 +97,7 @@ export interface DetectionResult {
 export interface InitOptions {
   force?: boolean;
   noScan?: boolean;
+  withSkills?: boolean;
 }
 
 export interface ReqPatternConfig {

--- a/packages/artgraph/templates/skills/artgraph-coverage.md
+++ b/packages/artgraph/templates/skills/artgraph-coverage.md
@@ -1,0 +1,56 @@
+---
+name: "artgraph-coverage"
+description: "進捗確認や残作業確認の依頼時にトリガー。artgraph coverage を実行し、各仕様の coverage 状態（verified / impl-only / untagged）を一覧表示して残作業を可視化する。"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## 目的
+
+進捗確認時に `artgraph coverage` を実行し、各仕様の coverage 状態を一覧表示する。
+残作業の把握と優先順位付けに活用する。
+
+## 実行手順
+
+### 1. artgraph の存在確認
+
+```bash
+command -v artgraph || npx artgraph --version
+```
+
+コマンドが見つからない場合は以下を案内して終了:
+
+```
+artgraph がインストールされていません。
+セットアップ手順:
+  npm install -D artgraph
+  npx artgraph init
+```
+
+### 2. カバレッジ状況の取得
+
+```bash
+artgraph coverage --format json
+```
+
+### 3. 結果の表示
+
+実行結果の JSON を解析し、以下の情報を報告する:
+
+items: 各仕様のカバレッジ状態
+- reqId: 仕様 ID
+- status: verified（実装+テストあり）/ impl-only（実装のみ）/ untagged（未実装）
+
+summary: 集計情報
+- total: 仕様の総数
+- verified: verified の数
+- implOnly: impl-only の数
+- untagged: untagged の数
+
+### 4. 進捗サマリの提示
+
+カバレッジ状態に基づいて進捗を報告する:
+
+- 全仕様が verified の場合: 「全仕様が verified 状態です」と報告
+- untagged が存在する場合: 未実装の仕様一覧を表示し、優先的に着手すべき項目を提案する
+- impl-only が存在する場合: テストが不足している仕様の一覧を表示する

--- a/packages/artgraph/templates/skills/artgraph-plan.md
+++ b/packages/artgraph/templates/skills/artgraph-plan.md
@@ -1,0 +1,54 @@
+---
+name: "artgraph-plan"
+description: "Plan 策定や設計検討の依頼時にトリガー。artgraph impact を実行し、変更の影響範囲をコンテキストに注入して、既存仕様との整合性を考慮した Plan 策定を支援する。"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## 目的
+
+Plan 策定前に `artgraph impact` を実行し、変更対象の仕様に波及する既存の仕様・実装・テストの影響範囲を把握する。
+エージェントはこの情報を踏まえて、既存仕様との矛盾や影響漏れを考慮した Plan を立てる。
+
+## 実行手順
+
+### 1. artgraph の存在確認
+
+```bash
+command -v artgraph || npx artgraph --version
+```
+
+コマンドが見つからない場合は以下を案内して終了:
+
+```
+artgraph がインストールされていません。
+セットアップ手順:
+  npm install -D artgraph
+  npx artgraph init
+```
+
+### 2. Impact 分析の実行
+
+```bash
+artgraph impact --diff --format json
+```
+
+- `--diff` で git diff から変更ファイルを自動検出する
+- 差分がない場合（初回コミット等）は「差分なし」として正常終了し、Plan 策定を続行する
+
+### 3. 結果のコンテキスト注入
+
+実行結果の JSON を解析し、以下の情報を Plan のコンテキストとして活用する:
+
+- affectedReqs: 影響を受ける仕様 ID の一覧
+- affectedDocs: 影響を受けるドキュメントの一覧
+- affectedFiles: 影響を受ける実装ファイルの一覧
+- drifted: 仕様変更が未反映の項目（drift 検出）
+
+### 4. Plan 策定への反映
+
+上記の影響範囲情報を踏まえて:
+
+- 影響を受ける仕様への言及を Plan に含める
+- drift が検出された場合は Plan 内で対処方針を明記する
+- 影響を受けるファイルの変更が Plan と矛盾しないか確認する

--- a/packages/artgraph/templates/skills/artgraph-rename.md
+++ b/packages/artgraph/templates/skills/artgraph-rename.md
@@ -1,0 +1,64 @@
+---
+name: "artgraph-rename"
+description: "仕様 ID のリネーム・分割・統合の依頼時にトリガー。artgraph rename を使い、spec / @impl / テストタグ / frontmatter / lock を一括で安全に書き換える。破壊的操作のため必ず --dry-run で確認してから適用する。"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## 目的
+
+仕様 ID のライフサイクル（rename / split / merge）を `artgraph rename` で一括処理する。
+5 種類の参照（spec のリスト項目・見出し、`@impl` タグ、テストの `[ID]` / `req:` タグ、
+frontmatter の `depends_on` / `derives_from`、`.trace.lock` のキー）を横断的に書き換える。
+
+## 重要な前提
+
+- **破壊的操作**: git 追跡ファイルを直接書き換える。必ず作業ツリーをコミット済みにしてから実行する。
+- **必ず `--dry-run` で確認**してから本適用する。
+- ターゲット ID は再スキャン可能な形式（`REQ-001` / `auth/FR-2` / `doc:xxx`）のみ受理される。
+  `REQ-COMBINED` や `REQ-001a` のような形式は拒否される。
+
+## 実行手順
+
+### 1. artgraph の存在確認
+
+```bash
+command -v artgraph || npx artgraph --version
+```
+
+### 2. dry-run で影響範囲を確認
+
+```bash
+# リネーム
+artgraph rename --from REQ-001 --to REQ-100 --dry-run
+# 分割（1 → 複数）
+artgraph rename --split REQ-001 --into REQ-101 REQ-102 --dry-run
+# 統合（複数 → 1）
+artgraph rename --merge REQ-001 REQ-002 --into REQ-100 --dry-run
+```
+
+変更予定のファイル・行・lock キー変更が表示される。意図と一致するか確認する。
+
+### 3. 本適用
+
+`--dry-run` を外して実行する。適用後、lock は自動的に再 reconcile され、
+書き換えたノードの contentHash・参照・specFile が最新化される。
+
+### 4. 後処理
+
+- **split**: 新しい ID には `@impl` が自動付与されない（手動割り当てが必要）。
+  CLI が警告した対象ファイルで `@impl` を新 ID に割り当て、scaffold 行（`(TODO: ...)`）を記述する。
+- 統合元の見出し直下にあった子箇条書きは残るため、必要に応じて整理する。
+- 最後に必ず整合性を確認する:
+
+```bash
+artgraph check
+```
+
+rename / merge は後続の `check` がそのままパスする。split は新 ID が `uncovered`
+として残るため、`@impl` 割り当て後に再度 `check` する。
+
+## 出力形式
+
+`--format json` を付けると結果が JSON で出力される（失敗時も `{ "error": "..." }` の JSON）。
+スクリプトから扱う場合に利用する。

--- a/packages/artgraph/templates/skills/artgraph-verify.md
+++ b/packages/artgraph/templates/skills/artgraph-verify.md
@@ -1,0 +1,63 @@
+---
+name: "artgraph-verify"
+description: "実装完了報告やコードレビュー前にトリガー。artgraph check を実行し、drift/orphan/uncovered を検出して仕様と実装の整合性をセルフチェックする。"
+user-invocable: true
+disable-model-invocation: false
+---
+
+## 目的
+
+実装完了時に `artgraph check` を実行し、仕様と実装の整合性を検証する。
+Stop hook（`artgraph check --gate`）でブロックされる前にセルフチェックすることで、手戻りコストを削減する。
+
+## 実行手順
+
+### 1. artgraph の存在確認
+
+```bash
+command -v artgraph || npx artgraph --version
+```
+
+コマンドが見つからない場合は以下を案内して終了:
+
+```
+artgraph がインストールされていません。
+セットアップ手順:
+  npm install -D artgraph
+  npx artgraph init
+```
+
+### 2. 整合性チェックの実行
+
+```bash
+artgraph check --diff --format text
+```
+
+- `--diff` で git diff にスコープを絞り、変更に関連する部分のみチェックする
+- `--gate` は付けない（ゲーティングはせず結果表示のみ）
+
+### 3. 結果の表示と対応
+
+出力結果を解析し、以下の項目を報告する:
+
+DRIFT (仕様変更の未反映):
+- 検出された場合: 各 drift 項目のノード ID と種別を表示し、実装の更新が必要であることを報告する
+
+ORPHANS (実装タグの宙ぶらりん):
+- 検出された場合: 対応する仕様が存在しない `@impl` / `@verify` タグの一覧を表示する
+
+UNCOVERED (未実装の仕様):
+- 検出された場合: 実装が紐づいていない仕様 ID の一覧を表示する
+
+COVERAGE (各仕様のカバレッジ状態):
+- 各仕様の状態（verified / impl-only / untagged）を一覧表示する
+
+全ての仕様が整合している場合:
+- 「全てのチェックが通過しました」と報告する
+
+### 4. 問題がある場合の対応提案
+
+問題が検出された場合は、具体的な修正アクションを提案する:
+- drift: 実装を仕様に合わせて更新し、`artgraph reconcile` を実行する
+- orphan: 不要なタグを削除するか、対応する仕様を追加する
+- uncovered: `@impl` タグを追加して仕様と実装を紐づける

--- a/packages/artgraph/tests/cli.test.ts
+++ b/packages/artgraph/tests/cli.test.ts
@@ -515,6 +515,55 @@ describe("CLI: init", () => {
     expect(stdout).toContain("scan skipped");
     expect(stdout).not.toContain("Nodes:");
   });
+
+  it("should install skills with --with-skills (text output)", { timeout: 30000 }, () => {
+    const { existsSync } = require("node:fs");
+    const { join } = require("node:path");
+    const { exitCode, stdout } = runInit(["--no-scan", "--with-skills"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Installed");
+    expect(stdout).toContain("Claude Code skills");
+    expect(stdout).toContain(".claude/skills/artgraph-plan.md");
+    expect(existsSync(join(initTmp, ".claude", "skills", "artgraph-plan.md"))).toBe(true);
+    expect(existsSync(join(initTmp, ".claude", "skills", "artgraph-verify.md"))).toBe(true);
+    expect(existsSync(join(initTmp, ".claude", "skills", "artgraph-coverage.md"))).toBe(true);
+    expect(existsSync(join(initTmp, ".claude", "skills", "artgraph-rename.md"))).toBe(true);
+  });
+
+  it("should report skillsInstalled in JSON output with --with-skills", { timeout: 30000 }, () => {
+    const { exitCode, stdout } = runInit(["--no-scan", "--with-skills", "--format", "json"]);
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(Array.isArray(result.skillsInstalled)).toBe(true);
+    expect(result.skillsInstalled.length).toBe(4);
+    expect(result.skillsInstalled).toContain(".claude/skills/artgraph-plan.md");
+  });
+
+  it("should not install skills by default", { timeout: 30000 }, () => {
+    const { existsSync } = require("node:fs");
+    const { join } = require("node:path");
+    const { exitCode, stdout } = runInit(["--no-scan"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).not.toContain("Installed");
+    expect(existsSync(join(initTmp, ".claude", "skills"))).toBe(false);
+  });
+
+  it(
+    "should fail and not write .artgraph.json when skill files conflict",
+    { timeout: 30000 },
+    () => {
+      const { mkdirSync, writeFileSync, existsSync } = require("node:fs");
+      const { join } = require("node:path");
+      mkdirSync(join(initTmp, ".claude", "skills"), { recursive: true });
+      writeFileSync(join(initTmp, ".claude", "skills", "artgraph-plan.md"), "user\n");
+
+      const { exitCode, stderr } = runInit(["--no-scan", "--with-skills"]);
+      expect(exitCode).toBe(1);
+      expect(stderr).toMatch(/artgraph-plan\.md.*--force/);
+      // Pre-flight validation must reject before any write.
+      expect(existsSync(join(initTmp, ".artgraph.json"))).toBe(false);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -620,28 +669,46 @@ describe("CLI: test-results integration", () => {
     if (existsSync(ALL_VERIFIED_LOCK)) unlinkSync(ALL_VERIFIED_LOCK);
   });
 
-  it("should accept --test-results option on check command without crash", { timeout: 30000 }, () => {
-    const vitestPath = resolve(TEST_RESULTS_DIR, "vitest-pass.json");
-    const { exitCode } = runAllVerified(["check", "--test-results", vitestPath]);
-    // Without --gate, check always exits 0 even with issues
-    expect(exitCode).toBe(0);
-  });
+  it(
+    "should accept --test-results option on check command without crash",
+    { timeout: 30000 },
+    () => {
+      const vitestPath = resolve(TEST_RESULTS_DIR, "vitest-pass.json");
+      const { exitCode } = runAllVerified(["check", "--test-results", vitestPath]);
+      // Without --gate, check always exits 0 even with issues
+      expect(exitCode).toBe(0);
+    },
+  );
 
-  it("should accept --test-results option on coverage command without crash", { timeout: 30000 }, () => {
-    const vitestPath = resolve(TEST_RESULTS_DIR, "vitest-pass.json");
-    const { exitCode } = runAllVerified(["coverage", "--test-results", vitestPath]);
-    expect(exitCode).toBe(0);
-  });
+  it(
+    "should accept --test-results option on coverage command without crash",
+    { timeout: 30000 },
+    () => {
+      const vitestPath = resolve(TEST_RESULTS_DIR, "vitest-pass.json");
+      const { exitCode } = runAllVerified(["coverage", "--test-results", vitestPath]);
+      expect(exitCode).toBe(0);
+    },
+  );
 
-  it("should accept --test-results option on scan command without crash", { timeout: 30000 }, () => {
-    const vitestPath = resolve(TEST_RESULTS_DIR, "vitest-pass.json");
-    const { exitCode } = runAllVerified(["scan", "--test-results", vitestPath]);
-    expect(exitCode).toBe(0);
-  });
+  it(
+    "should accept --test-results option on scan command without crash",
+    { timeout: 30000 },
+    () => {
+      const vitestPath = resolve(TEST_RESULTS_DIR, "vitest-pass.json");
+      const { exitCode } = runAllVerified(["scan", "--test-results", vitestPath]);
+      expect(exitCode).toBe(0);
+    },
+  );
 
   it("should include testResultStats in scan JSON output", { timeout: 30000 }, () => {
     const vitestPath = resolve(TEST_RESULTS_DIR, "vitest-mixed.json");
-    const { stdout, exitCode } = runAllVerified(["scan", "--format", "json", "--test-results", vitestPath]);
+    const { stdout, exitCode } = runAllVerified([
+      "scan",
+      "--format",
+      "json",
+      "--test-results",
+      vitestPath,
+    ]);
     expect(exitCode).toBe(0);
     const result = JSON.parse(stdout);
     expect(result.testResultStats).toBeDefined();
@@ -676,16 +743,26 @@ describe("CLI: test-results integration", () => {
     expect(byId["VER-002"]).toBe("verified");
   });
 
-  it("should downgrade a REQ to impl-only when its test fails (verified -> impl-only)", { timeout: 30000 }, () => {
-    const failPath = resolve(TEST_RESULTS_DIR, "all-verified-fail.json");
-    const { stdout } = runAllVerified(["coverage", "--format", "json", "--test-results", failPath]);
-    const cov = JSON.parse(stdout);
-    const byId = Object.fromEntries(cov.items.map((i: any) => [i.reqId, i.status]));
-    // VER-001's test failed -> must transition away from "verified".
-    expect(byId["VER-001"]).toBe("impl-only");
-    // VER-002's test still passes -> stays verified.
-    expect(byId["VER-002"]).toBe("verified");
-  });
+  it(
+    "should downgrade a REQ to impl-only when its test fails (verified -> impl-only)",
+    { timeout: 30000 },
+    () => {
+      const failPath = resolve(TEST_RESULTS_DIR, "all-verified-fail.json");
+      const { stdout } = runAllVerified([
+        "coverage",
+        "--format",
+        "json",
+        "--test-results",
+        failPath,
+      ]);
+      const cov = JSON.parse(stdout);
+      const byId = Object.fromEntries(cov.items.map((i: any) => [i.reqId, i.status]));
+      // VER-001's test failed -> must transition away from "verified".
+      expect(byId["VER-001"]).toBe("impl-only");
+      // VER-002's test still passes -> stays verified.
+      expect(byId["VER-002"]).toBe("verified");
+    },
+  );
 
   it("should pass check --gate when all tests pass", { timeout: 30000 }, () => {
     const passPath = resolve(TEST_RESULTS_DIR, "all-verified-pass.json");
@@ -701,11 +778,15 @@ describe("CLI: test-results integration", () => {
     expect(stdout).toContain("VER-001");
   });
 
-  it("should not fail check --gate for test failures when --test-results is absent", { timeout: 30000 }, () => {
-    // Legacy: without test results the gate ignores pass/fail entirely.
-    const { exitCode } = runAllVerified(["check", "--gate"]);
-    expect(exitCode).toBe(0);
-  });
+  it(
+    "should not fail check --gate for test failures when --test-results is absent",
+    { timeout: 30000 },
+    () => {
+      // Legacy: without test results the gate ignores pass/fail entirely.
+      const { exitCode } = runAllVerified(["check", "--gate"]);
+      expect(exitCode).toBe(0);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -839,11 +920,15 @@ describe("CLI: hook-pretool graceful degradation", () => {
 // hook-pretool: stderr content verification
 // ---------------------------------------------------------------------------
 describe("CLI: hook-pretool stderr", () => {
-  it("should output 'failed to parse hook input' to stderr for invalid JSON", { timeout: 30000 }, () => {
-    const { stderr, exitCode } = runWithStdin(["hook-pretool"], "{not valid json}");
-    expect(exitCode).toBe(0);
-    expect(stderr).toContain("artgraph: failed to parse hook input");
-  });
+  it(
+    "should output 'failed to parse hook input' to stderr for invalid JSON",
+    { timeout: 30000 },
+    () => {
+      const { stderr, exitCode } = runWithStdin(["hook-pretool"], "{not valid json}");
+      expect(exitCode).toBe(0);
+      expect(stderr).toContain("artgraph: failed to parse hook input");
+    },
+  );
 
   it("should output 'completed in' to stderr on successful run", { timeout: 30000 }, () => {
     const stdin = JSON.stringify({

--- a/packages/artgraph/tests/init.test.ts
+++ b/packages/artgraph/tests/init.test.ts
@@ -1,8 +1,23 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
-import { runInit, detectProject, generateConfig } from "../src/init.js";
+import {
+  runInit,
+  detectProject,
+  generateConfig,
+  installSkills,
+  SkillsInstallError,
+} from "../src/init.js";
 
 function makeTmpDir(): string {
   return mkdtempSync(join(tmpdir(), "artgraph-init-"));
@@ -316,5 +331,157 @@ describe("runInit --with-skills", () => {
     const body = readFileSync(join(tmp, ".claude", "skills", "artgraph-plan.md"), "utf-8");
     expect(body.startsWith("---")).toBe(true);
     expect(body).not.toBe("user content\n");
+  });
+
+  it("lists all conflicting files in the error (not just the first)", () => {
+    mkdirSync(join(tmp, ".claude", "skills"), { recursive: true });
+    writeFileSync(join(tmp, ".claude", "skills", "artgraph-plan.md"), "x\n");
+    writeFileSync(join(tmp, ".claude", "skills", "artgraph-verify.md"), "y\n");
+
+    let caught: unknown;
+    try {
+      runInit(tmp, { noScan: true, withSkills: true });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(SkillsInstallError);
+    const msg = (caught as Error).message;
+    expect(msg).toContain("artgraph-plan.md");
+    expect(msg).toContain("artgraph-verify.md");
+    expect(msg).toMatch(/--force/);
+  });
+
+  it("preserves user-authored skill files outside the template set on --force", () => {
+    mkdirSync(join(tmp, ".claude", "skills"), { recursive: true });
+    writeFileSync(join(tmp, ".claude", "skills", "my-custom.md"), "user skill\n");
+
+    runInit(tmp, { noScan: true, withSkills: true, force: true });
+
+    // Custom file untouched, even when --force overwrites artgraph-* templates.
+    expect(readFileSync(join(tmp, ".claude", "skills", "my-custom.md"), "utf-8")).toBe(
+      "user skill\n",
+    );
+  });
+
+  it("does not write .artgraph.json when skills pre-flight validation fails", () => {
+    mkdirSync(join(tmp, ".claude", "skills"), { recursive: true });
+    writeFileSync(join(tmp, ".claude", "skills", "artgraph-plan.md"), "preexisting\n");
+
+    expect(() => runInit(tmp, { noScan: true, withSkills: true })).toThrow(SkillsInstallError);
+
+    // Config must not exist — pre-flight check should fail before any write.
+    expect(existsSync(join(tmp, ".artgraph.json"))).toBe(false);
+    // Existing user content preserved.
+    expect(readFileSync(join(tmp, ".claude", "skills", "artgraph-plan.md"), "utf-8")).toBe(
+      "preexisting\n",
+    );
+  });
+});
+
+describe("installSkills (direct invocation)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = makeTmpDir();
+  });
+
+  afterEach(() => {
+    cleanup(tmp);
+  });
+
+  it("returns paths matching every *.md template in the template directory", () => {
+    const installed = installSkills(tmp);
+
+    // Source of truth: the templates directory itself, not a hardcoded list.
+    const templateDir = resolve(import.meta.dirname, "..", "templates", "skills");
+    const expected = readdirSync(templateDir).filter((f) => f.endsWith(".md"));
+    expect(installed.length).toBe(expected.length);
+    for (const name of expected) {
+      expect(installed).toContain(join(".claude", "skills", name));
+      expect(existsSync(join(tmp, ".claude", "skills", name))).toBe(true);
+    }
+  });
+
+  it("creates .claude/skills/ recursively when it does not exist", () => {
+    expect(existsSync(join(tmp, ".claude"))).toBe(false);
+    installSkills(tmp);
+    expect(existsSync(join(tmp, ".claude", "skills"))).toBe(true);
+  });
+
+  it("throws SkillsInstallError when the templates directory is missing (packaging fault)", () => {
+    const missingDir = join(tmp, "does-not-exist");
+
+    expect(() => installSkills(tmp, { templateDir: missingDir })).toThrow(SkillsInstallError);
+    expect(() => installSkills(tmp, { templateDir: missingDir })).toThrow(
+      /template directory not found.*packaging/i,
+    );
+  });
+
+  it("throws SkillsInstallError when the templates directory has no .md files", () => {
+    const emptyTemplates = mkdtempSync(join(tmpdir(), "artgraph-empty-templates-"));
+    // Place a non-.md file to ensure the empty check is on the filter result.
+    writeFileSync(join(emptyTemplates, "README.txt"), "not a skill\n");
+
+    try {
+      expect(() => installSkills(tmp, { templateDir: emptyTemplates })).toThrow(SkillsInstallError);
+      expect(() => installSkills(tmp, { templateDir: emptyTemplates })).toThrow(
+        /No skill templates.*packaging/i,
+      );
+    } finally {
+      rmSync(emptyTemplates, { recursive: true, force: true });
+    }
+  });
+
+  it("throws SkillsInstallError with partiallyInstalled when a copy fails mid-loop", () => {
+    const customTemplates = mkdtempSync(join(tmpdir(), "artgraph-custom-templates-"));
+    writeFileSync(join(customTemplates, "only.md"), "skill body\n");
+
+    // Place a directory at the destination so copyFileSync fails with EISDIR.
+    // force: true is required so the conflict check passes and we reach the copy step.
+    mkdirSync(join(tmp, ".claude", "skills", "only.md"), { recursive: true });
+
+    let caught: unknown;
+    try {
+      installSkills(tmp, { templateDir: customTemplates, force: true });
+    } catch (e) {
+      caught = e;
+    } finally {
+      rmSync(customTemplates, { recursive: true, force: true });
+    }
+
+    expect(caught).toBeInstanceOf(SkillsInstallError);
+    const err = caught as SkillsInstallError;
+    expect(err.partiallyInstalled).toEqual([]);
+    expect(err.message).toMatch(/Failed to copy only\.md/);
+  });
+});
+
+describe("skill template <-> dogfood sync", () => {
+  // Guards against drift between packages/artgraph/templates/skills/ (the
+  // distributed source of truth) and .claude/skills/ (this repo's dogfood
+  // copy). If one is updated without the other, this test fails.
+  function sha256(path: string): string {
+    return createHash("sha256").update(readFileSync(path)).digest("hex");
+  }
+
+  const templateDir = resolve(import.meta.dirname, "..", "templates", "skills");
+  // From packages/artgraph/tests/ up two levels to repo root, then into .claude/.
+  const dogfoodDir = resolve(import.meta.dirname, "..", "..", "..", ".claude", "skills");
+
+  it("every template has a matching dogfood file with identical content", () => {
+    // Only run when the dogfood directory actually exists (i.e. inside this
+    // repo). Consumers of the published package won't have it.
+    if (!existsSync(dogfoodDir)) {
+      return;
+    }
+
+    const templates = readdirSync(templateDir).filter((f) => f.endsWith(".md"));
+    for (const name of templates) {
+      const tHash = sha256(join(templateDir, name));
+      const dPath = join(dogfoodDir, name);
+      expect(existsSync(dPath), `dogfood file missing: ${dPath}`).toBe(true);
+      expect(sha256(dPath), `content drift in ${name}`).toBe(tHash);
+    }
   });
 });

--- a/packages/artgraph/tests/init.test.ts
+++ b/packages/artgraph/tests/init.test.ts
@@ -252,3 +252,69 @@ describe("runInit", () => {
     expect(result.scanSummary!.nodeCount).toBe(0);
   });
 });
+
+describe("runInit --with-skills", () => {
+  let tmp: string;
+  const SKILL_NAMES = [
+    "artgraph-plan.md",
+    "artgraph-verify.md",
+    "artgraph-coverage.md",
+    "artgraph-rename.md",
+  ];
+
+  beforeEach(() => {
+    tmp = makeTmpDir();
+  });
+
+  afterEach(() => {
+    cleanup(tmp);
+  });
+
+  it("does not install skills by default", () => {
+    const result = runInit(tmp, { noScan: true });
+
+    expect(result.skillsInstalled).toBeUndefined();
+    expect(existsSync(join(tmp, ".claude", "skills"))).toBe(false);
+  });
+
+  it("copies all skill templates into .claude/skills/ when --with-skills is set", () => {
+    const result = runInit(tmp, { noScan: true, withSkills: true });
+
+    expect(result.skillsInstalled).toBeDefined();
+    expect(result.skillsInstalled!.length).toBe(SKILL_NAMES.length);
+    for (const name of SKILL_NAMES) {
+      const dest = join(tmp, ".claude", "skills", name);
+      expect(existsSync(dest)).toBe(true);
+      // Frontmatter sanity: each template begins with `---` block + `name:` field.
+      const body = readFileSync(dest, "utf-8");
+      expect(body.startsWith("---")).toBe(true);
+      expect(body).toMatch(/name:\s*["']?artgraph-/);
+    }
+  });
+
+  it("throws when a skill file already exists and --force is not set", () => {
+    mkdirSync(join(tmp, ".claude", "skills"), { recursive: true });
+    writeFileSync(join(tmp, ".claude", "skills", "artgraph-plan.md"), "user content\n");
+
+    expect(() => runInit(tmp, { noScan: true, withSkills: true })).toThrow(
+      /artgraph-plan\.md.*--force/,
+    );
+
+    // Existing user content must be preserved.
+    expect(readFileSync(join(tmp, ".claude", "skills", "artgraph-plan.md"), "utf-8")).toBe(
+      "user content\n",
+    );
+  });
+
+  it("overwrites existing skill files when --force is set", () => {
+    mkdirSync(join(tmp, ".claude", "skills"), { recursive: true });
+    writeFileSync(join(tmp, ".claude", "skills", "artgraph-plan.md"), "user content\n");
+
+    const result = runInit(tmp, { noScan: true, withSkills: true, force: true });
+
+    expect(result.skillsInstalled!.length).toBe(SKILL_NAMES.length);
+    const body = readFileSync(join(tmp, ".claude", "skills", "artgraph-plan.md"), "utf-8");
+    expect(body.startsWith("---")).toBe(true);
+    expect(body).not.toBe("user content\n");
+  });
+});


### PR DESCRIPTION
## Summary

`artgraph init` に `--with-skills` フラグを追加し、`.claude/skills/` に 4 つの Skills テンプレート（plan / verify / coverage / rename）を配置する。

- `packages/artgraph/templates/skills/artgraph-*.md` をパッケージ配布物のソースに（package.json の `files` に `templates` を追加）
- `installSkills()` を `src/init.ts` に追加: 既存ファイルがあれば衝突リストを含むエラーで停止、`--force` 指定時は上書き
- `InitOptions.withSkills` / `InitResult.skillsInstalled` を追加
- CLI: `--with-skills` フラグ追加、JSON / text 両出力で配置先を報告
- text 出力末尾に "Installed N Claude Code skills:" 案内を追加
- tests/init.test.ts に 4 ケース追加（既定 off / 4 ファイル配置 / 既存衝突エラー / --force 上書き）

## Test plan

- [x] `pnpm -r build` 緑
- [x] `pnpm -r test` 24 ファイル / 385 tests pass（既存 381 + 新 4）
- [x] smoke test: `node packages/artgraph/dist/cli.js init --no-scan --with-skills` で `.claude/skills/` に 4 ファイル配置確認
- [x] 既存ファイル衝突時のエラー / `--force` 上書き挙動を unit test で網羅

## 関連 Issue

- Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)