### PR TITLE
feat(artgraph): Markdown インラインリンクから doc→doc 依存を自動抽出 (#11)

### DIFF
--- a/packages/artgraph/README.md
+++ b/packages/artgraph/README.md
@@ -47,6 +47,13 @@ pair always wins over an inline link.
 }
 ```
 
+> **Behavior change on upgrade.** `inlineLinks` and `linkWarnings.unresolved`
+> default to `true`, so an upgrade in place can both add `depends_on` edges to
+> the graph and emit new `WARNING: unresolved-link` lines on stderr for inline
+> links pointing at non-existent `.md` files. If you gate CI on stderr or on
+> graph stability, opt out with `"docGraph": { "inlineLinks": false }` (and/or
+> `"linkWarnings": { "unresolved": false }`) and migrate at your pace.
+
 ## Commands
 
 | Command               | Purpose                                                        |

--- a/packages/artgraph/README.md
+++ b/packages/artgraph/README.md
@@ -22,9 +22,30 @@ npx artgraph init      # writes .artgraph.json
 | Spec heading (Kiro) | `### Requirement 1: description`                |
 | Implementation      | `// @impl REQ-001`                              |
 | Test                | `it("[REQ-001] …")` or `// req: "REQ-001"`      |
-| Doc relations       | frontmatter `artgraph.depends_on` / `derives_from` |
+| Doc relations       | frontmatter `artgraph.depends_on` / `derives_from`, or inline `[text](./other.md)` links |
 
 Custom grammars are configurable via `reqPatterns` in `.artgraph.json`.
+
+Inline markdown links between spec/doc files are picked up automatically and
+emitted as `depends_on` edges (e.g. `design.md` with `See [requirements](./requirements.md)`
+generates `doc:design.md --depends_on--> doc:requirements.md`). Direct, reference-style
+(`[x][ref]` + `[ref]: ./...`), and shortcut forms are all supported; anchors and
+queries are stripped; links inside code fences and inline code are ignored. A
+frontmatter relation (`derives_from` / `depends_on`) on the same `(source, target)`
+pair always wins over an inline link.
+
+```jsonc
+// .artgraph.json
+{
+  "docGraph": {
+    "inlineLinks": true,             // default true — set false to disable
+    "linkWarnings": {
+      "unresolved": true,            // default true — warn on links to missing .md
+      "outOfScope": false            // default false — warn on .md outside specDirs
+    }
+  }
+}
+```
 
 ## Commands
 

--- a/packages/artgraph/src/cli.ts
+++ b/packages/artgraph/src/cli.ts
@@ -456,6 +456,16 @@ function printWarnings(warnings: BuildWarning[]) {
       case "reserved-prefix":
         console.error(`WARNING: reserved prefix in ID "${w.id}" in ${w.files.join(", ")}`);
         break;
+      case "unresolved-link":
+        console.error(
+          `WARNING: unresolved-link "${w.id}" referenced from ${w.files.join(", ")}`,
+        );
+        break;
+      case "out-of-scope-link":
+        console.error(
+          `WARNING: out-of-scope-link "${w.id}" referenced from ${w.files.join(", ")} (outside specDirs)`,
+        );
+        break;
     }
   }
 }

--- a/packages/artgraph/src/graph/builder.ts
+++ b/packages/artgraph/src/graph/builder.ts
@@ -276,7 +276,13 @@ export function buildGraph(
   if (inlineLinksEnabled && allInlineLinks.length > 0) {
     const docNodesByFilePath = new Map<string, GraphNode>();
     for (const node of nodes.values()) {
-      if (node.kind === "doc") docNodesByFilePath.set(node.filePath, node);
+      if (node.kind === "doc") {
+        // node.filePath is `relative(rootDir, file)`, which yields
+        // back-slashes on Windows; targetRelPath from the parser is
+        // already forward-slash-normalized. Normalize the key so lookups
+        // succeed on both platforms.
+        docNodesByFilePath.set(node.filePath.split(/[\\/]/).join("/"), node);
+      }
     }
 
     // Pairs (source, target) already declared by frontmatter — inline links
@@ -290,6 +296,12 @@ export function buildGraph(
         explicitPairs.add(`${edge.source}|${edge.target}`);
       }
     }
+
+    // Suppress duplicate warnings when an author writes the same broken /
+    // out-of-scope target multiple times in one file. Edges get deduped at the
+    // end of buildGraph; warnings need their own bookkeeping because the same
+    // (source, target) never reaches the edges array.
+    const warnedLinks = new Set<string>();
 
     for (const link of allInlineLinks) {
       const sourceNode = nodes.get(link.sourceDocId);
@@ -309,16 +321,22 @@ export function buildGraph(
       // No matching doc node — decide between unresolved (file missing) and
       // out-of-scope (file present but not under specDirs).
       const targetExists = existsSync(resolve(rootDir, link.targetRelPath));
-      if (targetExists) {
-        if (warnOutOfScope) {
-          warnings.push({
-            type: "out-of-scope-link",
-            id: link.targetRelPath,
-            files: [sourceNode.filePath],
-            message: `inline link "${link.rawHref}" targets ${link.targetRelPath} which is outside specDirs`,
-          });
-        }
-      } else if (warnUnresolved) {
+      const warnType = targetExists ? "out-of-scope-link" : "unresolved-link";
+      if (warnType === "out-of-scope-link" && !warnOutOfScope) continue;
+      if (warnType === "unresolved-link" && !warnUnresolved) continue;
+
+      const dedupKey = `${warnType}|${sourceNode.filePath}|${link.targetRelPath}`;
+      if (warnedLinks.has(dedupKey)) continue;
+      warnedLinks.add(dedupKey);
+
+      if (warnType === "out-of-scope-link") {
+        warnings.push({
+          type: "out-of-scope-link",
+          id: link.targetRelPath,
+          files: [sourceNode.filePath],
+          message: `inline link "${link.rawHref}" targets ${link.targetRelPath} which is outside specDirs`,
+        });
+      } else {
         warnings.push({
           type: "unresolved-link",
           id: link.targetRelPath,

--- a/packages/artgraph/src/graph/builder.ts
+++ b/packages/artgraph/src/graph/builder.ts
@@ -1,11 +1,19 @@
 import { resolve, relative, basename, dirname } from "node:path";
+import { existsSync } from "node:fs";
 import { globSync } from "glob";
-import { parseMarkdown, type ParseWarning } from "../parsers/markdown.js";
+import { parseMarkdown, type ParseWarning, type InlineLinkRef } from "../parsers/markdown.js";
 import { createTSParser } from "../parsers/typescript.js";
 import type { ArtifactGraph, GraphNode, GraphEdge, ArtgraphConfig } from "../types.js";
 
 export interface BuildWarning {
-  type: "duplicate-id" | "ambiguous-id" | "orphan-doc" | "invalid-relation" | "reserved-prefix";
+  type:
+    | "duplicate-id"
+    | "ambiguous-id"
+    | "orphan-doc"
+    | "invalid-relation"
+    | "reserved-prefix"
+    | "unresolved-link"
+    | "out-of-scope-link";
   id: string;
   files: string[];
   message?: string;
@@ -28,6 +36,9 @@ export function buildGraph(
 
   const autoNodes = config.docGraph?.autoNodes ?? true;
   const autoContains = config.docGraph?.autoContains ?? true;
+  const inlineLinksEnabled = config.docGraph?.inlineLinks ?? true;
+  const warnUnresolved = config.docGraph?.linkWarnings?.unresolved ?? true;
+  const warnOutOfScope = config.docGraph?.linkWarnings?.outOfScope ?? false;
   const RESERVED_PREFIXES = ["doc:", "file:", "test:", "symbol:"];
   const parseWarnings: ParseWarning[] = [];
 
@@ -35,6 +46,7 @@ export function buildGraph(
   const collected: CollectedReq[] = [];
   const nonReqNodes: GraphNode[] = [];
   const nonReqEdges: GraphEdge[] = [];
+  const allInlineLinks: InlineLinkRef[] = [];
 
   for (const specDirName of config.specDirs) {
     const specFiles = globSync(resolve(rootDir, specDirName, "**/*.md"));
@@ -48,8 +60,11 @@ export function buildGraph(
       : relFile;
     const expectedAutoDocId = `doc:${specDirRelPath}`;
 
-    // Collect parse warnings
+    // Collect parse warnings and inline-link references
     parseWarnings.push(...result.warnings);
+    if (inlineLinksEnabled) {
+      allInlineLinks.push(...result.inlineLinks);
+    }
 
     for (const node of result.nodes) {
       if (node.kind === "req") {
@@ -247,6 +262,68 @@ export function buildGraph(
           id: edge.target,
           files: [sourceNode.filePath],
           message: `referenced from ${sourceNode.filePath} but not found in graph`,
+        });
+      }
+    }
+  }
+
+  // Issue #11: Convert collected inline markdown links into depends_on edges.
+  // This must run AFTER all doc nodes are registered (so we can resolve
+  // targets) and AFTER frontmatter edges land (so we can suppress inline
+  // edges that conflict with an explicit relation), but BEFORE dedup so the
+  // existing (source|target|kind) dedup naturally collapses redundant inline
+  // links to the same target.
+  if (inlineLinksEnabled && allInlineLinks.length > 0) {
+    const docNodesByFilePath = new Map<string, GraphNode>();
+    for (const node of nodes.values()) {
+      if (node.kind === "doc") docNodesByFilePath.set(node.filePath, node);
+    }
+
+    // Pairs (source, target) already declared by frontmatter — inline links
+    // pointing at the same pair are dropped regardless of kind so an author's
+    // explicit `derives_from` always wins over an inferred `depends_on`.
+    const explicitPairs = new Set<string>();
+    for (const edge of edges) {
+      if (edge.kind !== "derives_from" && edge.kind !== "depends_on") continue;
+      const sourceNode = nodes.get(edge.source);
+      if (sourceNode?.kind === "doc") {
+        explicitPairs.add(`${edge.source}|${edge.target}`);
+      }
+    }
+
+    for (const link of allInlineLinks) {
+      const sourceNode = nodes.get(link.sourceDocId);
+      if (!sourceNode) continue; // source doc was filtered out (autoNodes=false)
+
+      const targetNode = docNodesByFilePath.get(link.targetRelPath);
+      if (targetNode) {
+        if (explicitPairs.has(`${link.sourceDocId}|${targetNode.id}`)) continue;
+        edges.push({
+          source: link.sourceDocId,
+          target: targetNode.id,
+          kind: "depends_on",
+        });
+        continue;
+      }
+
+      // No matching doc node — decide between unresolved (file missing) and
+      // out-of-scope (file present but not under specDirs).
+      const targetExists = existsSync(resolve(rootDir, link.targetRelPath));
+      if (targetExists) {
+        if (warnOutOfScope) {
+          warnings.push({
+            type: "out-of-scope-link",
+            id: link.targetRelPath,
+            files: [sourceNode.filePath],
+            message: `inline link "${link.rawHref}" targets ${link.targetRelPath} which is outside specDirs`,
+          });
+        }
+      } else if (warnUnresolved) {
+        warnings.push({
+          type: "unresolved-link",
+          id: link.targetRelPath,
+          files: [sourceNode.filePath],
+          message: `inline link "${link.rawHref}" → ${link.targetRelPath} not found`,
         });
       }
     }

--- a/packages/artgraph/src/parsers/markdown.ts
+++ b/packages/artgraph/src/parsers/markdown.ts
@@ -20,7 +20,10 @@ const METADATA_FIELDS = ["title", "status", "priority", "owner"] as const;
 // Matches `<scheme>:` at the start of an href (e.g. `http:`, `mailto:`, `tel:`,
 // `javascript:`). Used to skip absolute URLs — only relative paths point at
 // another file in the workspace.
-const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+// The scheme requires at least 2 characters so single-letter prefixes like
+// `C:/foo.md` (Windows drive letters) aren't mistaken for URL schemes; no real
+// scheme is a single letter (RFC 3986 allows it in theory but none are deployed).
+const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]+:/i;
 
 export interface ParseWarning {
   type: "invalid-relation" | "reserved-prefix";
@@ -259,10 +262,10 @@ function resolveInlineHref(rawHref: string, sourceAbsPath: string, rootDir: stri
   const absTarget = resolvePath(dirname(sourceAbsPath), decoded);
   const rel = relative(rootDir, absTarget);
   if (!rel || rel.startsWith("..")) {
-    // Outside rootDir — the builder can still warn via `out-of-scope-link` if
-    // it cares, but we surface only the normalized form here. Returning null
-    // for now keeps the parser side strict; the builder will issue
-    // out-of-scope warnings based on specDirs when needed (a follow-up).
+    // Outside rootDir — drop silently here. The "rootDir-internal but outside
+    // specDirs" case is handled by the builder via the `out-of-scope-link`
+    // warning (which checks the file actually exists). Anything truly outside
+    // the project tree gets no treatment at all.
     return null;
   }
   // Normalize path separators to forward slashes for cross-platform stability.

--- a/packages/artgraph/src/parsers/markdown.ts
+++ b/packages/artgraph/src/parsers/markdown.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { relative } from "node:path";
+import { relative, resolve as resolvePath, dirname } from "node:path";
 import matter from "gray-matter";
 import { unified } from "unified";
 import remarkParse from "remark-parse";
@@ -17,6 +17,10 @@ export interface ParseMarkdownOptions {
 const LIST_ITEM_RE = /^(?:\*\*)?([A-Z][A-Za-z]*-\d+)(?:\*\*)?[:\s]/;
 const KIRO_HEADING_RE = /^Requirement\s+(\d+)\s*:/;
 const METADATA_FIELDS = ["title", "status", "priority", "owner"] as const;
+// Matches `<scheme>:` at the start of an href (e.g. `http:`, `mailto:`, `tel:`,
+// `javascript:`). Used to skip absolute URLs — only relative paths point at
+// another file in the workspace.
+const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
 
 export interface ParseWarning {
   type: "invalid-relation" | "reserved-prefix";
@@ -24,10 +28,25 @@ export interface ParseWarning {
   filePath: string;
 }
 
+export interface InlineLinkRef {
+  // The doc node id of the source markdown file. Resolved at parse time using
+  // the same logic as the doc node itself, so the builder can treat it as the
+  // edge's source without re-deriving it.
+  sourceDocId: string;
+  // Project-root-relative path of the target .md file. Anchor (`#...`) and
+  // query (`?...`) are stripped and the path is percent-decoded so the builder
+  // can map it 1-to-1 onto a doc node.
+  targetRelPath: string;
+  // The raw href as written in the source markdown — kept for diagnostics so
+  // unresolved/out-of-scope warnings can quote what the author wrote.
+  rawHref: string;
+}
+
 interface ParsedSpec {
   nodes: GraphNode[];
   edges: GraphEdge[];
   warnings: ParseWarning[];
+  inlineLinks: InlineLinkRef[];
 }
 
 export function parseMarkdown(filePath: string, options?: ParseMarkdownOptions): ParsedSpec {
@@ -157,7 +176,97 @@ export function parseMarkdown(filePath: string, options?: ParseMarkdownOptions):
     });
   });
 
-  return { nodes, edges, warnings };
+  const inlineLinks = extractInlineLinks(tree, {
+    sourceAbsPath: filePath,
+    rootDir,
+    sourceDocId: docId,
+  });
+
+  return { nodes, edges, warnings, inlineLinks };
+}
+
+interface ExtractInlineLinksContext {
+  sourceAbsPath: string;
+  rootDir?: string;
+  sourceDocId: string;
+}
+
+function extractInlineLinks(tree: any, ctx: ExtractInlineLinksContext): InlineLinkRef[] {
+  if (!ctx.rootDir) return [];
+
+  // Definitions can appear anywhere in the file (often at the bottom), so we
+  // collect them first and then resolve linkReferences against this map.
+  const definitions = new Map<string, string>();
+  visit(tree, "definition", (node: any) => {
+    if (typeof node.identifier === "string" && typeof node.url === "string") {
+      definitions.set(node.identifier, node.url);
+    }
+  });
+
+  const links: InlineLinkRef[] = [];
+
+  const handle = (rawHref: string) => {
+    const target = resolveInlineHref(rawHref, ctx.sourceAbsPath, ctx.rootDir!);
+    if (target == null) return;
+    links.push({
+      sourceDocId: ctx.sourceDocId,
+      targetRelPath: target,
+      rawHref,
+    });
+  };
+
+  // remark-parse never emits `link`/`linkReference` children inside `code`,
+  // `inlineCode`, or `image` nodes, so fenced/indented code blocks, inline
+  // code spans, and images are naturally excluded without explicit handling.
+  visit(tree, "link", (node: any) => {
+    if (typeof node.url === "string") handle(node.url);
+  });
+
+  visit(tree, "linkReference", (node: any) => {
+    if (typeof node.identifier !== "string") return;
+    const url = definitions.get(node.identifier);
+    if (typeof url === "string") handle(url);
+  });
+
+  return links;
+}
+
+function resolveInlineHref(rawHref: string, sourceAbsPath: string, rootDir: string): string | null {
+  if (!rawHref) return null;
+  // Pure-fragment links like `#section` and protocol-relative URLs like
+  // `//cdn/...` are not workspace references.
+  if (rawHref.startsWith("#") || rawHref.startsWith("//")) return null;
+  if (URL_SCHEME_RE.test(rawHref)) return null;
+
+  // Strip fragment first so a `?` inside the fragment isn't mistaken for query.
+  let href = rawHref;
+  const hashAt = href.indexOf("#");
+  if (hashAt >= 0) href = href.slice(0, hashAt);
+  const queryAt = href.indexOf("?");
+  if (queryAt >= 0) href = href.slice(0, queryAt);
+  if (!href) return null;
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(href);
+  } catch {
+    // Malformed percent-encoding — skip rather than crash the whole parse.
+    return null;
+  }
+
+  if (!decoded.toLowerCase().endsWith(".md")) return null;
+
+  const absTarget = resolvePath(dirname(sourceAbsPath), decoded);
+  const rel = relative(rootDir, absTarget);
+  if (!rel || rel.startsWith("..")) {
+    // Outside rootDir — the builder can still warn via `out-of-scope-link` if
+    // it cares, but we surface only the normalized form here. Returning null
+    // for now keeps the parser side strict; the builder will issue
+    // out-of-scope warnings based on specDirs when needed (a follow-up).
+    return null;
+  }
+  // Normalize path separators to forward slashes for cross-platform stability.
+  return rel.split(/[\\/]/).join("/");
 }
 
 function extractMetadata(fm: Record<string, any>): Record<string, string> | undefined {

--- a/packages/artgraph/src/types.ts
+++ b/packages/artgraph/src/types.ts
@@ -119,6 +119,11 @@ export type TestResultMap = Map<string, TestResultRecord[]>;
 export interface DocGraphConfig {
   autoNodes?: boolean;
   autoContains?: boolean;
+  inlineLinks?: boolean;
+  linkWarnings?: {
+    unresolved?: boolean;
+    outOfScope?: boolean;
+  };
 }
 
 export interface ArtgraphConfig {

--- a/packages/artgraph/tests/builder.test.ts
+++ b/packages/artgraph/tests/builder.test.ts
@@ -376,6 +376,74 @@ describe("buildGraph: inline markdown links (issue #11)", () => {
     const unresolved = warnings.filter((w) => w.type === "unresolved-link");
     expect(unresolved).toHaveLength(0);
   });
+
+  it("dedupes unresolved-link warnings when the same source links to the same missing target multiple times", () => {
+    const tmpRoot = resolve(import.meta.dirname, "fixtures/tmp-warn-dedup");
+    const tmpSpecs = resolve(tmpRoot, "specs");
+    mkdirSync(tmpSpecs, { recursive: true });
+    writeFileSync(
+      resolve(tmpSpecs, "loud.md"),
+      `# Loud\n\n[a](./gone.md) [b](./gone.md) [c](./gone.md)\n`,
+    );
+
+    try {
+      const tmpConfig: ArtgraphConfig = { ...config, include: [], testPatterns: [] };
+      const { warnings } = buildGraph(tmpRoot, tmpConfig);
+      const unresolved = warnings.filter(
+        (w) => w.type === "unresolved-link" && w.id === "specs/gone.md",
+      );
+      // 3 inline links → 1 warning, not 3
+      expect(unresolved).toHaveLength(1);
+      expect(unresolved[0].files).toContain("specs/loud.md");
+    } finally {
+      rmSync(tmpRoot, { recursive: true });
+    }
+  });
+
+  it("emits out-of-scope-link only when the target exists outside specDirs and the warning is enabled", () => {
+    // tmp layout:
+    //   specs/foo.md   — inline link to ../docs/notes.md
+    //   docs/notes.md  — exists, but `docs/` is NOT in specDirs
+    const tmpRoot = resolve(import.meta.dirname, "fixtures/tmp-out-of-scope");
+    const tmpSpecs = resolve(tmpRoot, "specs");
+    const tmpDocs = resolve(tmpRoot, "docs");
+    mkdirSync(tmpSpecs, { recursive: true });
+    mkdirSync(tmpDocs, { recursive: true });
+    writeFileSync(
+      resolve(tmpSpecs, "foo.md"),
+      `# Foo\n\nSee [notes](../docs/notes.md).\n`,
+    );
+    writeFileSync(resolve(tmpDocs, "notes.md"), `# Notes\n`);
+
+    try {
+      const tmpConfig: ArtgraphConfig = {
+        ...config,
+        include: [],
+        testPatterns: [],
+        // specDirs intentionally excludes "docs" so the target is "out of scope"
+        specDirs: ["specs"],
+      };
+
+      // Default (outOfScope: false) — silent
+      const silentResult = buildGraph(tmpRoot, tmpConfig);
+      expect(silentResult.warnings.some((w) => w.type === "out-of-scope-link")).toBe(false);
+      // It's also not an unresolved-link, because the file exists
+      expect(silentResult.warnings.some((w) => w.type === "unresolved-link")).toBe(false);
+
+      // Opt-in (outOfScope: true) — emits warning
+      const loudResult = buildGraph(tmpRoot, {
+        ...tmpConfig,
+        docGraph: { linkWarnings: { outOfScope: true } },
+      });
+      const w = loudResult.warnings.find(
+        (w) => w.type === "out-of-scope-link" && w.id === "docs/notes.md",
+      );
+      expect(w).toBeDefined();
+      expect(w!.files).toContain("specs/foo.md");
+    } finally {
+      rmSync(tmpRoot, { recursive: true });
+    }
+  });
 });
 
 describe("buildGraph: lock file excludes contains edges (T065)", () => {

--- a/packages/artgraph/tests/builder.test.ts
+++ b/packages/artgraph/tests/builder.test.ts
@@ -288,6 +288,96 @@ describe("buildGraph: contains edges with autoNodes=false + explicit node_id", (
   });
 });
 
+describe("buildGraph: inline markdown links (issue #11)", () => {
+  it("creates depends_on edges from inline links to existing doc nodes", () => {
+    const { graph } = buildGraph(FIXTURE_DIR, config);
+    // source.md → target.md (which has node_id "il-target")
+    const edge = graph.edges.find(
+      (e) =>
+        e.kind === "depends_on" &&
+        e.source === "doc:inline-links/source.md" &&
+        e.target === "il-target",
+    );
+    expect(edge).toBeDefined();
+  });
+
+  it("dedupes inline-link edges so source.md contributes only one depends_on to target", () => {
+    const { graph } = buildGraph(FIXTURE_DIR, config);
+    const edges = graph.edges.filter(
+      (e) =>
+        e.kind === "depends_on" &&
+        e.source === "doc:inline-links/source.md" &&
+        e.target === "il-target",
+    );
+    expect(edges).toHaveLength(1);
+  });
+
+  it("resolves reference-style inline links to the same target", () => {
+    const { graph } = buildGraph(FIXTURE_DIR, config);
+    const edge = graph.edges.find(
+      (e) =>
+        e.kind === "depends_on" &&
+        e.source === "doc:inline-links/ref-source.md" &&
+        e.target === "il-target",
+    );
+    expect(edge).toBeDefined();
+  });
+
+  it("does not generate inline edges from code-fenced links", () => {
+    const { graph } = buildGraph(FIXTURE_DIR, config);
+    const fenced = graph.edges.filter(
+      (e) => e.source === "doc:inline-links/code-fence.md" && e.target === "il-target",
+    );
+    // Only the trailing real link creates an edge — exactly 1, not 4
+    expect(fenced).toHaveLength(1);
+  });
+
+  it("warns unresolved-link when a .md target does not exist", () => {
+    const { warnings } = buildGraph(FIXTURE_DIR, config);
+    const w = warnings.find(
+      (w) => w.type === "unresolved-link" && w.id === "specs/inline-links/missing.md",
+    );
+    expect(w).toBeDefined();
+    expect(w!.files).toContain("specs/inline-links/dead-source.md");
+  });
+
+  it("frontmatter derives_from suppresses inline depends_on to the same target", () => {
+    const { graph } = buildGraph(FIXTURE_DIR, config);
+    // conflict.md frontmatter: derives_from il-target. Inline link also points to target.md.
+    // We must keep the frontmatter edge and drop the inline one.
+    const fromConflict = graph.edges.filter(
+      (e) => e.source === "il-conflict" && e.target === "il-target",
+    );
+    expect(fromConflict).toHaveLength(1);
+    expect(fromConflict[0].kind).toBe("derives_from");
+  });
+
+  it("respects docGraph.inlineLinks=false", () => {
+    const off: ArtgraphConfig = {
+      ...config,
+      docGraph: { inlineLinks: false },
+    };
+    const { graph, warnings } = buildGraph(FIXTURE_DIR, off);
+    const inlineEdges = graph.edges.filter(
+      (e) => e.kind === "depends_on" && e.source === "doc:inline-links/source.md",
+    );
+    expect(inlineEdges).toHaveLength(0);
+    // No unresolved-link warnings either when the feature is off
+    const unresolved = warnings.filter((w) => w.type === "unresolved-link");
+    expect(unresolved).toHaveLength(0);
+  });
+
+  it("respects docGraph.linkWarnings.unresolved=false", () => {
+    const quiet: ArtgraphConfig = {
+      ...config,
+      docGraph: { linkWarnings: { unresolved: false } },
+    };
+    const { warnings } = buildGraph(FIXTURE_DIR, quiet);
+    const unresolved = warnings.filter((w) => w.type === "unresolved-link");
+    expect(unresolved).toHaveLength(0);
+  });
+});
+
 describe("buildGraph: lock file excludes contains edges (T065)", () => {
   it("should not include contains-only dependencies in lock file", () => {
     // Use an isolated fixture where a doc has contains edges but no depends_on/derives_from

--- a/packages/artgraph/tests/cli.test.ts
+++ b/packages/artgraph/tests/cli.test.ts
@@ -436,6 +436,80 @@ describe("CLI: warning output", () => {
       rm(tmpRoot, { recursive: true, force: true });
     }
   });
+
+  it("should output unresolved-link warning to stderr (issue #11)", { timeout: 30000 }, () => {
+    const { mkdirSync, writeFileSync, rmSync: rm } = require("node:fs");
+    const { mkdtempSync } = require("node:fs");
+    const { tmpdir } = require("node:os");
+    const { join } = require("node:path");
+    const tmpRoot = mkdtempSync(join(tmpdir(), "artgraph-warn-"));
+    mkdirSync(join(tmpRoot, "specs"), { recursive: true });
+    mkdirSync(join(tmpRoot, "src"), { recursive: true });
+    writeFileSync(join(tmpRoot, "src", "app.ts"), "export const x = 1;\n");
+    writeFileSync(
+      join(tmpRoot, ".artgraph.json"),
+      JSON.stringify({ include: ["src/**/*.ts"], specDirs: ["specs"] }),
+    );
+    writeFileSync(
+      join(tmpRoot, "specs", "dead.md"),
+      `# Dead link\n\nSee [gone](./missing.md).\n`,
+    );
+
+    try {
+      const proc = spawnSync("node", [CLI, "scan"], {
+        encoding: "utf-8",
+        cwd: tmpRoot,
+        timeout: 30000,
+      });
+      expect(proc.status).toBe(0);
+      expect(proc.stderr).toContain("unresolved-link");
+      expect(proc.stderr).toContain("specs/missing.md");
+    } finally {
+      rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("should build depends_on edge from inline markdown link (issue #11)", { timeout: 30000 }, () => {
+    const { mkdirSync, writeFileSync, rmSync: rm } = require("node:fs");
+    const { mkdtempSync } = require("node:fs");
+    const { tmpdir } = require("node:os");
+    const { join } = require("node:path");
+    const tmpRoot = mkdtempSync(join(tmpdir(), "artgraph-il-"));
+    mkdirSync(join(tmpRoot, "specs"), { recursive: true });
+    mkdirSync(join(tmpRoot, "src"), { recursive: true });
+    writeFileSync(join(tmpRoot, "src", "app.ts"), "export const x = 1;\n");
+    writeFileSync(
+      join(tmpRoot, ".artgraph.json"),
+      JSON.stringify({ include: ["src/**/*.ts"], specDirs: ["specs"] }),
+    );
+    writeFileSync(
+      join(tmpRoot, "specs", "design.md"),
+      `# Design\n\nDerived from [requirements](./requirements.md).\n`,
+    );
+    writeFileSync(
+      join(tmpRoot, "specs", "requirements.md"),
+      `# Requirements\n`,
+    );
+
+    try {
+      const proc = spawnSync("node", [CLI, "graph", "--format", "json"], {
+        encoding: "utf-8",
+        cwd: tmpRoot,
+        timeout: 30000,
+      });
+      expect(proc.status).toBe(0);
+      const out = JSON.parse(proc.stdout);
+      const edge = out.edges.find(
+        (e: any) =>
+          e.kind === "depends_on" &&
+          e.source === "doc:design.md" &&
+          e.target === "doc:requirements.md",
+      );
+      expect(edge).toBeDefined();
+    } finally {
+      rm(tmpRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/artgraph/tests/fixtures/specs/inline-links/code-fence.md
+++ b/packages/artgraph/tests/fixtures/specs/inline-links/code-fence.md
@@ -1,0 +1,15 @@
+# Code-fenced and inline-coded links
+
+Inside a fenced code block (must be ignored):
+
+```
+[fenced](./target.md)
+```
+
+Inside an indented code block (must be ignored):
+
+    [indented](./target.md)
+
+Inside inline code (must be ignored): `[inline](./target.md)`.
+
+A real link still works outside code: [real](./target.md).

--- a/packages/artgraph/tests/fixtures/specs/inline-links/conflict.md
+++ b/packages/artgraph/tests/fixtures/specs/inline-links/conflict.md
@@ -1,0 +1,13 @@
+---
+artgraph:
+  node_id: "il-conflict"
+  derives_from:
+    - il-target
+---
+
+# Conflict
+
+frontmatter says `derives_from`, inline link below would otherwise generate `depends_on`.
+The inline edge must be dropped because frontmatter wins.
+
+See [target](./target.md).

--- a/packages/artgraph/tests/fixtures/specs/inline-links/dead-source.md
+++ b/packages/artgraph/tests/fixtures/specs/inline-links/dead-source.md
@@ -1,0 +1,3 @@
+# Dead link source
+
+This link points at a file that does not exist: [gone](./missing.md).

--- a/packages/artgraph/tests/fixtures/specs/inline-links/ref-source.md
+++ b/packages/artgraph/tests/fixtures/specs/inline-links/ref-source.md
@@ -1,0 +1,11 @@
+# Reference-style links
+
+Full reference: [target full][ref-target].
+
+Collapsed: [ref-target][].
+
+Shortcut: [ref-target].
+
+Unknown definition is ignored: [missing][nope].
+
+[ref-target]: ./target.md

--- a/packages/artgraph/tests/fixtures/specs/inline-links/source.md
+++ b/packages/artgraph/tests/fixtures/specs/inline-links/source.md
@@ -1,0 +1,23 @@
+# Inline-link source
+
+Plain inline link: [target](./target.md).
+
+With anchor: [target-anchor](./target.md#section).
+
+With query: [target-query](./target.md?v=1).
+
+With anchor and query: [target-both](./target.md?v=1#x).
+
+Percent-encoded: [encoded](./target%2Emd).
+
+Image is ignored: ![alt](./target.md)
+
+Pure fragment is ignored: [self](#section)
+
+Empty href is ignored: [empty]()
+
+External URL ignored: [ext](https://example.com/design.md)
+
+mailto ignored: [mail](mailto:foo@example.com)
+
+Non-md ignored: [code](./source.ts)

--- a/packages/artgraph/tests/fixtures/specs/inline-links/target.md
+++ b/packages/artgraph/tests/fixtures/specs/inline-links/target.md
@@ -1,0 +1,8 @@
+---
+artgraph:
+  node_id: "il-target"
+---
+
+# Inline link target
+
+A doc with a custom node_id, referenced by source.md / ref-source.md / etc.

--- a/packages/artgraph/tests/markdown.test.ts
+++ b/packages/artgraph/tests/markdown.test.ts
@@ -315,6 +315,100 @@ artgraph:
     });
   });
 
+  describe("issue #11: inline markdown links", () => {
+    it("extracts a plain inline link as an inlineLinks ref", () => {
+      const result = parseMarkdown(resolve(FIXTURE_DIR, "specs/inline-links/source.md"), {
+        rootDir: FIXTURE_DIR,
+        specDirPrefix: "specs",
+      });
+      const targets = result.inlineLinks.map((l) => l.targetRelPath);
+      expect(targets).toContain("specs/inline-links/target.md");
+    });
+
+    it("strips fragment and query before resolving the target", () => {
+      const result = parseMarkdown(resolve(FIXTURE_DIR, "specs/inline-links/source.md"), {
+        rootDir: FIXTURE_DIR,
+        specDirPrefix: "specs",
+      });
+      // 4 links in source.md hit target.md: plain, #section, ?v=1, ?v=1#x — all should normalize to the same target path
+      const toTarget = result.inlineLinks.filter(
+        (l) => l.targetRelPath === "specs/inline-links/target.md",
+      );
+      expect(toTarget.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it("ignores images, external URLs, mailto, non-md, empty href and pure fragments", () => {
+      const result = parseMarkdown(resolve(FIXTURE_DIR, "specs/inline-links/source.md"), {
+        rootDir: FIXTURE_DIR,
+        specDirPrefix: "specs",
+      });
+      // None of the inline links should target external/non-md/etc.
+      for (const link of result.inlineLinks) {
+        expect(link.targetRelPath.endsWith(".md")).toBe(true);
+        expect(link.targetRelPath.startsWith("http")).toBe(false);
+      }
+      // The image and external/mailto/.ts entries should not appear
+      const raws = result.inlineLinks.map((l) => l.rawHref);
+      expect(raws).not.toContain("https://example.com/design.md");
+      expect(raws).not.toContain("mailto:foo@example.com");
+      expect(raws).not.toContain("./source.ts");
+      expect(raws).not.toContain("#section");
+      expect(raws).not.toContain("");
+    });
+
+    it("decodes percent-encoded paths", () => {
+      const result = parseMarkdown(resolve(FIXTURE_DIR, "specs/inline-links/source.md"), {
+        rootDir: FIXTURE_DIR,
+        specDirPrefix: "specs",
+      });
+      const encoded = result.inlineLinks.find((l) => l.rawHref === "./target%2Emd");
+      expect(encoded).toBeDefined();
+      expect(encoded!.targetRelPath).toBe("specs/inline-links/target.md");
+    });
+
+    it("resolves reference-style links (full, collapsed, shortcut)", () => {
+      const result = parseMarkdown(resolve(FIXTURE_DIR, "specs/inline-links/ref-source.md"), {
+        rootDir: FIXTURE_DIR,
+        specDirPrefix: "specs",
+      });
+      const toTarget = result.inlineLinks.filter(
+        (l) => l.targetRelPath === "specs/inline-links/target.md",
+      );
+      // Three resolvable references: [target full][ref-target], [ref-target][], [ref-target]
+      expect(toTarget.length).toBe(3);
+    });
+
+    it("does not resolve reference-style links with unknown definition", () => {
+      const result = parseMarkdown(resolve(FIXTURE_DIR, "specs/inline-links/ref-source.md"), {
+        rootDir: FIXTURE_DIR,
+        specDirPrefix: "specs",
+      });
+      // The [missing][nope] reference cites an undefined label
+      const ghost = result.inlineLinks.find((l) => l.rawHref?.includes("nope"));
+      expect(ghost).toBeUndefined();
+    });
+
+    it("ignores links inside fenced and indented code blocks and inline code", () => {
+      const result = parseMarkdown(resolve(FIXTURE_DIR, "specs/inline-links/code-fence.md"), {
+        rootDir: FIXTURE_DIR,
+        specDirPrefix: "specs",
+      });
+      // Only the trailing [real](./target.md) link should be picked up
+      expect(result.inlineLinks).toHaveLength(1);
+      expect(result.inlineLinks[0].targetRelPath).toBe("specs/inline-links/target.md");
+    });
+
+    it("populates sourceDocId from the source file's doc node id", () => {
+      const result = parseMarkdown(resolve(FIXTURE_DIR, "specs/inline-links/source.md"), {
+        rootDir: FIXTURE_DIR,
+        specDirPrefix: "specs",
+      });
+      for (const link of result.inlineLinks) {
+        expect(link.sourceDocId).toBe("doc:inline-links/source.md");
+      }
+    });
+  });
+
   describe("mixed format coverage", () => {
     it("should recognize both list-item and heading formats across fixtures", () => {
       const speckitResult = parseMarkdown(resolve(FIXTURE_DIR, "specs/speckit-style.md"));

--- a/packages/artgraph/tests/markdown.test.ts
+++ b/packages/artgraph/tests/markdown.test.ts
@@ -330,11 +330,12 @@ artgraph:
         rootDir: FIXTURE_DIR,
         specDirPrefix: "specs",
       });
-      // 4 links in source.md hit target.md: plain, #section, ?v=1, ?v=1#x — all should normalize to the same target path
+      // 5 links in source.md hit target.md after normalization:
+      //   plain, #section, ?v=1, ?v=1#x, percent-encoded ./target%2Emd
       const toTarget = result.inlineLinks.filter(
         (l) => l.targetRelPath === "specs/inline-links/target.md",
       );
-      expect(toTarget.length).toBeGreaterThanOrEqual(4);
+      expect(toTarget.length).toBe(5);
     });
 
     it("ignores images, external URLs, mailto, non-md, empty href and pure fragments", () => {
@@ -383,9 +384,15 @@ artgraph:
         rootDir: FIXTURE_DIR,
         specDirPrefix: "specs",
       });
-      // The [missing][nope] reference cites an undefined label
-      const ghost = result.inlineLinks.find((l) => l.rawHref?.includes("nope"));
-      expect(ghost).toBeUndefined();
+      // Only the 3 resolvable references to target.md (full, collapsed,
+      // shortcut) survive — the `[missing][nope]` line cites an undefined
+      // label and must produce no entry. Pinning the total count catches
+      // both directions: undefined labels leaking through, or resolvable
+      // references being dropped by mistake.
+      expect(result.inlineLinks).toHaveLength(3);
+      for (const link of result.inlineLinks) {
+        expect(link.targetRelPath).toBe("specs/inline-links/target.md");
+      }
     });
 
     it("ignores links inside fenced and indented code blocks and inline code", () => {
@@ -405,6 +412,68 @@ artgraph:
       });
       for (const link of result.inlineLinks) {
         expect(link.sourceDocId).toBe("doc:inline-links/source.md");
+      }
+    });
+
+    it("does not mistake a Windows drive letter `C:/...` for a URL scheme", () => {
+      // Regression: URL_SCHEME_RE used to match single-letter prefixes, so
+      // `[w](C:/foo.md)` would be silently dropped as if it were `mailto:` etc.
+      const tmpRoot = resolve(import.meta.dirname, "fixtures/tmp-win-drive");
+      const tmpSpecs = resolve(tmpRoot, "specs");
+      mkdirSync(tmpSpecs, { recursive: true });
+      const src = resolve(tmpSpecs, "win.md");
+      writeFileSync(src, `# Windows drive letter\n\n[w](C:/proj/specs/target.md)\n`);
+
+      try {
+        const result = parseMarkdown(src, { rootDir: tmpRoot });
+        // The link is captured (not rejected as a URL). The target path won't
+        // resolve to a real doc node on Linux/macOS, but that's the builder's
+        // problem — what we're asserting here is the scheme-check no longer
+        // trips on `C:`.
+        expect(result.inlineLinks).toHaveLength(1);
+        expect(result.inlineLinks[0].rawHref).toBe("C:/proj/specs/target.md");
+      } finally {
+        unlinkSync(src);
+        rmdirSync(tmpSpecs);
+        rmdirSync(tmpRoot);
+      }
+    });
+
+    it("does not parse links with rootDir-escaping `..` (returns no inlineLinks)", () => {
+      // M7: parser drops links that resolve outside rootDir silently.
+      const tmpRoot = resolve(import.meta.dirname, "fixtures/tmp-rootdir-escape");
+      const tmpSpecs = resolve(tmpRoot, "specs");
+      mkdirSync(tmpSpecs, { recursive: true });
+      const src = resolve(tmpSpecs, "escape.md");
+      writeFileSync(src, `# Escape\n\nUp two dirs: [esc](../../outside.md).\n`);
+
+      try {
+        const result = parseMarkdown(src, { rootDir: tmpRoot });
+        expect(result.inlineLinks).toEqual([]);
+      } finally {
+        unlinkSync(src);
+        rmdirSync(tmpSpecs);
+        rmdirSync(tmpRoot);
+      }
+    });
+
+    it("survives malformed percent-encoding without throwing", () => {
+      // M7: decodeURIComponent throws on `%G9` etc.; parser must catch and skip.
+      const tmpRoot = resolve(import.meta.dirname, "fixtures/tmp-bad-percent");
+      const tmpSpecs = resolve(tmpRoot, "specs");
+      mkdirSync(tmpSpecs, { recursive: true });
+      const src = resolve(tmpSpecs, "bad.md");
+      writeFileSync(src, `# Bad percent\n\nMalformed: [bad](./target%G9.md).\n`);
+
+      try {
+        const result = parseMarkdown(src, { rootDir: tmpRoot });
+        // The malformed link is silently dropped from inlineLinks; parse did
+        // not throw. No other links exist in this file.
+        expect(result.inlineLinks).toEqual([]);
+      } finally {
+        unlinkSync(src);
+        rmdirSync(tmpSpecs);
+        rmdirSync(tmpRoot);
       }
     });
   });

--- a/specs/008-document-graph/spec.md
+++ b/specs/008-document-graph/spec.md
@@ -149,7 +149,7 @@ Acceptance Scenarios:
 ## Assumptions
 
 - グラフの基本単位はファイル（doc ノード）とする。要求 ID 抽出は「ある場合に拾う」ベストエフォートであり、散文のみのドキュメントもグラフに参加できる
-- doc→doc 依存の入力は v1 では frontmatter の 1 経路のみとする。インラインリンク自動抽出（C-2）、ツール規約の自動推論（C-3）は v1 スコープ外
+- doc→doc 依存の入力は v1 では frontmatter の 1 経路のみとする。ツール規約の自動推論（C-3）は v1 スコープ外。インラインリンク自動抽出（C-2）は issue #11 で本 spec 後に実装し、`docGraph.inlineLinks`（既定 true）で制御する
 - 要求⇔要求の依存（req→req）は v1 スコープ外
 - `via` エッジメタデータは v1 では追加しない（消費者がいないため）。002-doc-impact-ux の via フィールド（impact 出力で各ノードに到達した際のエッジ型表示）とは別概念であり、本 spec の via 非ゴールはグラフモデル自体へのエッジメタデータ追加を指す
 - DOT / Mermaid 等のリッチ可視化は v1 スコープ外（text/JSON のみ）


### PR DESCRIPTION
Closes #11

## Summary

- frontmatter 限定だったドキュメント依存の入力経路に、本文中の **インライン Markdown リンク** を追加。`[design](./requirements.md)` のようなリンクから `depends_on` エッジを自動生成し、散文中心の SDD 出力でも doc→doc → req → 実装の一気通貫トレースに乗るようにした
- 直リンクと参照型リンク（full / collapsed / shortcut）の双方を解決。アンカー・クエリは除去、URL スキーム / 画像 / 非 .md / code-fence 内は除外
- frontmatter での明示的な `derives_from` / `depends_on` を常に優先（同一 `(source,target)` ペアの推論側を破棄）
- 未解決リンク → `unresolved-link` 警告（既定 ON）、specDirs 外で実在 → `out-of-scope-link` 警告（既定 OFF）

## Design notes

Issue #11 で挙がっていた 6 論点はそれぞれ以下の方針で対応:

| 論点 | 対応 |
|---|---|
| アンカー付きリンク | パース時に `#fragment` / `?query` を除去（v1 では section 粒度は持たない） |
| 参照型リンク | `linkReference` + `definition` の 2 段階解決で full / collapsed / shortcut すべて対応 |
| 相対パス正規化 / 逆引き | parser は rootDir 相対パスのみ返し、builder で `filePath → docNode` Map を構築して逆引き |
| 非 .md / specDirs 外 / 未解決 | 種類別に方針を分け、警告のオン/オフは個別に設定可 |
| code-fence / encode / 大文字小文字 | remark AST は code/inlineCode 配下を link 化しないので自然に除外、percent-decode 実装、大文字小文字は FS 任せ（symlink は `realpath` 不使用） |
| frontmatter と推論の競合 | 同一 `(source,target)` ペアは frontmatter 完全勝利。kind 違いでも明示が勝つ |

設定例:

\`\`\`jsonc
{
  "docGraph": {
    "inlineLinks": true,
    "linkWarnings": { "unresolved": true, "outOfScope": false }
  }
}
\`\`\`

## Test plan

- [x] parser 単体テスト 8 件（`tests/markdown.test.ts`）
- [x] builder テスト 7 件（生成・dedup・frontmatter 優先・警告・トグル — `tests/builder.test.ts`）
- [x] CLI 統合テスト 2 件（`unresolved-link` の stderr、`graph --format json` での edge 出力 — `tests/cli.test.ts`）
- [x] フィクスチャ 6 種（直リンク / 参照型 / code-fence / dead / conflict / target）
- [x] `tsc -p` ✅ / `vitest run` → **399 passed** ✅ / `knip` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)