### PR TITLE
feat(hooks): installHooks + settings.json.template を PM 非依存で実装 (closes #109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,22 @@ npm install -D artgraph && npx artgraph init       # default: full agent-native 
 # deno add npm:artgraph && deno run -A npm:artgraph/cli init
 ```
 
-`artgraph init` runs the full setup by default: `.artgraph.json` config + initial scan + Claude Code Skills + auto-integrate detected SDD tools (Spec Kit / Kiro) + Stop hook + CLAUDE.md / AGENTS.md snippet. Pass `--minimal` for bare config only, or any of `--no-skills` / `--no-integrate` / `--no-hooks` / `--no-agent-context` to skip specific stages. Commit `.claude/settings.json` to share the Stop hook with teammates, or add it to `.gitignore` if you want per-developer hooks.
+`artgraph init` runs the full setup by default: `.artgraph.json` config + initial scan + Claude Code Skills + auto-integrate detected SDD tools (Spec Kit / Kiro) + Stop hook. Pass `--minimal` for bare config only, or any of `--no-skills` / `--no-integrate` / `--no-hooks` to skip specific stages. Commit `.claude/settings.json` to share the Stop hook with teammates, or add it to `.gitignore` if you want per-developer hooks.
+
+> **Note:** The generated Stop hook `command` string is package-manager-specific
+> (e.g., `pnpm exec artgraph …` under pnpm, `bunx artgraph …` under bun,
+> `npx artgraph …` under npm, `deno run -A npm:artgraph/cli …` under Deno). If
+> team members use different package managers, either standardize on a single
+> package manager for the repo, or add `.claude/settings.json` to `.gitignore`
+> so each developer runs `artgraph init` locally to get their PM-appropriate
+> command.
+
+### Disabling the Stop hook (troubleshooting)
+
+If `artgraph check` blocks Claude Code unexpectedly (e.g., after an artgraph
+upgrade regression), you can temporarily disable the Stop hook by editing
+`.claude/settings.json` and removing the `Stop` entry from `hooks`. Re-run
+`artgraph init --force` (once the issue is resolved) to reinstall it.
 
 If you use Claude Code, you can skip the manual install entirely — type `/artgraph-setup` and the Skill detects the package manager, installs artgraph, and runs `init` for you in one turn.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install -D artgraph && npx artgraph init       # default: full agent-native 
 # deno add npm:artgraph && deno run -A npm:artgraph/cli init
 ```
 
-`artgraph init` runs the full setup by default: `.artgraph.json` config + initial scan + Claude Code Skills + auto-integrate detected SDD tools (Spec Kit / Kiro) + Stop hook + CLAUDE.md / AGENTS.md snippet. Pass `--minimal` for bare config only, or any of `--no-skills` / `--no-integrate` / `--no-hooks` / `--no-agent-context` to skip specific stages.
+`artgraph init` runs the full setup by default: `.artgraph.json` config + initial scan + Claude Code Skills + auto-integrate detected SDD tools (Spec Kit / Kiro) + Stop hook + CLAUDE.md / AGENTS.md snippet. Pass `--minimal` for bare config only, or any of `--no-skills` / `--no-integrate` / `--no-hooks` / `--no-agent-context` to skip specific stages. Commit `.claude/settings.json` to share the Stop hook with teammates, or add it to `.gitignore` if you want per-developer hooks.
 
 If you use Claude Code, you can skip the manual install entirely — type `/artgraph-setup` and the Skill detects the package manager, installs artgraph, and runs `init` for you in one turn.
 

--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -46,7 +46,7 @@ deno run -A npm:artgraph/cli init
 - scan (初回 spec/impl/test 索引化)
 - Skills install (`.claude/skills/<name>/SKILL.md` 配置)
 - integrate-auto (検出された SDD ツール: Spec Kit / Kiro)
-- Stop hook (P1)
+- Stop hook
 - agent context snippet 注入 (P1)
 
 | フラグ | 挙動 |

--- a/specs/012-skills-expansion/contracts/settings-merge.md
+++ b/specs/012-skills-expansion/contracts/settings-merge.md
@@ -138,3 +138,15 @@ async function installHooks(targetDir: string): Promise<HookInstallResult> {
 | 不正 JSON | `not a json` | JSON parse エラー、exit 1 |
 
 各 case で `.claude/settings.json` の前後の状態を fixture で比較する。
+
+---
+
+## 補足事項 (#109 実装で確定)
+
+- **Case D 判定式**: `Array.isArray(existing.hooks?.Stop) && existing.hooks.Stop.length > 0`。非配列 (`hooks.Stop = {}` / `42` 等) / 空配列 (`hooks.Stop = []`) / `null` はいずれも Case D ではなく Case B/C 扱い (上書き対象)。
+- **`.claude/settings.json` が directory / symlink の場合**: `lstatSync` で通常ファイルでないことを検出し、明示的に拒否する (`action: "io-error"`)。ファイルは生成・変更しない。
+- **BOM 対応**: 既存ファイル読み込み時、`JSON.parse` の前に UTF-8 BOM (`﻿` / `charCodeAt(0) === 0xfeff`) を strip する。`src/package-manager.ts:90` の既存ロジックと同水準の扱い。
+- **JSONC 非サポート**: `//` コメント付き JSON (JSONC) はサポート対象外。`JSON.parse` が失敗するため `action: "invalid-json"` として扱う (ファイル無変更)。
+- **PM 検出優先度**: `installHooks` に渡す PM は (1) 呼び出し元が明示する `detectedPm` 引数 → (2) `.artgraph.json#packageManager` → (3) `null` の順で解決する。`null` の場合は graceful skip (`action: "skipped-no-pm", failure: false`)。ただし `--minimal --with-hooks` のように hooks stage を明示 opt-in している場合は、PM 未検出を `failure: true` に昇格させる (ユーザーが明示的に要求した stage が実行できないため)。
+- **部分状態 (graceful degradation)**: Case D (衝突) や `skipped-no-pm` / `invalid-json` / `io-error` が発生しても、`.artgraph.json` の生成と Skills のインストールはそのまま残る。Stop hook のみがスキップされる。
+- **`InitResult` との連携**: `installHooks` は `InitResult.hooksInstall = { action, reason?, failure? }` を返す構造化データのみを扱い、stdout/stderr への出力は行わない。text/JSON 出力のフォーマットは `src/cli.ts` に集約し、`init.ts` の print-free な既存慣習を維持する。

--- a/specs/012-skills-expansion/contracts/settings-merge.md
+++ b/specs/012-skills-expansion/contracts/settings-merge.md
@@ -18,7 +18,7 @@
     "Stop": [
       {
         "hooks": [
-          { "type": "command", "command": "npx artgraph check --gate --diff" }
+          { "type": "command", "command": "npx artgraph check --gate --diff --mode symbol" }
         ]
       }
     ]
@@ -60,7 +60,7 @@ To add artgraph's gate, manually merge the following into hooks.Stop:
 
   {
     "hooks": [
-      { "type": "command", "command": "npx artgraph check --gate --diff" }
+      { "type": "command", "command": "npx artgraph check --gate --diff --mode symbol" }
     ]
   }
 ```

--- a/specs/012-skills-expansion/tasks.md
+++ b/specs/012-skills-expansion/tasks.md
@@ -132,7 +132,8 @@ Single project (per [plan.md](./plan.md) Project Structure):
 
 - [x] T026 [US4] Implement `installHooks(targetDir)` in `src/init.ts` per [contracts/settings-merge.md](./contracts/settings-merge.md) implementation guide. Case A/B/C は merge して exit 0、Case D は警告 + exit 1。 `--force` 不問 (settings.json merge は常に fail-on-conflict、R4)
 - [ ] T027 [US4] Implement `installAgentContext(targetDir)` in `src/init.ts` — CLAUDE.md / AGENTS.md のターゲットファイル走査、HTML マーカー検出、idempotent 注入。両ファイル無ければ CLAUDE.md を新規作成 (FR-015, R3)
-- [x] T028 [US4] Wire `installHooks()` and `installAgentContext()` into the default `runInit()` flow from T009. Verify both are called by default and skipped by `--no-hooks` / `--no-agent-context` / `--minimal`
+- [x] T028a [US4] Wire `installHooks()` into the default `runInit()` flow from T009. Verify it is called by default and skipped by `--no-hooks` / `--minimal` (本 PR で完了)
+- [ ] T028b [US4] Wire `installAgentContext()` into the default `runInit()` flow from T009. Verify it is called by default and skipped by `--no-agent-context` / `--minimal` (T027 と同時に PR-B で完了)
 
 #### Kiro steering 改修 (US5)
 
@@ -353,7 +354,7 @@ Task: "Create artgraph-detect SKILL.md" (T017)
 | US1 (setup) | T006, T008, T009, T015, T019 = 5 |
 | US2 (integrate existing) | T007, T016, T017 = 3 |
 | US3 (skill refactor + impact rename + English) | T005, T010, T011, T012, T013, T014, T018 = 7 |
-| US4 (hooks + agent context) | T020, T021, T022, T023, T024, T025, T026, T027, T028 = 9 |
+| US4 (hooks + agent context) | T020, T021, T022, T023, T024, T025, T026, T027, T028a, T028b = 10 |
 | US5 (Kiro inclusion auto) | T030, T031 = 2 |
 | US6 (Plugin) | T032, T033, T034, T035, T036, T037 = 6 |
 | US7 (Spec Kit hook) | T038, T041, T042, T043 = 4 |

--- a/specs/012-skills-expansion/tasks.md
+++ b/specs/012-skills-expansion/tasks.md
@@ -116,23 +116,23 @@ Single project (per [plan.md](./plan.md) Project Structure):
 
 ### Tests for Phase 4 (TDD) ⚠️
 
-- [ ] T020 [P] [US4] Write `tests/hooks-merge.test.ts` — 4 cases per [contracts/settings-merge.md](./contracts/settings-merge.md): (A) settings.json なし、(B) `{}`、(C) 他 hook あり Stop なし、(D) Stop hook 衝突 (exit 1)。`--force` を渡しても Case D で上書きしないことを assert (FR-012, FR-013, FR-028 — --with-hooks, R4)
+- [x] T020 [P] [US4] Write `tests/hooks-merge.test.ts` — 4 cases per [contracts/settings-merge.md](./contracts/settings-merge.md): (A) settings.json なし、(B) `{}`、(C) 他 hook あり Stop なし、(D) Stop hook 衝突 (exit 1)。`--force` を渡しても Case D で上書きしないことを assert (FR-012, FR-013, FR-028 — --with-hooks, R4)
 - [ ] T021 [P] [US4] Write `tests/agent-context-injection.test.ts` — (a) CLAUDE.md なしで作成、(b) 既存 CLAUDE.md に追記、(c) マーカー既存で更新、(d) 2 回実行で idempotent (diff なし)、(e) AGENTS.md にも同等動作、(f) スニペットが 30 行以下 (FR-014, FR-015, FR-028 — --with-agent-context, R3)
 
 ### Implementation for Phase 4
 
 #### テンプレファイル (US4)
 
-- [ ] T022 [P] [US4] Create `templates/hooks/settings.json.template` — 内容は [data-model.md](./data-model.md) E3 + [contracts/settings-merge.md](./contracts/settings-merge.md) の入力ソース節通り (Stop hook で `npx artgraph check --gate --diff` を登録)。**(注: `npx` 表記は npm 環境前提。pkg mgr 検出による generic 化はフォローアップ issue)**
+- [x] T022 [P] [US4] Create `templates/hooks/settings.json.template` — 内容は [data-model.md](./data-model.md) E3 + [contracts/settings-merge.md](./contracts/settings-merge.md) の入力ソース節通り (Stop hook で `npx artgraph check --gate --diff` を登録)。**(注: `npx` 表記は npm 環境前提。pkg mgr 検出による generic 化はフォローアップ issue)**
 - [ ] T023 [P] [US4] Create `templates/hooks/pre-commit.sh.template` — husky/lefthook 利用者向けの参考スクリプト (本体は `npx artgraph check --gate --diff` を実行)。任意配布で、`init` の default では自動配置しない (将来の `--with-precommit` 用テンプレ予約)
 - [ ] T024 [P] [US4] Create `templates/agent-context/claude-md-snippet.md` (**Japanese OK**) — 30 行以下。`<!-- artgraph: BEGIN agent context -->` / `<!-- artgraph: END agent context -->` で囲った内容。Skills の使い方、`@impl` 文法、`artgraph impact` / `check` の呼びどころ、Skills 配置場所の 4 点を簡潔に (FR-014, R3, [data-model.md](./data-model.md) E5)
 - [ ] T025 [P] [US4] Create `templates/agent-context/agents-md-snippet.md` (**Japanese OK**) — 同上スニペット (Kiro / 他エージェント共通プロトコル AGENTS.md 用)
 
 #### `installHooks()` / `installAgentContext()` 実装 (US4)
 
-- [ ] T026 [US4] Implement `installHooks(targetDir)` in `src/init.ts` per [contracts/settings-merge.md](./contracts/settings-merge.md) implementation guide. Case A/B/C は merge して exit 0、Case D は警告 + exit 1。 `--force` 不問 (settings.json merge は常に fail-on-conflict、R4)
+- [x] T026 [US4] Implement `installHooks(targetDir)` in `src/init.ts` per [contracts/settings-merge.md](./contracts/settings-merge.md) implementation guide. Case A/B/C は merge して exit 0、Case D は警告 + exit 1。 `--force` 不問 (settings.json merge は常に fail-on-conflict、R4)
 - [ ] T027 [US4] Implement `installAgentContext(targetDir)` in `src/init.ts` — CLAUDE.md / AGENTS.md のターゲットファイル走査、HTML マーカー検出、idempotent 注入。両ファイル無ければ CLAUDE.md を新規作成 (FR-015, R3)
-- [ ] T028 [US4] Wire `installHooks()` and `installAgentContext()` into the default `runInit()` flow from T009. Verify both are called by default and skipped by `--no-hooks` / `--no-agent-context` / `--minimal`
+- [x] T028 [US4] Wire `installHooks()` and `installAgentContext()` into the default `runInit()` flow from T009. Verify both are called by default and skipped by `--no-hooks` / `--no-agent-context` / `--minimal`
 
 #### Kiro steering 改修 (US5)
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -103,7 +103,7 @@ function resolveTestResults(
 program
   .command("init")
   .description(
-    "Initialize artgraph for this project (default: config + scan + Skills + auto-integrate detected SDD tools; Stop hook and agent-context snippet land in PR-B). Use --minimal for bare config only.",
+    "Initialize artgraph for this project (default: config + scan + Skills + auto-integrate detected SDD tools + Stop hook; agent-context snippet lands in PR-B). Use --minimal for bare config only.",
   )
   .option("--force", "Overwrite existing .artgraph.json")
   .option("--minimal", "Bare config only — opt out of every extra setup stage")
@@ -111,12 +111,12 @@ program
   .option("--no-scan", "Skip initial scan + reconcile")
   .option("--no-skills", "Skip Claude Code Skills install (default mode only — already off under --minimal)")
   .option("--no-integrate", "Skip SDD-tool auto-integration (default mode only)")
-  .option("--no-hooks", "Skip Stop hook installation (default mode only; P1 deliverable)")
+  .option("--no-hooks", "Skip Stop hook installation (default mode only)")
   .option("--no-agent-context", "Skip CLAUDE.md / AGENTS.md snippet injection (default mode only; P1 deliverable)")
   // Stage opt-ins (used with --minimal)
   .option("--with-skills", "Install Claude Code Skills into .claude/skills/ (use with --minimal)")
   .option("--with-integrate", "Auto-integrate detected SDD tools (use with --minimal)")
-  .option("--with-hooks", "Install Stop hook (use with --minimal; P1 deliverable, no effect yet)")
+  .option("--with-hooks", "Install Stop hook (use with --minimal)")
   .option("--with-agent-context", "Inject CLAUDE.md / AGENTS.md snippet (use with --minimal; P1 deliverable, no effect yet)")
   // Explicit integrate list (overrides auto-detect)
   .option(
@@ -142,12 +142,9 @@ program
       process.exit(1);
     }
 
-    // C1: --with-hooks / --with-agent-context are accepted (so the flag
-    // surface is stable for PR-B) but currently no-op. Warn so the user
-    // doesn't think they got hooks/snippet without checking output.
-    if (opts.withHooks === true) {
-      console.error("WARNING: --with-hooks is a P1 deliverable; the flag has no effect in this release.");
-    }
+    // C1: --with-agent-context is accepted (so the flag surface is stable
+    // for PR-B) but currently no-op. Warn so the user doesn't think they got
+    // the snippet without checking output.
     if (opts.withAgentContext === true) {
       console.error("WARNING: --with-agent-context is a P1 deliverable; the flag has no effect in this release.");
     }
@@ -222,6 +219,7 @@ program
               : null,
             integrationResults: result.integrationResults ?? null,
             integrationWarnings: result.integrationWarnings ?? null,
+            hooksInstall: result.hooksInstall ?? null,
           }),
         );
       } else {
@@ -282,6 +280,41 @@ program
           console.log(`Run "artgraph impact --diff" to see impact of your changes.`);
         }
 
+        // Stop hook install result (issue #109). Structured data comes from
+        // `runInit`/`installHooks`; formatting is fully owned here so init.ts
+        // stays print-free.
+        if (result.hooksInstall) {
+          switch (result.hooksInstall.action) {
+            case "created":
+              console.log("\nCreated .claude/settings.json with artgraph Stop hook");
+              break;
+            case "merged-b":
+              console.log("\nAdded artgraph Stop hook to existing .claude/settings.json");
+              break;
+            case "merged-c":
+              console.log("\nAdded artgraph Stop hook (other hooks preserved)");
+              break;
+            case "conflict":
+              console.error(
+                `\n[WARN] .claude/settings.json already has a Stop hook configured.\nartgraph did NOT modify this file to avoid clobbering your setup.\n\nTo add artgraph's gate, manually merge the following into hooks.Stop:\n\n  {\n    "hooks": [\n      { "type": "command", "command": "${result.hooksInstall.reason}" }\n    ]\n  }\n\n(artgraph's config and Skills were installed successfully; only the Stop hook was skipped.)\n`,
+              );
+              break;
+            case "invalid-json":
+              console.error(
+                `\nERROR: .claude/settings.json is not valid JSON: ${result.hooksInstall.reason}. Not modifying.`,
+              );
+              break;
+            case "io-error":
+              console.error(`\nERROR: Stop hook install failed: ${result.hooksInstall.reason}`);
+              break;
+            case "skipped-no-pm":
+              console.error(
+                "\nWARNING: Cannot detect package manager; skipping Stop hook install (config saved to .artgraph.json).",
+              );
+              break;
+          }
+        }
+
         // Skip Tips entirely if the user already requested one-shot integration —
         // the per-tool sections above already cover discovery.
         if (!integrations) {
@@ -293,6 +326,9 @@ program
       // so CI / wrapper scripts catch it. We still emit the per-tool
       // sections above so the user has the full picture before exit.
       if (result.integrationFailureCount && result.integrationFailureCount > 0) {
+        process.exitCode = 1;
+      }
+      if (result.hooksInstall?.failure) {
         process.exitCode = 1;
       }
     } catch (e) {
@@ -1485,6 +1521,7 @@ export async function runCli(argv: string[], opts: RunCliOptions = {}): Promise<
   const origStderrWrite = process.stderr.write.bind(process.stderr);
   const hadStdinOverride = _hookStdinOverride !== undefined;
   const prevStdinOverride = _hookStdinOverride;
+  const origProcessExitCode = process.exitCode;
 
   const pushStdout = (s: string) => stdoutChunks.push(s);
   const pushStderr = (s: string) => stderrChunks.push(s);
@@ -1494,6 +1531,9 @@ export async function runCli(argv: string[], opts: RunCliOptions = {}): Promise<
   try {
     if (opts.cwd) process.chdir(opts.cwd);
     if (opts.stdin !== undefined) _hookStdinOverride = opts.stdin;
+    // Reset so a prior test's leftover `process.exitCode` doesn't leak into
+    // this invocation's captured return value.
+    process.exitCode = undefined;
 
     console.log = (...args: unknown[]) => {
       pushStdout(args.map(formatLogArg).join(" ") + "\n");
@@ -1522,6 +1562,12 @@ export async function runCli(argv: string[], opts: RunCliOptions = {}): Promise<
 
     try {
       await program.parseAsync(argv, { from: "user" });
+      // Commands may signal failure by mutating `process.exitCode` instead of
+      // throwing (e.g. `init` on hooksInstall failure). Read it here so those
+      // exits are visible in RunCliResult.
+      if (typeof process.exitCode === "number" && process.exitCode !== 0) {
+        exitCode = process.exitCode;
+      }
     } catch (e) {
       if (e instanceof CliExitError) {
         exitCode = e.exitCode;
@@ -1545,6 +1591,9 @@ export async function runCli(argv: string[], opts: RunCliOptions = {}): Promise<
     process.stdout.write = origStdoutWrite;
     process.stderr.write = origStderrWrite;
     _hookStdinOverride = hadStdinOverride ? prevStdinOverride : undefined;
+    // Restore prior `process.exitCode` so a runCli call doesn't leak its
+    // exit state into the surrounding test process.
+    process.exitCode = origProcessExitCode;
   }
 
   return {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -129,6 +129,13 @@ program
   .action((opts) => {
     const rootDir = process.cwd();
 
+    // Parse --integrations first so the M24 conflict check below can also
+    // flag `--no-integrate` combined with a non-empty `--integrations=<list>`
+    // (or `--integrations=all`). Without this pre-parse, that pair silently
+    // dropped in default mode and reversed meaning under `--minimal`
+    // (explicit list acts as an integrate opt-in — see computeStageGates).
+    const integrations = parseInitIntegrations(opts.integrations);
+
     // M24: detect mutually-exclusive --no-X + --with-X combinations before
     // doing any work. commander otherwise silently lets --with-X "win"
     // (last flag), which has bitten users in PR #103 review.
@@ -137,6 +144,16 @@ program
     if (opts.integrate === false && opts.withIntegrate === true) conflicts.push("--no-integrate / --with-integrate");
     if (opts.hooks === false && opts.withHooks === true) conflicts.push("--no-hooks / --with-hooks");
     if (opts.agentContext === false && opts.withAgentContext === true) conflicts.push("--no-agent-context / --with-agent-context");
+    // E2-2: `--no-integrate` is only really an opt-out if we also reject the
+    // silent-conflict pair `--no-integrate --integrations=<...>`. An empty
+    // list (`parseInitIntegrations` collapses to undefined) is a no-op and
+    // must NOT trigger the check.
+    if (opts.integrate === false && Array.isArray(integrations) && integrations.length > 0) {
+      conflicts.push("--no-integrate / --integrations=<non-empty>");
+    }
+    if (opts.integrate === false && integrations === "all") {
+      conflicts.push("--no-integrate / --integrations=all");
+    }
     if (conflicts.length > 0) {
       console.error(`Error: mutually exclusive flag combinations: ${conflicts.join("; ")}`);
       process.exit(1);
@@ -149,11 +166,8 @@ program
       console.error("WARNING: --with-agent-context is a P1 deliverable; the flag has no effect in this release.");
     }
 
-    // Parse --integrations: "all" stays as the literal sentinel; otherwise
-    // it's a comma-separated provider id list. Empty/undefined leaves
-    // integrations unspecified so runInit's auto-detect kicks in.
-    const integrations = parseInitIntegrations(opts.integrations);
-
+    // `integrations` is already resolved above (needed by the M24 check).
+    //
     // M12: surface valid provider ids when the user fat-fingers an
     // --integrations value. runInit's own warning also fires later, but
     // showing the valid set here gives the user the hint *before* init runs.
@@ -295,8 +309,14 @@ program
               console.log("\nAdded artgraph Stop hook (other hooks preserved)");
               break;
             case "conflict":
+              // A2: `.artgraph.json` has already been (re-)written by the
+              // time we hit this branch, so a bare re-run of `artgraph init`
+              // now trips the "already exists" guard. Point the user at
+              // `--force` (with `--no-hooks` as the escape hatch) so they
+              // know how to complete setup after resolving the Stop
+              // conflict — that guidance was missing.
               console.error(
-                `\n[WARN] .claude/settings.json already has a Stop hook configured.\nartgraph did NOT modify this file to avoid clobbering your setup.\n\nTo add artgraph's gate, manually merge the following into hooks.Stop:\n\n  {\n    "hooks": [\n      { "type": "command", "command": "${result.hooksInstall.reason}" }\n    ]\n  }\n\n(artgraph's config and Skills were installed successfully; only the Stop hook was skipped.)\n`,
+                `\n[WARN] .claude/settings.json already has a Stop hook configured.\nartgraph did NOT modify this file to avoid clobbering your setup.\n\nTo add artgraph's gate, manually merge the following into hooks.Stop:\n\n  {\n    "hooks": [\n      { "type": "command", "command": "${result.hooksInstall.reason}" }\n    ]\n  }\n\n(artgraph's config and Skills were installed successfully; only the Stop hook was skipped.)\n\nAfter you have merged the snippet above, re-run \`artgraph init --force\` to\ncomplete setup (or run with \`--no-hooks\` if you prefer to keep the current\nStop hook and skip artgraph's gate).\n`,
               );
               break;
             case "invalid-json":
@@ -312,6 +332,13 @@ program
                 "\nWARNING: Cannot detect package manager; skipping Stop hook install (config saved to .artgraph.json).",
               );
               break;
+            default: {
+              // E3: exhaustiveness guard — a new `hooksInstall.action`
+              // variant will fail `tsc` here instead of silently skipping
+              // the CLI-level formatting. Mirrors `printWarnings`.
+              const _exhaustive: never = result.hooksInstall.action;
+              void _exhaustive;
+            }
           }
         }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -4,17 +4,20 @@ import {
   lstatSync,
   mkdirSync,
   readdirSync,
+  readFileSync,
+  renameSync,
   rmdirSync,
   statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
-import { join, relative, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import {
   DEFAULT_CONFIG,
   type ArtgraphConfig,
   type IntegrateResult,
   type IntegrationProviderId,
+  type PackageManager,
   type ScanSummary,
   type SddToolInfo,
   type DetectionResult,
@@ -23,11 +26,13 @@ import {
 import { scan, reconcile } from "./scan.js";
 import type { BuildWarning } from "./graph/builder.js";
 import { getProviderStatuses, runIntegrate } from "./integrate/index.js";
-import { detectPackageManager } from "./package-manager.js";
+import { detectPackageManager, execPrefix } from "./package-manager.js";
 import { loadConfig } from "./config.js";
+import { renderTemplate } from "./template.js";
 
 const SKILLS_TEMPLATE_DIR = resolve(import.meta.dirname, "../templates/skills");
 const SKILLS_DEST_SUBDIR = join(".claude", "skills");
+const HOOKS_TEMPLATE_PATH = resolve(import.meta.dirname, "../templates/hooks/settings.json.template");
 
 export class SkillsInstallError extends Error {
   readonly partiallyInstalled: string[];
@@ -72,6 +77,29 @@ export interface InitResult {
    * failure" must exit 1).
    */
   integrationFailureCount?: number;
+  /**
+   * Structured outcome of the Stop-hook install stage (FR-012/013,
+   * specs/012-skills-expansion/contracts/settings-merge.md). `installHooks`
+   * only returns this data — it never writes to stdout/stderr. Formatting
+   * the text/JSON output (success messages, the Case D warning block, exit
+   * code translation) is the CLI layer's job so init.ts stays print-free.
+   * Undefined when the hooks stage did not run (`--no-hooks` / `--minimal`
+   * without `--with-hooks`).
+   */
+  hooksInstall?: {
+    action:
+      | "created"
+      | "merged-b"
+      | "merged-c"
+      | "conflict"
+      | "invalid-json"
+      | "io-error"
+      | "skipped-no-pm";
+    /** Detail for conflict/error outcomes: rendered command or parse/IO error message. */
+    reason?: string;
+    /** true → CLI translates this into a non-zero exit code. */
+    failure?: boolean;
+  };
 }
 
 export function detectProject(rootDir: string): DetectionResult {
@@ -352,13 +380,133 @@ export function computeStageGates(opts: InitOptions): {
 }
 
 /**
- * Stop-hook installation. P1 will replace this stub with the real merger
- * defined in specs/012-skills-expansion/contracts/settings-merge.md (T026).
- * In P0 the stage is wired but does nothing observable.
+ * Merge the artgraph Stop hook into `<rootDir>/.claude/settings.json`
+ * following the 4-case strategy in
+ * specs/012-skills-expansion/contracts/settings-merge.md.
+ *
+ * Never throws: every fs / JSON / template failure is caught and converted
+ * into a structured `{ action, reason?, failure? }` result so a Stop-hook
+ * install problem never aborts the rest of `init` (config + Skills already
+ * landed by the time this runs).
+ *
+ * `options.force` is accepted for signature symmetry with the other stage
+ * installers but is deliberately ignored on the Case D (conflict) branch —
+ * see contract §--force フラグの扱い ("settings.json is the most sensitive
+ * user config; artgraph never overwrites a pre-existing Stop hook, even with
+ * --force").
  */
-function installHooks(_rootDir: string, _options: { force?: boolean } = {}): void {
-  // P1 (T026): merge templates/hooks/settings.json.template into
-  // <rootDir>/.claude/settings.json with the 4-case strategy.
+function installHooks(
+  rootDir: string,
+  detectedPm: PackageManager | null,
+  options: { force?: boolean; explicitOptIn?: boolean } = {},
+): NonNullable<InitResult["hooksInstall"]> {
+  if (detectedPm === null) {
+    return { action: "skipped-no-pm", failure: options.explicitOptIn === true };
+  }
+
+  let rendered: { hooks: { Stop: unknown[] } };
+  try {
+    const raw = readFileSync(HOOKS_TEMPLATE_PATH, "utf-8");
+    const substituted = renderTemplate(raw, { ARTGRAPH_EXEC: execPrefix(detectedPm) });
+    rendered = JSON.parse(substituted);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { action: "io-error", reason: msg, failure: true };
+  }
+
+  const settingsPath = resolve(rootDir, ".claude", "settings.json");
+
+  // Refuse to follow/overwrite anything that isn't a regular file (symlink,
+  // directory, socket, ...). Mirrors installSkills' symlink refusal — never
+  // override even with --force, since that could clobber a file outside the
+  // .claude/ tree via a malicious or accidental symlink.
+  const existingStat = lstatSync(settingsPath, { throwIfNoEntry: false });
+  if (existingStat && !existingStat.isFile()) {
+    return { action: "io-error", reason: "settings.json is not a regular file", failure: true };
+  }
+
+  const writeAtomic = (data: unknown): void => {
+    const tmpPath = `${settingsPath}.tmp`;
+    writeFileSync(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+    renameSync(tmpPath, settingsPath);
+  };
+
+  // Case A: no existing settings.json — write the template verbatim.
+  if (!existingStat) {
+    try {
+      mkdirSync(dirname(settingsPath), { recursive: true });
+      writeAtomic(rendered);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      // Best-effort cleanup of a partial .tmp file left by a failed rename.
+      try {
+        unlinkSync(`${settingsPath}.tmp`);
+      } catch {
+        // no tmp file to clean up, or cleanup itself failed — ignore
+      }
+      return { action: "io-error", reason: msg, failure: true };
+    }
+    return { action: "created", failure: false };
+  }
+
+  let raw: string;
+  try {
+    raw = readFileSync(settingsPath, "utf-8");
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { action: "io-error", reason: msg, failure: true };
+  }
+  // Strip a leading UTF-8 BOM before parsing (same treatment as
+  // package-manager.ts's packageManager-field reader).
+  if (raw.charCodeAt(0) === 0xfeff) raw = raw.slice(1);
+
+  let existing: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new Error("settings.json root must be a JSON object");
+    }
+    existing = parsed as Record<string, unknown>;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { action: "invalid-json", reason: msg, failure: true };
+  }
+
+  const existingHooks =
+    existing.hooks && typeof existing.hooks === "object"
+      ? (existing.hooks as Record<string, unknown>)
+      : undefined;
+
+  // Case D: a populated hooks.Stop array already exists — never overwrite,
+  // even with --force (contract §--force フラグの扱い). Non-array / empty-
+  // array / null hooks.Stop are NOT conflicts and fall through to Case B/C.
+  if (Array.isArray(existingHooks?.Stop) && existingHooks.Stop.length > 0) {
+    return {
+      action: "conflict",
+      reason: `${execPrefix(detectedPm)} check --gate --diff`,
+      failure: true,
+    };
+  }
+
+  // Case B/C: merge Stop into (possibly absent/non-object) hooks, preserving
+  // any other top-level fields and any other hook keys (e.g. PreToolUse).
+  // Extension point: if the template ever grows beyond Stop, spread
+  // rendered.hooks here instead of setting Stop alone.
+  const originalHooks =
+    existing.hooks && typeof existing.hooks === "object" && !Array.isArray(existing.hooks)
+      ? (existing.hooks as Record<string, unknown>)
+      : {};
+  const hadOtherHookKeys = Object.keys(originalHooks).length > 0;
+  existing.hooks = { ...originalHooks, Stop: rendered.hooks.Stop };
+
+  try {
+    writeAtomic(existing);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { action: "io-error", reason: msg, failure: true };
+  }
+
+  return { action: hadOtherHookKeys ? "merged-c" : "merged-b", failure: false };
 }
 
 /**
@@ -447,9 +595,18 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
     ? runRequestedIntegrations(abs, detection, options)
     : { failureCount: 0 };
 
-  if (stages.hooks) {
-    installHooks(abs, { force: options.force });
-  }
+  // PM resolution priority for the hooks stage (contract §PM 検出優先度):
+  // (1) live detection this run, (2) the value already recorded in
+  // .artgraph.json (covers repos where lockfiles were removed/rotated after
+  // the initial init), (3) null → graceful skip.
+  const pmForHooks = detectedPm ?? config.packageManager ?? null;
+  const hooksInstall = stages.hooks
+    ? installHooks(abs, pmForHooks, {
+        force: options.force,
+        explicitOptIn: options.withHooks === true,
+      })
+    : undefined;
+
   if (stages.agentContext) {
     installAgentContext(abs, { force: options.force });
   }
@@ -465,6 +622,7 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
     integrationResults: integration.results,
     integrationWarnings: integration.warnings,
     integrationFailureCount: integration.failureCount > 0 ? integration.failureCount : undefined,
+    hooksInstall,
   };
 }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -381,8 +381,13 @@ export function computeStageGates(opts: InitOptions): {
 
 /**
  * Merge the artgraph Stop hook into `<rootDir>/.claude/settings.json`
- * following the 4-case strategy in
+ * (Claude Code specific) following the 4-case strategy in
  * specs/012-skills-expansion/contracts/settings-merge.md.
+ *
+ * Support for other agent environments (Cursor / Windsurf / Kiro Custom
+ * Agents) is out of scope for spec 012; when a cross-agent hook spec lands,
+ * this function will be renamed to `installClaudeCodeHooks` and a per-agent
+ * dispatch layer will be added on top.
  *
  * Never throws: every fs / JSON / template failure is caught and converted
  * into a structured `{ action, reason?, failure? }` result so a Stop-hook
@@ -404,11 +409,19 @@ function installHooks(
     return { action: "skipped-no-pm", failure: options.explicitOptIn === true };
   }
 
-  let rendered: { hooks: { Stop: unknown[] } };
+  // Narrow the parsed template shape so downstream lookups (Case D reason,
+  // Case B/C merge) work off a single typed handle rather than repeated
+  // `unknown` casts.
+  type RenderedTemplate = {
+    hooks: {
+      Stop: Array<{ hooks: Array<{ type: string; command: string }> }>;
+    };
+  };
+  let rendered: RenderedTemplate;
   try {
     const raw = readFileSync(HOOKS_TEMPLATE_PATH, "utf-8");
     const substituted = renderTemplate(raw, { ARTGRAPH_EXEC: execPrefix(detectedPm) });
-    rendered = JSON.parse(substituted);
+    rendered = JSON.parse(substituted) as RenderedTemplate;
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     return { action: "io-error", reason: msg, failure: true };
@@ -416,34 +429,59 @@ function installHooks(
 
   const settingsPath = resolve(rootDir, ".claude", "settings.json");
 
+  // D1: `lstatSync({ throwIfNoEntry: false })` only suppresses ENOENT — EACCES
+  // / EPERM / ELOOP still throw and would escape the JSDoc "never throws"
+  // contract without this try/catch. Convert any lstat failure into an
+  // `io-error` result so the caller sees the same structured outcome as
+  // every other fs failure in this function.
+  let existingStat: ReturnType<typeof lstatSync> | undefined;
+  try {
+    existingStat = lstatSync(settingsPath, { throwIfNoEntry: false });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { action: "io-error", reason: msg, failure: true };
+  }
   // Refuse to follow/overwrite anything that isn't a regular file (symlink,
   // directory, socket, ...). Mirrors installSkills' symlink refusal — never
   // override even with --force, since that could clobber a file outside the
   // .claude/ tree via a malicious or accidental symlink.
-  const existingStat = lstatSync(settingsPath, { throwIfNoEntry: false });
   if (existingStat && !existingStat.isFile()) {
     return { action: "io-error", reason: "settings.json is not a regular file", failure: true };
   }
 
+  // B1+B2: single atomic-write helper with symmetric cleanup on failure.
+  // Pre-clears any stale `.tmp` (which may itself be a symlink planted by an
+  // attacker) — `unlinkSync` removes the symlink itself, not the target, so
+  // the subsequent `writeFileSync` lands on a fresh regular file.
   const writeAtomic = (data: unknown): void => {
     const tmpPath = `${settingsPath}.tmp`;
-    writeFileSync(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
-    renameSync(tmpPath, settingsPath);
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // no stale tmp file — expected happy path
+    }
+    try {
+      writeFileSync(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+      renameSync(tmpPath, settingsPath);
+    } catch (e) {
+      try {
+        unlinkSync(tmpPath);
+      } catch {
+        // best-effort cleanup — nothing to remove or a lower-level failure
+      }
+      throw e;
+    }
   };
 
   // Case A: no existing settings.json — write the template verbatim.
+  // `.tmp` cleanup is handled inside writeAtomic itself, so this branch is
+  // now free of a redundant unlinkSync.
   if (!existingStat) {
     try {
       mkdirSync(dirname(settingsPath), { recursive: true });
       writeAtomic(rendered);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      // Best-effort cleanup of a partial .tmp file left by a failed rename.
-      try {
-        unlinkSync(`${settingsPath}.tmp`);
-      } catch {
-        // no tmp file to clean up, or cleanup itself failed — ignore
-      }
       return { action: "io-error", reason: msg, failure: true };
     }
     return { action: "created", failure: false };
@@ -472,6 +510,19 @@ function installHooks(
     return { action: "invalid-json", reason: msg, failure: true };
   }
 
+  // H9: an ARRAY `hooks` field would otherwise slip past the object check
+  // (`typeof [] === "object"`) — its `.Stop` is undefined, so Case D would
+  // not fire and Case B/C would overwrite the array wholesale, silently
+  // destroying whatever the user had encoded. Reject it up front so nothing
+  // is lost.
+  if (Array.isArray(existing.hooks)) {
+    return {
+      action: "invalid-json",
+      reason: "settings.json 'hooks' field must be an object, not an array",
+      failure: true,
+    };
+  }
+
   const existingHooks =
     existing.hooks && typeof existing.hooks === "object"
       ? (existing.hooks as Record<string, unknown>)
@@ -481,9 +532,14 @@ function installHooks(
   // even with --force (contract §--force フラグの扱い). Non-array / empty-
   // array / null hooks.Stop are NOT conflicts and fall through to Case B/C.
   if (Array.isArray(existingHooks?.Stop) && existingHooks.Stop.length > 0) {
+    // A3: derive the reason string from the SAME `rendered` object we would
+    // have written on the merge path. Duplicating the command literal here
+    // was drifting silently whenever the template changed (e.g. the
+    // `--mode symbol` suffix in spec 012 G1).
+    const conflictCmd = rendered.hooks.Stop[0]?.hooks[0]?.command ?? "";
     return {
       action: "conflict",
-      reason: `${execPrefix(detectedPm)} check --gate --diff`,
+      reason: conflictCmd,
       failure: true,
     };
   }
@@ -492,11 +548,15 @@ function installHooks(
   // any other top-level fields and any other hook keys (e.g. PreToolUse).
   // Extension point: if the template ever grows beyond Stop, spread
   // rendered.hooks here instead of setting Stop alone.
-  const originalHooks =
-    existing.hooks && typeof existing.hooks === "object" && !Array.isArray(existing.hooks)
-      ? (existing.hooks as Record<string, unknown>)
-      : {};
-  const hadOtherHookKeys = Object.keys(originalHooks).length > 0;
+  //
+  // The array-hooks case was already rejected above (H9), so at this point
+  // `existing.hooks` is either undefined or a plain object.
+  const originalHooks = existingHooks ?? {};
+  // C1: distinguish "user had a genuine sibling hook" (→ merged-c) from
+  // "user had `{hooks: {Stop: []}}`" (→ merged-b). Counting Stop itself
+  // would tag the latter as "other hooks preserved" — technically true,
+  // but only of a placeholder Stop that we're about to overwrite.
+  const hadOtherHookKeys = Object.keys(originalHooks).some((k) => k !== "Stop");
   existing.hooks = { ...originalHooks, Stop: rendered.hooks.Stop };
 
   try {
@@ -549,11 +609,16 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
 
   // Record the detected package manager so downstream tooling (hooks /
   // agent-context / plugin templating in #109/#110/#111) can build exec
-  // commands without re-sniffing lockfiles. `detectPackageManager` warns to
-  // stderr and returns null when nothing is detectable; in that case we leave
-  // the existing `packageManager` value alone (preserving any prior detection
-  // recorded in the file) instead of clobbering it with undefined (FR-008).
-  const detectedPm = detectPackageManager(abs);
+  // commands without re-sniffing lockfiles. `detectPackageManager` returns
+  // null when nothing is detectable; in that case we leave the existing
+  // `packageManager` value alone (preserving any prior detection recorded in
+  // the file) instead of clobbering it with undefined (FR-008).
+  //
+  // F3-caller: pass `quiet: true` so the low-level `ERROR:` message is
+  // suppressed here — the CLI's `skipped-no-pm` branch emits its own
+  // user-facing `WARNING:` line, and having both fire produced a confusing
+  // ERROR + WARNING pair for the same event.
+  const detectedPm = detectPackageManager(abs, { quiet: true });
   if (detectedPm) {
     config.packageManager = detectedPm;
   }
@@ -603,7 +668,13 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
   const hooksInstall = stages.hooks
     ? installHooks(abs, pmForHooks, {
         force: options.force,
-        explicitOptIn: options.withHooks === true,
+        // E1: `explicitOptIn` is only meaningful under `--minimal`, where the
+        // user has to opt IN to each stage. In default mode `--with-hooks` is
+        // redundant (hooks are already on) and MUST NOT escalate PM-missing
+        // to a failure — otherwise `init --with-hooks` in a repo without a
+        // detectable PM exits 1 while plain `init` exits 0 for the exact
+        // same on-disk state.
+        explicitOptIn: options.minimal === true && options.withHooks === true,
       })
     : undefined;
 

--- a/src/integrate/templates.ts
+++ b/src/integrate/templates.ts
@@ -1,38 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-/**
- * Thrown by {@link renderTemplate} when the template references a variable
- * that isn't supplied. Surfaced as an error (not silently rendered "") to
- * make missing-variable bugs loud.
- */
-export class MissingTemplateVarError extends Error {
-  readonly varName: string;
-  constructor(varName: string) {
-    super(`Missing template variable: ${varName}`);
-    this.name = "MissingTemplateVarError";
-    this.varName = varName;
-  }
-}
-
-const PLACEHOLDER = /\{\{\s*(\w+)\s*\}\}/g;
-
-/**
- * Substitute `{{ varName }}` placeholders in `template` with values from
- * `vars`. Whitespace inside braces is tolerated. Throws
- * {@link MissingTemplateVarError} if a referenced variable is absent.
- *
- * No loops / conditionals / nesting are supported — keep templates flat
- * (contracts/agent-guidance.md §テンプレート変数仕様).
- */
-export function renderTemplate(template: string, vars: Record<string, string>): string {
-  return template.replace(PLACEHOLDER, (_match, name: string) => {
-    if (!Object.prototype.hasOwnProperty.call(vars, name)) {
-      throw new MissingTemplateVarError(name);
-    }
-    return vars[name]!;
-  });
-}
+export { MissingTemplateVarError, renderTemplate } from "../template.js";
 
 const TEMPLATES_ROOT = resolve(import.meta.dirname, "../../templates/integrate");
 

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -16,10 +16,18 @@ export type { PackageManager } from "./types.js";
  * downstream fallback all resolve to pnpm. Only an explicit npm signal
  * (`package-lock.json` / `packageManager: npm@x`) returns npm.
  *
+ * @param options.quiet When true, suppress the final "cannot detect" error
+ *   message. Callers that emit their own user-facing warning should set this
+ *   to avoid redundant stderr output. `warn()` calls (yarn signals) are
+ *   still emitted — those are informational notices about the detected PM,
+ *   distinct from a silent-skip decision by the caller.
  * @returns the detected PM, or `null` when nothing can be detected (no
  *          package.json, no lockfile, no deno marker).
  */
-export function detectPackageManager(rootDir: string): PackageManager | null {
+export function detectPackageManager(
+  rootDir: string,
+  options?: { quiet?: boolean },
+): PackageManager | null {
   // Use isFile() (not existsSync) so a directory or symlink named like a
   // lockfile (e.g. `mkdir bun.lockb`) does not get mistaken for the real
   // lockfile. Mirrors `[ -f <name> ]` in the bash snippet.
@@ -68,7 +76,13 @@ export function detectPackageManager(rootDir: string): PackageManager | null {
 
   // (4) Nothing detectable. Match the bash snippet's stderr prefix exactly
   // ("ERROR:") so SSOT scripts and the TS detector emit identical text.
-  error("Cannot detect package manager; ask the user which to use");
+  // When the caller opts into `quiet`, it takes over user-facing messaging
+  // (see src/cli.ts install-hooks flow) — suppressing this avoids a
+  // redundant `ERROR:` + `WARNING:` pair for the same event that would
+  // otherwise trip CI log grep for hard failures.
+  if (!options?.quiet) {
+    error("Cannot detect package manager; ask the user which to use");
+  }
   return null;
 }
 

--- a/src/package-manager.ts
+++ b/src/package-manager.ts
@@ -112,7 +112,7 @@ export function buildExecCommand(pm: PackageManager, subcommand = ""): string {
   return sub ? `${prefix} ${sub}` : prefix;
 }
 
-function execPrefix(pm: PackageManager): string {
+export function execPrefix(pm: PackageManager): string {
   switch (pm) {
     case "npm":
       return "npx artgraph";

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,0 +1,32 @@
+/**
+ * Thrown by {@link renderTemplate} when the template references a variable
+ * that isn't supplied. Surfaced as an error (not silently rendered "") to
+ * make missing-variable bugs loud.
+ */
+export class MissingTemplateVarError extends Error {
+  readonly varName: string;
+  constructor(varName: string) {
+    super(`Missing template variable: ${varName}`);
+    this.name = "MissingTemplateVarError";
+    this.varName = varName;
+  }
+}
+
+const PLACEHOLDER = /\{\{\s*(\w+)\s*\}\}/g;
+
+/**
+ * Substitute `{{ varName }}` placeholders in `template` with values from
+ * `vars`. Whitespace inside braces is tolerated. Throws
+ * {@link MissingTemplateVarError} if a referenced variable is absent.
+ *
+ * No loops / conditionals / nesting are supported — keep templates flat
+ * (contracts/agent-guidance.md §テンプレート変数仕様).
+ */
+export function renderTemplate(template: string, vars: Record<string, string>): string {
+  return template.replace(PLACEHOLDER, (_match, name: string) => {
+    if (!Object.prototype.hasOwnProperty.call(vars, name)) {
+      throw new MissingTemplateVarError(name);
+    }
+    return vars[name]!;
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,7 +166,7 @@ export interface InitOptions {
    *   2. scan + reconcile (unless noScan)
    *   3. install Skills into .claude/skills/ (unless noSkills)
    *   4. auto-integrate detected SDD tools (unless noIntegrate)
-   *   5. install Stop hook into .claude/settings.json (unless noHooks)        [P1]
+   *   5. install Stop hook into .claude/settings.json (unless noHooks)
    *   6. inject CLAUDE.md / AGENTS.md snippet (unless noAgentContext)         [P1]
    *
    * `--minimal` short-circuits stages 2–6 to off; each can be re-enabled with

--- a/templates/hooks/settings.json.template
+++ b/templates/hooks/settings.json.template
@@ -1,0 +1,7 @@
+{
+  "hooks": {
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "{{ARTGRAPH_EXEC}} check --gate --diff" } ] }
+    ]
+  }
+}

--- a/templates/hooks/settings.json.template
+++ b/templates/hooks/settings.json.template
@@ -1,7 +1,7 @@
 {
   "hooks": {
     "Stop": [
-      { "hooks": [ { "type": "command", "command": "{{ARTGRAPH_EXEC}} check --gate --diff" } ] }
+      { "hooks": [ { "type": "command", "command": "{{ARTGRAPH_EXEC}} check --gate --diff --mode symbol" } ] }
     ]
   }
 }

--- a/tests/hooks-merge.test.ts
+++ b/tests/hooks-merge.test.ts
@@ -1,0 +1,360 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runInit } from "../src/init.js";
+import { execPrefix, type PackageManager } from "../src/package-manager.js";
+import { runCli } from "../src/cli.js";
+
+// Comprehensive coverage of installHooks' 4-case Stop-hook merge, per
+// specs/012-skills-expansion/contracts/settings-merge.md and plan §8
+// (issue #109). installHooks itself is not exported; it is exercised
+// exclusively through runInit()/runCli(["init", ...]) and the resulting
+// InitResult.hooksInstall / on-disk .claude/settings.json state.
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "artgraph-hooks-"));
+}
+
+function cleanup(dir: string) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+function settingsPath(tmp: string): string {
+  return join(tmp, ".claude", "settings.json");
+}
+
+/** Seed package.json + a matching lockfile/config so PM detection resolves to `pm`. */
+function seedPm(tmp: string, pm: PackageManager): void {
+  if (pm !== "deno") {
+    writeFileSync(join(tmp, "package.json"), JSON.stringify({ name: "t", type: "module" }));
+  }
+  switch (pm) {
+    case "npm":
+      writeFileSync(join(tmp, "package-lock.json"), "{}");
+      break;
+    case "pnpm":
+      writeFileSync(join(tmp, "pnpm-lock.yaml"), "");
+      break;
+    case "bun":
+      writeFileSync(join(tmp, "bun.lock"), "");
+      break;
+    case "deno":
+      writeFileSync(join(tmp, "deno.json"), "{}");
+      break;
+  }
+}
+
+describe("installHooks (Stop-hook merge)", () => {
+  let tmp: string;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmp = makeTmpDir();
+    // detectPackageManager() writes "ERROR: Cannot detect package manager..."
+    // to stderr whenever no PM signal is present; several cases below
+    // intentionally exercise that path. Silence it so test output stays clean
+    // (the warning content itself is covered by package-manager tests).
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errSpy.mockRestore();
+    cleanup(tmp);
+  });
+
+  // -- Case A ----------------------------------------------------------------
+
+  it("Case A: no settings.json → created with the rendered Stop hook command", () => {
+    seedPm(tmp, "pnpm");
+
+    const result = runInit(tmp, { noScan: true });
+
+    const p = settingsPath(tmp);
+    expect(existsSync(p)).toBe(true);
+    const raw = readFileSync(p, "utf-8");
+    // Loud-fail guard: substitution must have fully resolved — no leftover
+    // {{...}} placeholders in the written file.
+    expect(raw).not.toContain("{{");
+    const parsed = JSON.parse(raw);
+    expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
+      `${execPrefix("pnpm")} check --gate --diff`,
+    );
+    expect(result.hooksInstall).toEqual({ action: "created", failure: false });
+  });
+
+  // -- Case B ------------------------------------------------------------------
+
+  it("Case B: pre-seeded {} with other top-level fields → Stop added, fields preserved", () => {
+    seedPm(tmp, "pnpm");
+    mkdirSync(join(tmp, ".claude"), { recursive: true });
+    writeFileSync(
+      settingsPath(tmp),
+      JSON.stringify({ permissions: { allow: ["Bash"] } }),
+    );
+
+    const result = runInit(tmp, { noScan: true });
+
+    const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
+    expect(parsed.permissions).toEqual({ allow: ["Bash"] });
+    expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
+      `${execPrefix("pnpm")} check --gate --diff`,
+    );
+    expect(result.hooksInstall?.action).toBe("merged-b");
+    expect(result.hooksInstall?.failure).toBe(false);
+  });
+
+  // -- Case C ------------------------------------------------------------------
+
+  it("Case C: pre-seeded hooks.PreToolUse → Stop added, PreToolUse preserved", () => {
+    seedPm(tmp, "pnpm");
+    mkdirSync(join(tmp, ".claude"), { recursive: true });
+    const preToolUse = [{ hooks: [{ type: "command", command: "echo pre" }] }];
+    writeFileSync(
+      settingsPath(tmp),
+      JSON.stringify({ hooks: { PreToolUse: preToolUse } }),
+    );
+
+    const result = runInit(tmp, { noScan: true });
+
+    const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
+    expect(parsed.hooks.PreToolUse).toEqual(preToolUse);
+    expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
+      `${execPrefix("pnpm")} check --gate --diff`,
+    );
+    expect(result.hooksInstall?.action).toBe("merged-c");
+    expect(result.hooksInstall?.failure).toBe(false);
+  });
+
+  // -- Case D ------------------------------------------------------------------
+
+  it("Case D: existing hooks.Stop → file byte-identical, conflict + failure", () => {
+    seedPm(tmp, "pnpm");
+    mkdirSync(join(tmp, ".claude"), { recursive: true });
+    const before = JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ type: "command", command: "echo x" }] }] },
+    });
+    writeFileSync(settingsPath(tmp), before);
+
+    const result = runInit(tmp, { noScan: true, force: true });
+
+    expect(readFileSync(settingsPath(tmp), "utf-8")).toBe(before);
+    expect(result.hooksInstall?.action).toBe("conflict");
+    expect(result.hooksInstall?.failure).toBe(true);
+  });
+
+  it("Case D via CLI --force: exit code 1, settings.json untouched, .artgraph.json still (re-)written", async () => {
+    seedPm(tmp, "pnpm");
+    mkdirSync(join(tmp, ".claude"), { recursive: true });
+    const before = JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ type: "command", command: "echo x" }] }] },
+    });
+    writeFileSync(settingsPath(tmp), before);
+
+    const r = await runCli(["init", "--force"], { cwd: tmp });
+
+    expect(r.exitCode).toBe(1);
+    expect(readFileSync(settingsPath(tmp), "utf-8")).toBe(before);
+    expect(existsSync(join(tmp, ".artgraph.json"))).toBe(true);
+    // .artgraph.json is a valid, freshly (re-)written config despite the
+    // Stop-hook conflict — hooks failure must not block config/skills.
+    const config = JSON.parse(readFileSync(join(tmp, ".artgraph.json"), "utf-8"));
+    expect(config.packageManager).toBe("pnpm");
+  });
+
+  // -- Invalid JSON --------------------------------------------------------------
+
+  it("invalid JSON: pre-seeded 'not a json' → invalid-json, failure, file unchanged", () => {
+    seedPm(tmp, "pnpm");
+    mkdirSync(join(tmp, ".claude"), { recursive: true });
+    writeFileSync(settingsPath(tmp), "not a json");
+
+    const result = runInit(tmp, { noScan: true, force: true });
+
+    expect(readFileSync(settingsPath(tmp), "utf-8")).toBe("not a json");
+    expect(result.hooksInstall?.action).toBe("invalid-json");
+    expect(result.hooksInstall?.failure).toBe(true);
+  });
+
+  // -- BOM ------------------------------------------------------------------------
+
+  it("BOM-prefixed existing settings.json parses OK (Case B result)", () => {
+    seedPm(tmp, "pnpm");
+    mkdirSync(join(tmp, ".claude"), { recursive: true });
+    writeFileSync(settingsPath(tmp), "﻿{}");
+
+    const result = runInit(tmp, { noScan: true, force: true });
+
+    const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
+    expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
+      `${execPrefix("pnpm")} check --gate --diff`,
+    );
+    expect(result.hooksInstall?.action).toBe("merged-b");
+    expect(result.hooksInstall?.failure).toBe(false);
+  });
+
+  // -- Non-regular-file guards ------------------------------------------------------
+
+  it(".claude/settings.json is a directory → io-error, failure, left untouched", () => {
+    seedPm(tmp, "pnpm");
+    mkdirSync(settingsPath(tmp), { recursive: true });
+
+    const result = runInit(tmp, { noScan: true });
+
+    expect(result.hooksInstall?.action).toBe("io-error");
+    expect(result.hooksInstall?.failure).toBe(true);
+    expect(statSync(settingsPath(tmp)).isDirectory()).toBe(true);
+  });
+
+  it(".claude/settings.json is a symlink → io-error, failure, symlink left untouched", () => {
+    seedPm(tmp, "pnpm");
+    mkdirSync(join(tmp, ".claude"), { recursive: true });
+    symlinkSync(join(tmp, "elsewhere-target.json"), settingsPath(tmp));
+
+    const result = runInit(tmp, { noScan: true });
+
+    expect(result.hooksInstall?.action).toBe("io-error");
+    expect(result.hooksInstall?.failure).toBe(true);
+    expect(lstatSync(settingsPath(tmp)).isSymbolicLink()).toBe(true);
+  });
+
+  // -- Regression guards: non-conflicting hooks.Stop shapes --------------------------
+
+  describe.each([
+    ["empty array", []],
+    ["empty object", {}],
+    ["non-array number", 42],
+  ] as const)("hooks.Stop = %s (not a populated array)", (_label, stopValue) => {
+    it("is overwritten (Case B/C path), not treated as a conflict", () => {
+      seedPm(tmp, "pnpm");
+      mkdirSync(join(tmp, ".claude"), { recursive: true });
+      writeFileSync(
+        settingsPath(tmp),
+        JSON.stringify({ hooks: { Stop: stopValue, PreToolUse: [] } }),
+      );
+
+      const result = runInit(tmp, { noScan: true, force: true });
+
+      expect(result.hooksInstall?.action).not.toBe("conflict");
+      expect(result.hooksInstall?.failure).toBeFalsy();
+      const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
+      expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
+        `${execPrefix("pnpm")} check --gate --diff`,
+      );
+    });
+  });
+
+  // -- PM matrix --------------------------------------------------------------------
+
+  describe.each([
+    ["npm", "package-lock.json"],
+    ["pnpm", "pnpm-lock.yaml"],
+    ["bun", "bun.lock"],
+    ["deno", "deno.json"],
+  ] as const)("PM detection: %s (via %s)", (pm, _lockfile) => {
+    it(`renders the Stop hook command with ${pm}'s exec prefix`, () => {
+      seedPm(tmp, pm);
+
+      runInit(tmp, { noScan: true });
+
+      const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
+      const command: string = parsed.hooks.Stop[0].hooks[0].command;
+      expect(command.startsWith(execPrefix(pm))).toBe(true);
+      expect(command).toBe(`${execPrefix(pm)} check --gate --diff`);
+    });
+  });
+
+  // -- PM detection failure -----------------------------------------------------------
+
+  it("PM undetectable + default full setup → skipped-no-pm, not a failure", () => {
+    // No package.json, no lockfile, no deno marker anywhere in tmp.
+    const result = runInit(tmp, { noScan: true });
+
+    expect(existsSync(settingsPath(tmp))).toBe(false);
+    expect(result.hooksInstall?.action).toBe("skipped-no-pm");
+    expect(result.hooksInstall?.failure).toBe(false);
+  });
+
+  it("PM undetectable + --minimal --with-hooks (explicit opt-in) → skipped-no-pm, failure", () => {
+    const result = runInit(tmp, { minimal: true, withHooks: true });
+
+    expect(existsSync(settingsPath(tmp))).toBe(false);
+    expect(result.hooksInstall?.action).toBe("skipped-no-pm");
+    expect(result.hooksInstall?.failure).toBe(true);
+  });
+
+  // -- .artgraph.json#packageManager fallback ------------------------------------------
+
+  it("falls back to the stored .artgraph.json#packageManager once the lockfile/package.json are gone", () => {
+    seedPm(tmp, "pnpm");
+
+    // First run: live pnpm-lock.yaml → .artgraph.json records packageManager: "pnpm",
+    // and the Stop hook is installed (Case A).
+    runInit(tmp, { noScan: true });
+    expect(
+      JSON.parse(readFileSync(join(tmp, ".artgraph.json"), "utf-8")).packageManager,
+    ).toBe("pnpm");
+    expect(existsSync(settingsPath(tmp))).toBe(true);
+
+    // Remove every live PM signal AND the previously-installed settings.json
+    // so the second run must fall back to the stored config value and hit
+    // Case A again (not Case D).
+    rmSync(join(tmp, "pnpm-lock.yaml"));
+    rmSync(join(tmp, "package.json"));
+    rmSync(settingsPath(tmp));
+
+    const result = runInit(tmp, { noScan: true, force: true });
+
+    // settings.json was removed above, so this is a fresh Case A write —
+    // the key assertion is that it used the *stored* PM (pnpm) rather than
+    // failing outright now that live detection is inconclusive.
+    expect(result.hooksInstall?.action).toBe("created");
+    expect(existsSync(settingsPath(tmp))).toBe(true);
+    const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
+    expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
+      `${execPrefix("pnpm")} check --gate --diff`,
+    );
+  });
+
+  // -- --no-hooks --------------------------------------------------------------------
+
+  it("--no-hooks preserves an existing settings.json byte-for-byte and reports no hooksInstall", () => {
+    seedPm(tmp, "pnpm");
+    mkdirSync(join(tmp, ".claude"), { recursive: true });
+    const before = JSON.stringify({
+      hooks: { Stop: [{ hooks: [{ type: "command", command: "echo x" }] }] },
+    });
+    writeFileSync(settingsPath(tmp), before);
+
+    const result = runInit(tmp, { noScan: true, noHooks: true, force: true });
+
+    expect(readFileSync(settingsPath(tmp), "utf-8")).toBe(before);
+    expect(result.hooksInstall).toBeUndefined();
+  });
+
+  // -- --minimal --with-hooks in an empty dir ------------------------------------------
+
+  it("--minimal --with-hooks creates .claude/settings.json when .claude/ doesn't exist yet", () => {
+    seedPm(tmp, "pnpm");
+    expect(existsSync(join(tmp, ".claude"))).toBe(false);
+
+    const result = runInit(tmp, { minimal: true, withHooks: true });
+
+    expect(existsSync(settingsPath(tmp))).toBe(true);
+    expect(result.hooksInstall?.action).toBe("created");
+    const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
+    expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
+      `${execPrefix("pnpm")} check --gate --diff`,
+    );
+  });
+});

--- a/tests/hooks-merge.test.ts
+++ b/tests/hooks-merge.test.ts
@@ -1,5 +1,28 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// vitest ESM: `vi.spyOn(fs, "renameSync")` fails with "Cannot redefine property"
+// because node:fs's exports are non-configurable. To simulate a renameSync
+// failure for the B1+B2 cleanup tests we mock the module with a flag-gated
+// pass-through. When `renameControl.shouldThrow` is false the real renameSync
+// is used, so every other test in the suite is unaffected.
+const renameControl = vi.hoisted(() => ({ shouldThrow: false }));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    renameSync: (
+      ...args: Parameters<typeof actual.renameSync>
+    ): ReturnType<typeof actual.renameSync> => {
+      if (renameControl.shouldThrow) {
+        throw new Error("simulated rename failure");
+      }
+      return actual.renameSync(...args);
+    },
+  };
+});
+
 import {
+  chmodSync,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -88,7 +111,7 @@ describe("installHooks (Stop-hook merge)", () => {
     expect(raw).not.toContain("{{");
     const parsed = JSON.parse(raw);
     expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
-      `${execPrefix("pnpm")} check --gate --diff`,
+      `${execPrefix("pnpm")} check --gate --diff --mode symbol`,
     );
     expect(result.hooksInstall).toEqual({ action: "created", failure: false });
   });
@@ -108,7 +131,7 @@ describe("installHooks (Stop-hook merge)", () => {
     const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
     expect(parsed.permissions).toEqual({ allow: ["Bash"] });
     expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
-      `${execPrefix("pnpm")} check --gate --diff`,
+      `${execPrefix("pnpm")} check --gate --diff --mode symbol`,
     );
     expect(result.hooksInstall?.action).toBe("merged-b");
     expect(result.hooksInstall?.failure).toBe(false);
@@ -130,7 +153,7 @@ describe("installHooks (Stop-hook merge)", () => {
     const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
     expect(parsed.hooks.PreToolUse).toEqual(preToolUse);
     expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
-      `${execPrefix("pnpm")} check --gate --diff`,
+      `${execPrefix("pnpm")} check --gate --diff --mode symbol`,
     );
     expect(result.hooksInstall?.action).toBe("merged-c");
     expect(result.hooksInstall?.failure).toBe(false);
@@ -186,6 +209,26 @@ describe("installHooks (Stop-hook merge)", () => {
     expect(result.hooksInstall?.failure).toBe(true);
   });
 
+  // -- H9: array-shaped `hooks` field ---------------------------------------------
+
+  it("hooks field is an array → invalid-json, failure, file untouched (H9)", () => {
+    // Before H9, a `hooks: []` field slipped past the `typeof === "object"`
+    // check (arrays ARE objects in JS), then Case B/C would wholesale
+    // replace it with `{Stop: [...]}` and silently discard the array. That's
+    // information loss — reject the shape up front instead.
+    seedPm(tmp, "pnpm");
+    mkdirSync(join(tmp, ".claude"), { recursive: true });
+    const before = JSON.stringify({ hooks: [{ Stop: "surprise" }] });
+    writeFileSync(settingsPath(tmp), before);
+
+    const result = runInit(tmp, { noScan: true, force: true });
+
+    expect(result.hooksInstall?.action).toBe("invalid-json");
+    expect(result.hooksInstall?.failure).toBe(true);
+    // File must be byte-identical — the original array content survives.
+    expect(readFileSync(settingsPath(tmp), "utf-8")).toBe(before);
+  });
+
   // -- BOM ------------------------------------------------------------------------
 
   it("BOM-prefixed existing settings.json parses OK (Case B result)", () => {
@@ -197,7 +240,7 @@ describe("installHooks (Stop-hook merge)", () => {
 
     const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
     expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
-      `${execPrefix("pnpm")} check --gate --diff`,
+      `${execPrefix("pnpm")} check --gate --diff --mode symbol`,
     );
     expect(result.hooksInstall?.action).toBe("merged-b");
     expect(result.hooksInstall?.failure).toBe(false);
@@ -249,9 +292,29 @@ describe("installHooks (Stop-hook merge)", () => {
       expect(result.hooksInstall?.failure).toBeFalsy();
       const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
       expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
-        `${execPrefix("pnpm")} check --gate --diff`,
+        `${execPrefix("pnpm")} check --gate --diff --mode symbol`,
       );
     });
+  });
+
+  // -- C1: bare {hooks: {Stop: []}} must NOT tag as merged-c -----------------------
+
+  it("C1: hooks.Stop present but no other hook keys → merged-b (not merged-c)", () => {
+    // Before C1, `hadOtherHookKeys` counted `Stop` itself, so a
+    // `{hooks: {Stop: []}}` seed reported "other hooks preserved" (merged-c)
+    // even though the only pre-existing key was the placeholder Stop we
+    // were about to overwrite.
+    seedPm(tmp, "pnpm");
+    mkdirSync(join(tmp, ".claude"), { recursive: true });
+    writeFileSync(
+      settingsPath(tmp),
+      JSON.stringify({ hooks: { Stop: [] } }),
+    );
+
+    const result = runInit(tmp, { noScan: true, force: true });
+
+    expect(result.hooksInstall?.action).toBe("merged-b");
+    expect(result.hooksInstall?.failure).toBe(false);
   });
 
   // -- PM matrix --------------------------------------------------------------------
@@ -270,7 +333,7 @@ describe("installHooks (Stop-hook merge)", () => {
       const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
       const command: string = parsed.hooks.Stop[0].hooks[0].command;
       expect(command.startsWith(execPrefix(pm))).toBe(true);
-      expect(command).toBe(`${execPrefix(pm)} check --gate --diff`);
+      expect(command).toBe(`${execPrefix(pm)} check --gate --diff --mode symbol`);
     });
   });
 
@@ -291,6 +354,19 @@ describe("installHooks (Stop-hook merge)", () => {
     expect(existsSync(settingsPath(tmp))).toBe(false);
     expect(result.hooksInstall?.action).toBe("skipped-no-pm");
     expect(result.hooksInstall?.failure).toBe(true);
+  });
+
+  it("E1: PM undetectable + default mode + --with-hooks → NOT a failure (redundant flag)", () => {
+    // Under default mode, --with-hooks is redundant (hooks are already on)
+    // and must NOT flip PM-missing into a failure. Before E1, passing
+    // `withHooks: true` in default mode escalated skipped-no-pm → exit 1,
+    // giving `init --with-hooks` and plain `init` opposite outcomes for
+    // identical on-disk state.
+    const result = runInit(tmp, { withHooks: true, noScan: true });
+
+    expect(existsSync(settingsPath(tmp))).toBe(false);
+    expect(result.hooksInstall?.action).toBe("skipped-no-pm");
+    expect(result.hooksInstall?.failure).toBe(false);
   });
 
   // -- .artgraph.json#packageManager fallback ------------------------------------------
@@ -322,7 +398,7 @@ describe("installHooks (Stop-hook merge)", () => {
     expect(existsSync(settingsPath(tmp))).toBe(true);
     const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
     expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
-      `${execPrefix("pnpm")} check --gate --diff`,
+      `${execPrefix("pnpm")} check --gate --diff --mode symbol`,
     );
   });
 
@@ -354,7 +430,199 @@ describe("installHooks (Stop-hook merge)", () => {
     expect(result.hooksInstall?.action).toBe("created");
     const parsed = JSON.parse(readFileSync(settingsPath(tmp), "utf-8"));
     expect(parsed.hooks.Stop[0].hooks[0].command).toBe(
-      `${execPrefix("pnpm")} check --gate --diff`,
+      `${execPrefix("pnpm")} check --gate --diff --mode symbol`,
     );
+  });
+
+  // -- A3: Case D reason SSOT (rendered template body) -----------------------------
+
+  it("A3: Case D reason mirrors the rendered template command (not a hard-coded literal)", () => {
+    // The Case D warning tells the user which command to paste into their
+    // hooks.Stop. If this reason string ever drifted from what Cases A/B/C
+    // write, the user would be told to paste something different from what
+    // artgraph actually wants — silently. Assert that the reason we emit is
+    // literally the rendered template body, including whatever suffix the
+    // current template carries (--mode symbol today).
+    seedPm(tmp, "pnpm");
+    mkdirSync(join(tmp, ".claude"), { recursive: true });
+    writeFileSync(
+      settingsPath(tmp),
+      JSON.stringify({
+        hooks: { Stop: [{ hooks: [{ type: "command", command: "echo x" }] }] },
+      }),
+    );
+
+    const result = runInit(tmp, { noScan: true, force: true });
+
+    expect(result.hooksInstall?.action).toBe("conflict");
+    expect(result.hooksInstall?.reason).toBe(
+      `${execPrefix("pnpm")} check --gate --diff --mode symbol`,
+    );
+  });
+
+  // -- B1+B2: writeAtomic .tmp cleanup on rename failure --------------------------
+
+  describe("writeAtomic .tmp cleanup on failure", () => {
+    afterEach(() => {
+      // Belt-and-suspenders: reset the mock flag even if a test throws
+      // before its own finally block runs.
+      renameControl.shouldThrow = false;
+    });
+
+    it("Case B: renameSync throw leaves no orphan .tmp file", () => {
+      // Simulate a rename failure (e.g. cross-device, EACCES on the parent
+      // dir). writeAtomic must delete the `.tmp` it created so a partial
+      // write doesn't linger on disk — this is the symmetric-cleanup half
+      // of B1+B2 (previously only Case A cleaned up).
+      seedPm(tmp, "pnpm");
+      mkdirSync(join(tmp, ".claude"), { recursive: true });
+      writeFileSync(
+        settingsPath(tmp),
+        JSON.stringify({ permissions: { allow: ["Bash"] } }),
+      );
+
+      renameControl.shouldThrow = true;
+      let result;
+      try {
+        result = runInit(tmp, { noScan: true, force: true });
+      } finally {
+        renameControl.shouldThrow = false;
+      }
+
+      expect(result.hooksInstall?.action).toBe("io-error");
+      expect(result.hooksInstall?.failure).toBe(true);
+      expect(existsSync(`${settingsPath(tmp)}.tmp`)).toBe(false);
+    });
+
+    it("Case A: renameSync throw leaves no orphan .tmp file", () => {
+      seedPm(tmp, "pnpm");
+
+      renameControl.shouldThrow = true;
+      let result;
+      try {
+        result = runInit(tmp, { noScan: true });
+      } finally {
+        renameControl.shouldThrow = false;
+      }
+
+      expect(result.hooksInstall?.action).toBe("io-error");
+      expect(result.hooksInstall?.failure).toBe(true);
+      expect(existsSync(`${settingsPath(tmp)}.tmp`)).toBe(false);
+    });
+
+    it("Case A: pre-existing symlink at settings.json.tmp is cleaned before write", () => {
+      // Symlink-attack surface: if an attacker pre-plants a symlink at
+      // `settings.json.tmp` pointing at a sensitive file, `writeFileSync`
+      // would follow it and clobber the target. writeAtomic must remove
+      // that symlink first (unlinkSync removes the link, not the target).
+      seedPm(tmp, "pnpm");
+      mkdirSync(join(tmp, ".claude"), { recursive: true });
+      const attackTarget = join(tmp, "innocent-victim.txt");
+      writeFileSync(attackTarget, "do not clobber me\n");
+      symlinkSync(attackTarget, `${settingsPath(tmp)}.tmp`);
+
+      const result = runInit(tmp, { noScan: true });
+
+      expect(result.hooksInstall?.action).toBe("created");
+      // The victim file is untouched — writeAtomic removed the symlink
+      // instead of writing through it.
+      expect(readFileSync(attackTarget, "utf-8")).toBe("do not clobber me\n");
+      // And the real settings.json is a plain regular file, not a symlink.
+      expect(lstatSync(settingsPath(tmp)).isSymbolicLink()).toBe(false);
+    });
+  });
+
+  // -- D1: lstat "never throws" contract on EACCES ---------------------------------
+
+  it("D1: lstat EACCES on parent dir → io-error, not an uncaught throw", () => {
+    // installHooks' JSDoc guarantees "never throws". Before D1,
+    // `lstatSync({ throwIfNoEntry: false })` still threw on EACCES / EPERM
+    // / ELOOP because the option only suppresses ENOENT. On non-root Linux
+    // we can reproduce EACCES by dropping execute permission on the parent
+    // dir so lstat on a file inside it fails. When we can't simulate that
+    // (root user / non-Unix FS), skip gracefully — the contract is still
+    // enforced by the try/catch code path + tsc.
+    //
+    // Uses `--minimal --with-hooks` so only the hooks stage runs; a full
+    // default init would hit the same chmod'd `.claude` in installSkills
+    // first and throw before we can exercise the lstat path.
+    if (typeof process.getuid === "function" && process.getuid() === 0) {
+      return;
+    }
+    seedPm(tmp, "pnpm");
+    const claudeDir = join(tmp, ".claude");
+    mkdirSync(claudeDir, { recursive: true });
+    writeFileSync(settingsPath(tmp), "{}");
+    chmodSync(claudeDir, 0o000);
+
+    let result;
+    try {
+      result = runInit(tmp, { minimal: true, withHooks: true, force: true });
+    } finally {
+      // Always restore so afterEach's rmSync can descend into `.claude`.
+      chmodSync(claudeDir, 0o755);
+    }
+
+    // Whatever the failure mode, it must be a structured `io-error` — not
+    // an escaped exception that took down the whole init.
+    expect(result.hooksInstall?.action).toBe("io-error");
+    expect(result.hooksInstall?.failure).toBe(true);
+  });
+});
+
+// -- E2-2: --no-integrate + --integrations conflict via CLI ------------------------
+
+describe("init CLI: --no-integrate + --integrations conflict (E2-2)", () => {
+  let tmp: string;
+  let errSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "artgraph-cli-conflicts-"));
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errSpy.mockRestore();
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("--no-integrate --integrations=speckit → exit 1 with 'mutually exclusive'", async () => {
+    // Before E2-2, this pair silently dropped `--integrations` in default
+    // mode and *reversed* into an opt-in under `--minimal`. Both surfaces
+    // must now be flagged as a hard error before any fs writes occur.
+    const r = await runCli(
+      ["init", "--no-integrate", "--integrations", "speckit"],
+      { cwd: tmp },
+    );
+
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/mutually exclusive/);
+    // No writes happened because the check runs before runInit.
+    expect(existsSync(join(tmp, ".artgraph.json"))).toBe(false);
+  });
+
+  it("--no-integrate --integrations=all → exit 1 with 'mutually exclusive'", async () => {
+    const r = await runCli(
+      ["init", "--no-integrate", "--integrations", "all"],
+      { cwd: tmp },
+    );
+
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toMatch(/mutually exclusive/);
+    expect(existsSync(join(tmp, ".artgraph.json"))).toBe(false);
+  });
+
+  it("--no-integrate --integrations='' (empty) is NOT a conflict (parseInitIntegrations collapses to undefined)", async () => {
+    // Empty / whitespace / ",,," inputs collapse to undefined, which is
+    // semantically "no provider chosen" — indistinguishable from omitting
+    // the flag. Must not trigger the mutual-exclusion check.
+    const r = await runCli(
+      ["init", "--no-integrate", "--integrations", "", "--minimal"],
+      { cwd: tmp },
+    );
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stderr).not.toMatch(/mutually exclusive/);
+    expect(existsSync(join(tmp, ".artgraph.json"))).toBe(true);
   });
 });

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -636,9 +636,16 @@ describe("runInit default behavior (P0)", () => {
     expect(ids).toEqual(["kiro", "speckit"]);
   });
 
-  it("default mode does NOT create .claude/settings.json (hooks stub no-op in P0)", () => {
+  it("default mode creates .claude/settings.json with the Stop hook", () => {
+    writeFileSync(join(tmp, "package.json"), JSON.stringify({ name: "t", type: "module" }));
+    writeFileSync(join(tmp, "pnpm-lock.yaml"), "");
+
     runInit(tmp);
-    expect(existsSync(join(tmp, ".claude", "settings.json"))).toBe(false);
+
+    const settingsPath = join(tmp, ".claude", "settings.json");
+    expect(existsSync(settingsPath)).toBe(true);
+    const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    expect(settings.hooks.Stop[0].hooks[0].command).toMatch(/^pnpm exec artgraph /);
   });
 
   it("default mode does NOT create or modify CLAUDE.md (agent-context stub no-op in P0)", () => {
@@ -647,7 +654,9 @@ describe("runInit default behavior (P0)", () => {
   });
 
   it("--no-hooks is accepted without error in default mode", () => {
-    expect(() => runInit(tmp, { noHooks: true })).not.toThrow();
+    const result = runInit(tmp, { noHooks: true });
+    expect(existsSync(join(tmp, ".claude", "settings.json"))).toBe(false);
+    expect(result.hooksInstall).toBeUndefined();
   });
 
   it("--no-agent-context is accepted without error in default mode", () => {

--- a/tests/template.test.ts
+++ b/tests/template.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { MissingTemplateVarError, renderTemplate } from "../src/template.js";
+
+// Unit tests for the renderTemplate SSOT (src/template.ts), extracted from
+// src/integrate/templates.ts per issue #109 so both `integrate` (loadTemplate
+// callers) and `init` (hooks Stop-hook template) share the same substitution
+// engine. tests/integrate/templates.test.ts covers the re-export shim; this
+// file covers the moved implementation directly.
+
+describe("renderTemplate", () => {
+  it("substitutes a {{name}} placeholder", () => {
+    expect(renderTemplate("hello {{name}}", { name: "world" })).toBe("hello world");
+  });
+
+  it("accepts surrounding whitespace inside the braces", () => {
+    expect(renderTemplate("a {{ name }} b", { name: "x" })).toBe("a x b");
+  });
+
+  it("throws MissingTemplateVarError for undefined keys", () => {
+    expect(() => renderTemplate("hi {{name}}", {})).toThrow(MissingTemplateVarError);
+  });
+
+  it("exposes the missing variable name on err.varName", () => {
+    try {
+      renderTemplate("{{ARTGRAPH_EXEC}} check --gate --diff", {});
+      expect.unreachable("renderTemplate should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(MissingTemplateVarError);
+      expect((e as MissingTemplateVarError).varName).toBe("ARTGRAPH_EXEC");
+    }
+  });
+
+  it("substitutes the same key multiple times", () => {
+    expect(renderTemplate("{{x}} and {{x}}", { x: "a" })).toBe("a and a");
+  });
+
+  it("substitutes multiple distinct keys in one template", () => {
+    expect(
+      renderTemplate("{{a}}-{{b}}-{{a}}", { a: "1", b: "2" }),
+    ).toBe("1-2-1");
+  });
+
+  it("returns content unchanged when there are no placeholders", () => {
+    expect(renderTemplate("plain text", {})).toBe("plain text");
+  });
+
+  it("passes through JSON content with only non-placeholder braces untouched", () => {
+    const input = '{"hooks": {"Stop": []}}';
+    expect(renderTemplate(input, {})).toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary

- `installHooks()` の空スタブ (`src/init.ts:359`) を実装し、`templates/hooks/settings.json.template` を PM 非依存で新設 (spec 012 T022/T026)
- `renderTemplate` を `src/template.ts` に SSOT 化 (契約凍結 #1)、integrate 経路は re-export shim 化
- `{{ARTGRAPH_EXEC}}` は `execPrefix(detectedPm)` から生成 (契約凍結 #2)
- `.claude/settings.json` の 4-case マージ (Create / Merge-B / Merge-C / Conflict) を実装。Case D は `--force` でも上書きしない (contract §--force)
- CLI: `--with-hooks` の "P1 no-effect" 警告削除、text/JSON 出力に `hooksInstall` を配信、失敗時に exit 1

## 実装のポイント

- **PM 検出フォールバック**: 引数 `detectedPm` → `.artgraph.json#packageManager` → null。null で default full setup なら graceful skip、`--minimal --with-hooks` 明示 opt-in なら failure に昇格
- **Atomic write** (`tmp + rename`) で SIGTERM / disk-full 時の truncation を防止
- **BOM strip** + directory / symlink 拒否 + 全 fs / JSON / render を try/catch で握って `action: "io-error" | "invalid-json"` に翻訳し init 全体は落とさない (graceful degradation)
- **Case D 判定**: `Array.isArray(hooks.Stop) && length > 0` — 非配列 / 空配列 / null は Case B/C 扱い
- `installHooks` は console 出力せず `InitResult.hooksInstall = { action, reason?, failure? }` を返す。formatting は `src/cli.ts` に集約 (init.ts 現状 print-free 慣習を維持)
- **`runCli` テストヘルパ**: `process.exitCode` mutation を戻り値に伝搬させるよう修正 (Case D via CLI 経由テストの false negative 解消)

## Test plan

- [x] `pnpm exec tsc --noEmit` 通過
- [x] `pnpm test` 全 1185 tests + 3 e2e + 3 perf green
- [x] `pnpm exec knip` 変化なし
- [x] `tests/hooks-merge.test.ts` (新規) 21 case: Case A/B/C/D + `--force + D` + 不正 JSON + BOM + directory/symlink + `hooks.Stop = []/{}/42` + PM matrix (npm/pnpm/bun/deno) + PM null (skip / 昇格) + `.artgraph.json#packageManager` fallback + `--no-hooks` 保持 + `--minimal --with-hooks` mkdir
- [x] `tests/template.test.ts` (新規) 8 case: 置換 / whitespace / undefined throw / varName プロパティ / 多重 / no-placeholder
- [x] `tests/init.test.ts` invariant 反転 (default で settings.json 生成) と `--no-hooks` 拡張
- [x] Manual smoke (quickstart.md US4): Setup A (create) / B (merge) / C (conflict) / C--force すべて期待通り

## スコープ外 (follow-up)

- CLAUDE.md / AGENTS.md 注入 (`installAgentContext`) → #110
- Plugin (`.claude-plugin`) hooks → #111
- `stop_hook_active` 再帰ガードの CLI 対応 → 別 issue
- `.artgraph.json#packageManager` 手編集 vs settings.json の drift 検出 → `artgraph check` の follow-up

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)