### PR TITLE
refactor(artgraph): frontmatter 受理規則を parser/rewriter で一元化 (#44)

### DIFF
--- a/packages/artgraph/src/parsers/markdown.ts
+++ b/packages/artgraph/src/parsers/markdown.ts
@@ -787,6 +787,13 @@ export function extractAnnotations(
   return { extracts, warnings };
 }
 
+// Single fence-line grammar shared by parseFrontmatter and findFrontmatterBounds.
+// Trailing whitespace is accepted (gray-matter compat, some editors auto-insert it)
+// but leading whitespace is NOT — the parser treats only column-0 `---` as a fence.
+// Keep the two consumers locked to this regex so rename's frontmatterBounds and the
+// parser cannot drift apart (#44).
+const FRONTMATTER_FENCE_RE = /^---[ \t]*$/;
+
 // Minimal YAML-frontmatter splitter. Replaces gray-matter to drop the js-yaml v3
 // advisory chain (GHSA-h67p-54hq-rp68 / issue #42); the YAML body is parsed by
 // eemeli/yaml which is already a workspace dependency.
@@ -795,12 +802,12 @@ function parseFrontmatter(raw: string): { data: Record<string, any>; content: st
   const firstNl = text.indexOf("\n");
   if (firstNl < 0) return { data: {}, content: raw };
   const firstLine = text.slice(0, firstNl).replace(/\r$/, "");
-  // Trailing whitespace on the opening fence is symmetric with the closing fence
-  // regex below — gray-matter accepted `--- ` / `---\t` and some editors auto-insert
-  // it, so rejecting strictly would silently drop the whole frontmatter.
-  if (!/^---[ \t]*$/.test(firstLine)) return { data: {}, content: raw };
+  if (!FRONTMATTER_FENCE_RE.test(firstLine)) return { data: {}, content: raw };
 
   const rest = text.slice(firstNl + 1);
+  // Closing fence: a line whose content matches FRONTMATTER_FENCE_RE, anchored
+  // to a line boundary (start of `rest` or after `\r?\n`) and followed by `\r?\n`
+  // or EOF.
   const closeRe = /(?:^|\r?\n)---[ \t]*(?:\r?\n|$)/;
   const match = closeRe.exec(rest);
   if (!match) return { data: {}, content: raw };
@@ -818,4 +825,27 @@ function parseFrontmatter(raw: string): { data: Record<string, any>; content: st
     throw new Error("frontmatter is not a YAML mapping");
   }
   return { data: parsed as Record<string, any>, content };
+}
+
+// Line-based view of parseFrontmatter's fence detection — returns the 0-based
+// indices of the opening and closing fence lines in `raw.split("\n")`, or null
+// when the file has no frontmatter. Used by rename.ts so the rewriter and the
+// parser cannot diverge on what counts as a fence (issue #44). The grammar is
+// identical to parseFrontmatter: opening fence on line 0 only, FRONTMATTER_FENCE_RE
+// on both fences, and a leading BOM tolerated. Trailing `\r` from CRLF files is
+// stripped per line so this is safe to call before any newline normalization.
+export function findFrontmatterBounds(
+  raw: string,
+): { start: number; end: number } | null {
+  const text = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+  const lines = text.split("\n");
+  if (lines.length < 2) return null;
+  const firstLine = lines[0].replace(/\r$/, "");
+  if (!FRONTMATTER_FENCE_RE.test(firstLine)) return null;
+  for (let i = 1; i < lines.length; i++) {
+    if (FRONTMATTER_FENCE_RE.test(lines[i].replace(/\r$/, ""))) {
+      return { start: 0, end: i };
+    }
+  }
+  return null;
 }

--- a/packages/artgraph/src/rename.ts
+++ b/packages/artgraph/src/rename.ts
@@ -1,5 +1,9 @@
 import type { ReqPatternConfig, TaskConventionPreset } from "./types.js";
-import { BUILTIN_TASK_PRESETS, maskInlineProtectedSpans } from "./parsers/markdown.js";
+import {
+  BUILTIN_TASK_PRESETS,
+  findFrontmatterBounds,
+  maskInlineProtectedSpans,
+} from "./parsers/markdown.js";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -388,27 +392,6 @@ export function rewriteTestTags(
 const FM_BLOCK_KEY_RE = /^(\s*)(depends_on|derives_from)\s*:(.*)$/;
 const FM_NODE_ID_RE = /^(\s*node_id:\s*["']?)(.+?)(["']?\s*)$/;
 
-interface FrontmatterBounds {
-  start: number;
-  end: number;
-}
-
-function frontmatterBounds(lines: string[]): FrontmatterBounds | null {
-  let start = -1;
-  let end = -1;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i].trim() === "---") {
-      if (start === -1) start = i;
-      else {
-        end = i;
-        break;
-      }
-    }
-  }
-  if (start === -1 || end === -1) return null;
-  return { start, end };
-}
-
 /**
  * True for a line that is part of an active `depends_on`/`derives_from` block
  * sequence (a `- …` list item or a blank continuation line).
@@ -435,7 +418,7 @@ export function rewriteFrontmatter(
   const lines = content.split("\n");
   const changes: RewriteChange[] = [];
 
-  const bounds = frontmatterBounds(lines);
+  const bounds = findFrontmatterBounds(content);
   if (!bounds) return { content, changes };
 
   const idRe = idBoundaryRegex(oldId);
@@ -502,7 +485,7 @@ export function expandFrontmatterDependsOn(
   const lines = content.split("\n");
   const changes: RewriteChange[] = [];
 
-  const bounds = frontmatterBounds(lines);
+  const bounds = findFrontmatterBounds(content);
   if (!bounds || newIds.length === 0) return { content, changes };
 
   const idRe = idBoundaryRegex(oldId);

--- a/packages/artgraph/tests/rename.test.ts
+++ b/packages/artgraph/tests/rename.test.ts
@@ -274,6 +274,57 @@ describe("rewriteFrontmatter", () => {
     const { content } = rewriteFrontmatter(input, "REQ-002", "REQ-200");
     expect(content).toContain('{ id: "REQ-200", relation: implements }');
   });
+
+  // ── Issue #44: parser/rewriter acceptance-rule parity ───────────────
+  //
+  // The local frontmatterBounds used to accept any `---` (via .trim()), so
+  // a mid-document horizontal rule paired with another `---` later in the
+  // file was mis-identified as a frontmatter region and IDs inside got
+  // silently rewritten — even though parseFrontmatter never extracted any
+  // frontmatter from such a file. After the unification both modules share
+  // findFrontmatterBounds and only honour a fence on line 0.
+
+  it("does NOT treat a mid-document `---` block as frontmatter (issue #44)", () => {
+    const input = [
+      "# Title",
+      "",
+      "Some body prose.",
+      "",
+      "---",
+      'node_id: "doc:old"',
+      "---",
+      "",
+      "More body.",
+    ].join("\n");
+    const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
+    // The parser sees no frontmatter here, so the rewriter must agree.
+    expect(content).toBe(input);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("does NOT treat an indented `   ---` as the opening fence (issue #44)", () => {
+    const input = [
+      "   ---",
+      'node_id: "doc:old"',
+      "---",
+      "# Body",
+    ].join("\n");
+    const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
+    expect(content).toBe(input);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("still accepts trailing whitespace on fences (gray-matter parity)", () => {
+    const input = [
+      "--- ",
+      'node_id: "doc:old"',
+      "---\t",
+      "# Body",
+    ].join("\n");
+    const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
+    expect(content).toContain('node_id: "doc:new"');
+    expect(changes).toHaveLength(1);
+  });
 });
 
 // ── expandFrontmatterDependsOn (F5) ─────────────────────────────────


### PR DESCRIPTION
## Summary

- `parsers/markdown.ts` の `parseFrontmatter` と `rename.ts` のローカル `frontmatterBounds` が **fence の受理規則を非対称に持っていた** ため、parser が「frontmatter 無し」と判定するファイルでも rewriter だけが body 中の `---` 区切りや leading whitespace 付きの `---` を fence と誤認し、本文中の `node_id:` / `depends_on:` を silent に書き換える可能性があった (issue #44)。
- `parsers/markdown.ts` に `findFrontmatterBounds(raw)` を新設し、`parseFrontmatter` と同じ grammar（`FRONTMATTER_FENCE_RE = /^---[ \t]*$/`、**先頭行のみ**、BOM/trailing `\r` 対応）を line-based に露出。`rename.ts` のローカル `frontmatterBounds` を削除して 2 箇所の呼び出しを差し替え、fence 正規表現を const 化して両モジュールが単一定義を参照するようにした。
- 新たな観察可能な挙動の変化:
  - mid-document の `---` ブロックは frontmatter として扱われなくなる
  - 先頭行の `   ---`（leading whitespace）は fence として扱われなくなる
  - `--- ` / `---\t`（trailing whitespace）は従来通り受理（gray-matter 互換維持）

## Issue 調査メモ

Issue で挙げられた具体例「`--- ` が rename.ts で frontmatter 無し扱い」は実際は誤り（`.trim() === "---"` は `--- ` を許容するため）。一方で **両実装が異なる受理規則を持つ** という大筋の指摘は正しく、本物の divergence は上記 3 点（特に opening fence の位置）にあった。

## Test plan

- [x] `pnpm -F artgraph test` — 704 件全 pass（追加した #44 回帰テスト 3 本含む）
  - mid-document `---` を frontmatter と誤認しないこと
  - 先頭行 `   ---` を fence と誤認しないこと
  - `--- ` / `---\t` の trailing whitespace 互換を維持すること
- [x] `pnpm -F artgraph build` — tsc 通過

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)