### PR TITLE
docs(oss): add CONTRIBUTING / CODE_OF_CONDUCT / SECURITY (#81)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,135 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers by submitting a private report through this
+repository's [GitHub Security Advisories][PVR] page (the same private channel
+used for security reports). All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+[PVR]: https://github.com/ShintaroMorimoto/artgraph/security/advisories/new
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing to artgraph
+
+Thanks for your interest in artgraph. This document covers the development setup, conventions, and review process for contributions.
+
+## Prerequisites
+
+- **Node.js** 22 or later (`engines.node` is set to `>=22`)
+- **pnpm** 11.x — pinned via `packageManager` in `package.json`, so Corepack will install the matching version automatically
+
+## Setup
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+## Common commands
+
+| Command           | Purpose                                         |
+| ----------------- | ----------------------------------------------- |
+| `pnpm build`      | Type-check and compile to `dist/`               |
+| `pnpm test`       | Run the vitest suite once                       |
+| `pnpm test:watch` | Run vitest in watch mode                        |
+| `pnpm knip`       | Detect unused exports / files / dependencies    |
+| `pnpm artgraph …` | Invoke the locally built CLI (after `pnpm build`) |
+
+Before opening a pull request, run `pnpm build && pnpm test && pnpm knip` locally — CI gates on the same three commands.
+
+## Commit messages
+
+We follow a Conventional-Commits-lite style:
+
+```
+<type>(<scope>): <summary>
+```
+
+Common types:
+
+- `feat` — user-visible new functionality
+- `fix` — bug fix
+- `refactor` — internal change without behavior shift
+- `docs` — documentation only
+- `chore` — toolchain, dependencies, repo housekeeping
+- `test` — tests only
+
+`<scope>` is optional but encouraged. Scopes seen in the history include `artgraph`, `graph`, `deps`, `oss-ci`, `oss-publish`. When a commit closes an issue, append `(#NN)` to the summary or write `Closes #NN` in the body.
+
+## Branch naming
+
+Branches follow `<type>/<short-slug>`:
+
+- `feat/<slug>`
+- `fix/<slug>` (or `fix/issue-<number>`)
+- `chore/<slug>`
+- `docs/<slug>`
+
+Keep slugs short, lowercase, and hyphen-separated (e.g. `docs/oss-standards`).
+
+## Pull requests
+
+1. Branch off `main` using the naming convention above.
+2. Keep commits focused and follow the message style above.
+3. Run `pnpm build && pnpm test && pnpm knip` locally.
+4. Open a PR and fill in [`.github/PULL_REQUEST_TEMPLATE.md`](./.github/PULL_REQUEST_TEMPLATE.md):
+   - Summary and linked issue
+   - Change-type checkbox
+   - Testing notes
+   - Breaking-change flag
+5. Wait for CI (build / knip / test on Node 22) to pass.
+
+Add new tests whenever you change behavior. Bug fixes should include a regression test.
+
+## Adding specs and docs
+
+artgraph is developed spec-first. Non-trivial features live under `specs/<NNN>-<slug>/`:
+
+- Three-digit numeric prefix followed by a kebab-case slug (e.g. `010-req-req-dependency`).
+- Inside, follow the Spec Kit layout (`spec.md` → `plan.md` → `tasks.md`, with optional `research.md`). The `speckit-*` skills shipped with the repository scaffold these for you.
+- Cross-cutting design notes or reference material that doesn't belong to a single feature go directly under `docs/`.
+
+## Reporting issues
+
+- **Bugs** and **feature requests** — open a GitHub issue using the templates in `.github/ISSUE_TEMPLATE/`.
+- **Security vulnerabilities** — do not open a public issue; see [`SECURITY.md`](./SECURITY.md).
+- **Code of Conduct concerns** — see [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md).
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](./LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+## Supported versions
+
+artgraph is pre-1.0. Only the latest `0.1.x` release line receives security
+fixes. Because the project is pre-1.0, the public API may change between minor
+releases, and previous minor lines are not maintained.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+| < 0.1   | :x:                |
+
+## Reporting a vulnerability
+
+**Please do not file a public GitHub issue for security reports.**
+
+Report vulnerabilities privately through GitHub's [Private Vulnerability
+Reporting][PVR]:
+
+1. Open the [Security tab][security] of this repository.
+2. Click **Report a vulnerability**.
+3. Describe the issue, steps to reproduce, affected versions, and — if you
+   have one — a suggested mitigation.
+
+[PVR]: https://github.com/ShintaroMorimoto/artgraph/security/advisories/new
+[security]: https://github.com/ShintaroMorimoto/artgraph/security
+
+## Response expectations
+
+artgraph is maintained on a best-effort basis. For a valid report, we will:
+
+- Acknowledge receipt within **7 days**.
+- Triage and confirm (or reject) the report within **14 days** when feasible.
+- Coordinate disclosure with the reporter and publish a fix as a patch release
+  on the `0.1.x` line.
+
+No bug bounty program is offered.


### PR DESCRIPTION
## Summary

Add the three root-level community-standards documents called out in #81:

- **CONTRIBUTING.md** — Node 22+ / pnpm 11 setup, common commands (`pnpm build` / `test` / `knip`), Conventional-Commits-lite message style, branch naming, PR flow, and the `specs/<NNN>-<slug>/` Spec Kit layout. Drops the stale `pnpm -r` and `Node 20+` wording from the issue body (workspace was flattened in #86, `engines.node` is `>=22`). Claude Code hooks intentionally not documented — it's a developer preference and `.claude/` is gitignored.
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.1 with the enforcement contact pointed at this repo's GitHub Security Advisories page (single private channel).
- **SECURITY.md** — supported versions (`0.1.x` only, pre-1.0), Private Vulnerability Reporting as the sole intake, best-effort response targets (ack 7d / triage 14d).

Closes #81.

## Change type

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [x] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

Docs-only change — no code paths exercised.

- [x] Existing tests pass (`pnpm test`) — not re-run, no source/test changes
- [ ] Added tests where needed
- [x] Ran `pnpm knip` and `pnpm build` — not re-run, no source/test changes

## Breaking change

- [ ] Yes (described below)
- [x] No

## Notes

Follow-up not in this PR (also tracked by #89): enable **Settings → Security → Private vulnerability reporting** in the repo so the link in `SECURITY.md` / `CODE_OF_CONDUCT.md` resolves to a working form. Until that toggle is on, the \`/security/advisories/new\` URL 404s for non-maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)