### PR TITLE
chore(oss-publish): npm publish 用メタ整備と prepublishOnly テストゲート (#80)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 11
 
       - uses: actions/setup-node@v4
         with:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Shintaro
+Copyright (c) 2026 Shintaro Morimoto
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -17,13 +17,29 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "knip": "knip",
-    "prepublishOnly": "rm -rf dist && tsc"
+    "prepublishOnly": "pnpm test && rm -rf dist && tsc"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ShintaroMorimoto/artgraph.git"
+  },
+  "bugs": {
+    "url": "https://github.com/ShintaroMorimoto/artgraph/issues"
+  },
+  "homepage": "https://github.com/ShintaroMorimoto/artgraph#readme",
   "keywords": [
     "traceability",
     "spec-driven-development",
-    "impact-analysis"
+    "impact-analysis",
+    "spec-kit",
+    "kiro",
+    "requirements",
+    "drift-detection",
+    "monorepo",
+    "typescript",
+    "cli"
   ],
+  "author": "Shintaro Morimoto",
   "license": "MIT",
   "dependencies": {
     "commander": "^13.1.0",
@@ -45,5 +61,6 @@
   },
   "engines": {
     "node": ">=22"
-  }
+  },
+  "packageManager": "pnpm@11.8.0"
 }


### PR DESCRIPTION
## Summary

- `LICENSE`: `Copyright (c) 2026 Shintaro` → `Shintaro Morimoto` に修正
- `package.json`:
  - `repository` / `bugs` / `homepage` / `author` を追加(`npm view artgraph` から GitHub に飛べるように)
  - `keywords` を 3 → 10 件に拡充 (`spec-kit`, `kiro`, `requirements`, `drift-detection`, `monorepo`, `typescript`, `cli`)
  - `prepublishOnly`: `rm -rf dist && tsc` → `pnpm test && rm -rf dist && tsc`(`&&` chain なのでテスト失敗で publish を停止)
  - `packageManager: "pnpm@11.8.0"` を追加(現行 corepack バージョンを固定)

Closes #80

## 設計判断: CLI 専用パッケージとして `main` / `types` / `exports` は未設定のまま維持

issue #80 の任意項目に対応。本パッケージは `bin: { artgraph: "./dist/cli.js" }` のみを公開する CLI ツールで、programmatic API を出す予定がない。`main` / `types` / `exports` を生やすと:

- 内部実装(`scan`, `parsers/markdown`, etc.)が ABI 表面に昇格し、将来のリファクタが破壊的変更扱いになる
- consumer に「import 可能なはず」という誤った期待を与える

→ 現状維持 + ここに判断を残置。将来 programmatic API を切り出す場合は別 issue/PR で `exports` map を明示的に設計する。

## Rebase context

`origin/main` に対して `9ce4977..eeecb0f` を fast-forward 取り込み:
- #86 (`eeecb0f`): pnpm workspace 解消 → リポジトリ直下フラット化
- #92 (`d192f5d`): フェンス検出 refactor

これにより issue #80 原文の「`packages/artgraph/LICENSE`」「`packages/artgraph/package.json`」「各 package に packageManager」はすべて **ルート単一ファイル**で対応すれば足りる。

## Test plan

- [x] `pnpm install` clean(packageManager 整合)
- [x] `pnpm build` green
- [x] `pnpm test` → 38 files / 730 tests pass
- [x] `pnpm pack --dry-run` → 同梱は `dist/` + `templates/` + 自動の `LICENSE`/`README.md`/`package.json` のみ(計 106 files / 125 kB)
- [x] `npm pkg get repository bugs homepage author keywords packageManager` ですべて表示
- [x] `npm pkg get scripts.prepublishOnly` → `"pnpm test && rm -rf dist && tsc"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)