### PR TITLE
refactor(lock): drop v1 lock-schema detection branch

### DIFF
--- a/src/lock.ts
+++ b/src/lock.ts
@@ -20,12 +20,10 @@ function assertWithinRoot(rootDir: string, fullPath: string): void {
 }
 
 /**
- * Thrown by `readLock` when the on-disk lock file uses the legacy v1
- * `dependsOn: string[]` shape (issue #35 / lock-schema-v2). v1 cannot be
- * silently migrated because the structured `provenances` array does not exist
- * on disk — fabricating it would invent provenance the parser never produced.
- * Surface a clear, actionable error instead so downstream code (`renameLockKey`,
- * `mergeLockKeys`, drift checks) never has to defend against the v1 shape.
+ * Thrown by `readLock` when the on-disk lock file is not a JSON object at the
+ * top level (e.g. a corrupted or hand-edited file). Surfacing a clear,
+ * actionable error keeps downstream code (`renameLockKey`, `mergeLockKeys`,
+ * drift checks) free of defensive shape-guards.
  */
 export class LockSchemaError extends Error {
   constructor(message: string) {
@@ -39,21 +37,6 @@ function validateLockSchema(lock: unknown): asserts lock is LockFile {
     throw new LockSchemaError(
       `LockFile must be a JSON object at the top level. Delete .trace.lock and re-run \`artgraph scan\` to regenerate.`,
     );
-  }
-  for (const [id, entry] of Object.entries(lock as Record<string, unknown>)) {
-    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) continue;
-    const deps = (entry as { dependsOn?: unknown }).dependsOn;
-    if (deps === undefined) continue;
-    if (!Array.isArray(deps)) continue;
-    for (const d of deps) {
-      if (typeof d === "string") {
-        throw new LockSchemaError(
-          `LockFile schema v1 detected at "${id}".dependsOn (string element).\n` +
-            `Schema v2 requires {id, provenances} objects.\n` +
-            `Delete .trace.lock and re-run \`artgraph scan\` to regenerate.`,
-        );
-      }
-    }
   }
 }
 
@@ -69,7 +52,7 @@ export function readLock(rootDir: string, lockPath: string): LockFile {
     return {};
   }
   // Schema validation is a hard fail (LockSchemaError), not a soft warning:
-  // continuing with a v1 shape causes cryptic TypeErrors in rename / merge.
+  // a non-object top level would cause cryptic TypeErrors in rename / merge.
   validateLockSchema(parsed);
   return parsed;
 }


### PR DESCRIPTION
## Summary

未リリースプロジェクトの「本質でない後方互換コード」を監査した結果の一環として、`src/lock.ts` の **v1 ロックスキーマ検出分岐**を削除しました。

オンディスクの `.trace.lock` フォーマットは #35 以降 v2 のみです。旧 v1 (`dependsOn: string[]`) シェイプを検出する分岐は移行期の防御コードで、

- それを pin するテストは存在しない
- 未リリースのため v1 ロックを認識する必要がない（stale な `.trace.lock` は migration されず `artgraph scan` で再生成される — spec 011 FR-006 / `contracts/lock-schema-v2.md` の方針に整合）

トップレベルの「JSON オブジェクトであること」ガードは後方互換ではない一般的なバリデーションのため保持しています。

## Change type

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [x] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm test:unit` — 1009 passed)
- [x] Added tests where needed（v1 挙動を pin するテストは元々存在しないため追加不要）
- [x] Ran `knip`（クリーン）/ `typecheck` 通過

監査では他に軽微な重複（`escapeRegex` / content hash）も検出していますが、cosmetic なため本 PR には含めていません。

## Breaking change

- [ ] Yes (described below)
- [x] No

未リリースで v1 ロックは存在せず、外部 import もない内部関数の変更のため影響なし。

## Notes

`-22 / +5` 行。削除したのは v1 専用の検出ループとエラーメッセージ、および関連コメントのみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0156tdzG8dEjsMhTozbNVAt2)_