### PR TITLE
feat(agent-context): AGENTS.md snippet を PM 非依存テンプレでレンダリング (closes #110)

### DIFF
--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -47,7 +47,7 @@ deno run -A npm:artgraph/cli init
 - Skills install (`.claude/skills/<name>/SKILL.md` 配置)
 - integrate-auto (検出された SDD ツール: Spec Kit / Kiro)
 - Stop hook
-- agent context snippet 注入 (P1)
+- agent context snippet 注入 (AGENTS.md canonical + CLAUDE.md / copilot wrapper。コマンド例は init 時に検出した PM の exec prefix でレンダリング)
 
 | フラグ | 挙動 |
 | --- | --- |

--- a/specs/013-cross-agent-extensions/contracts/agent-context-format.md
+++ b/specs/013-cross-agent-extensions/contracts/agent-context-format.md
@@ -22,12 +22,26 @@ AGENTS.md (canonical) と CLAUDE.md / `.github/copilot-instructions.md` (wrapper
 
 ## AGENTS.md (canonical, FR-005)
 
+### 本文のレンダリング (#110)
+
+block 本文は `templates/agent-context/agents-md-snippet.md` から `renderTemplate` (src/template.ts) でレンダリングする。テンプレート変数は 2 つ:
+
+| 変数 | 値 |
+|---|---|
+| `{{ARTGRAPH_EXEC}}` | init 時に検出した PM の `execPrefix()` (`npx artgraph` / `pnpm exec artgraph` / `bunx artgraph` / `deno run -A npm:artgraph/cli`)。PM 未検出時は bare `artgraph` にフォールバック (hooks と異なり stage skip しない — prose ガイドは global install 前提でも有用なため) |
+| `{{PM_NOTICE}}` | block 先頭の HTML コメント。「packageManager=X 前提で生成。PM 切替時は `<exec> init --force` で再生成」の passive notice (Default-Drift 気付き用)。PM 未検出時は global install 前提である旨の文言に切り替わる |
+
+PM 解決優先度は hooks stage と共有: (1) live detection → (2) `.artgraph.json#packageManager` → (3) null。
+
+以下のサンプルは **PM 未検出時 (bare `artgraph`) のレンダリング結果**。notice コメント行はレンダリングごとに PM に応じて変化する。
+
 ### 既存 AGENTS.md が無い場合
 
 新規作成:
 
 ```markdown
 <!-- artgraph:begin -->
+<!-- artgraph: no package manager was detected at init time; commands below assume a globally installed `artgraph`. After adding a lockfile, re-run `artgraph init --force` to regenerate this block. -->
 ## artgraph — Cross-agent traceability
 
 artgraph manages the trace lock and provides 8 Skills for spec ↔ code ↔ test traceability.
@@ -54,8 +68,8 @@ See `<agent_skills_path>/<skill-name>/SKILL.md` for each Skill's full descriptio
 ### Quickstart
 
 \`\`\`bash
-artgraph init --agents=<list>          # provision Skills + agent-context
-artgraph doctor                        # diagnose distribution health
+artgraph init --agents=<list>   # provision Skills + agent-context
+artgraph doctor                 # diagnose distribution health
 \`\`\`
 
 For full CLI reference, run `artgraph --help` or see https://github.com/ShintaroMorimoto/artgraph.

--- a/src/agents/agent-context.ts
+++ b/src/agents/agent-context.ts
@@ -28,7 +28,18 @@
 import { existsSync, mkdirSync, readFileSync, rmdirSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { atomicWriteFile } from "../integrate/atomic-write.js";
+import { execPrefix, type PackageManager } from "../package-manager.js";
+import { renderTemplate } from "../template.js";
 import type { AgentDescriptor } from "./descriptors.js";
+
+// `templates/agent-context/` lives next to `dist/` (tsc preserves the
+// directory layout, so this module compiles to `dist/agents/agent-context.js`
+// — two levels below the package root). Same convention as
+// SKILLS_TEMPLATE_DIR / HOOKS_TEMPLATE_PATH in src/init.ts.
+const AGENTS_MD_TEMPLATE_PATH = resolve(
+  import.meta.dirname,
+  "../../templates/agent-context/agents-md-snippet.md",
+);
 
 // ---------------------------------------------------------------------------
 // Marker block (T018)
@@ -60,11 +71,9 @@ export class MarkerBlockCorruptError extends Error {
 // flag self-heals IDE autocorrect that title-cases the marker into
 // `<!-- artgraph:Begin -->` / `<!-- artgraph:End -->` (OPS-9). Trailing
 // `\r?$` keeps CRLF line endings well-behaved (Windows / git autocrlf).
-const MARKER_RE =
-  /^<!--\s*artgraph:begin\s*-->[\s\S]*?<!--\s*artgraph:end\s*-->\r?$/im;
+const MARKER_RE = /^<!--\s*artgraph:begin\s*-->[\s\S]*?<!--\s*artgraph:end\s*-->\r?$/im;
 /** Global variant for enumeration / duplicate-block detection (A2). */
-const MARKER_RE_GLOBAL =
-  /^<!--\s*artgraph:begin\s*-->[\s\S]*?<!--\s*artgraph:end\s*-->\r?$/gim;
+const MARKER_RE_GLOBAL = /^<!--\s*artgraph:begin\s*-->[\s\S]*?<!--\s*artgraph:end\s*-->\r?$/gim;
 
 /** Begin/end discovery regexes for the `inspectMarkerBlock` diagnostic. */
 const BEGIN_RE = /^<!--\s*artgraph:begin\s*-->\r?$/im;
@@ -206,46 +215,48 @@ export function inspectMarkerBlock(content: string): MarkerBlockHealth {
 // ---------------------------------------------------------------------------
 
 /**
- * Canonical artgraph block body that lives inside AGENTS.md. Mirrors
- * contracts/agent-context-format.md §AGENTS.md verbatim (8 Skills + workflows
- * + quickstart). The text is the artgraph guide itself, NOT a wrapper.
+ * Canonical artgraph block body that lives inside AGENTS.md. Rendered from
+ * `templates/agent-context/agents-md-snippet.md` (8 Skills + workflows +
+ * quickstart — contracts/agent-context-format.md §AGENTS.md). The text is the
+ * artgraph guide itself, NOT a wrapper.
+ *
+ * PM independence (#110): command examples embed the exec prefix for the
+ * package manager detected at init time (`npx artgraph`, `pnpm exec artgraph`,
+ * …) via `{{ARTGRAPH_EXEC}}`. `{{PM_NOTICE}}` renders a leading HTML comment
+ * telling readers which PM the block was generated for and how to regenerate
+ * after switching — the passive Default-Drift breadcrumb from #110; there is
+ * no runtime drift warning.
+ *
+ * `detectedPm === null` (no lockfile / packageManager field) degrades to the
+ * bare `artgraph` binary rather than skipping the stage — unlike the Stop
+ * hook, prose guidance stays useful without a runnable exec prefix.
  *
  * Returned without surrounding markers — `applyMarkerBlock` adds them.
+ * Throws when the packaged template is missing or references a variable not
+ * supplied here (both are packaging faults, not user errors).
  */
-export function buildAgentsMdBody(): string {
-  return [
-    "## artgraph — Cross-agent traceability",
-    "",
-    "artgraph manages the trace lock and provides 8 Skills for spec ↔ code ↔ test traceability.",
-    "",
-    "### Available Skills",
-    "",
-    "- `artgraph-setup` — install artgraph in this project",
-    "- `artgraph-detect` — report artgraph installation state",
-    "- `artgraph-integrate` — wire artgraph into Spec Kit / Kiro",
-    "- `artgraph-impact` — file/symbol → REQs impact",
-    "- `artgraph-plan-coverage` — reverse audit of tasks.md / plan.md",
-    "- `artgraph-coverage` — per-REQ coverage status",
-    "- `artgraph-verify` — `artgraph check --diff` self-check",
-    "- `artgraph-rename` — safe rename / split / merge of REQ IDs",
-    "",
-    "See `<agent_skills_path>/<skill-name>/SKILL.md` for each Skill's full description (where `<agent_skills_path>` is `.claude/skills/`, `.agents/skills/`, `.cursor/skills/`, `.github/skills/`, or `.kiro/skills/` depending on your agent).",
-    "",
-    "### Common workflows",
-    "",
-    "- After editing `tasks.md` / `plan.md`: run **artgraph-plan-coverage** to catch implicit REQ impacts.",
-    "- Before review: run **artgraph-verify** (`artgraph check --diff`).",
-    "- When proposing a code change: invoke **artgraph-impact** with `path:symbol`.",
-    "",
-    "### Quickstart",
-    "",
-    "```bash",
-    "artgraph init --agents=<list>          # provision Skills + agent-context",
-    "artgraph doctor                        # diagnose distribution health",
-    "```",
-    "",
-    "For full CLI reference, run `artgraph --help` or see https://github.com/ShintaroMorimoto/artgraph.",
-  ].join("\n");
+export function buildAgentsMdBody(detectedPm: PackageManager | null): string {
+  const exec = detectedPm === null ? "artgraph" : execPrefix(detectedPm);
+  const notice =
+    detectedPm === null
+      ? "<!-- artgraph: no package manager was detected at init time; commands below assume a globally installed `artgraph`. After adding a lockfile, re-run `artgraph init --force` to regenerate this block. -->"
+      : `<!-- artgraph: generated for packageManager=${detectedPm}. If you switch package managers, re-run \`${exec} init --force\` to regenerate this block. -->`;
+
+  let raw: string;
+  try {
+    raw = readFileSync(AGENTS_MD_TEMPLATE_PATH, "utf-8");
+  } catch (e) {
+    const err = e as NodeJS.ErrnoException;
+    throw new Error(
+      `cannot read agent-context template at ${AGENTS_MD_TEMPLATE_PATH}: ` +
+        `${err.message ?? String(e)} (broken artgraph installation — try reinstalling)`,
+    );
+  }
+
+  // The template file ends with a POSIX trailing newline; strip exactly that
+  // one so `applyMarkerBlock` (which wraps the body in `\n…\n`) does not
+  // produce a blank line before the end marker.
+  return renderTemplate(raw, { ARTGRAPH_EXEC: exec, PM_NOTICE: notice }).replace(/\n$/, "");
 }
 
 export interface WriteResult {
@@ -270,10 +281,14 @@ export interface WriteResult {
  * `--force` only gates user-drift Skill file overwrites in `distribute()`;
  * it does NOT gate the AGENTS.md / wrapper block bodies, which are always
  * treated as machine-owned canonical content.
+ *
+ * `detectedPm` selects the exec prefix embedded in the block's command
+ * examples (see `buildAgentsMdBody`). A PM switch between runs therefore
+ * surfaces as a normal body refresh (`written: true`) on the next init.
  */
-export function writeAgentsMd(rootDir: string): WriteResult {
+export function writeAgentsMd(rootDir: string, detectedPm: PackageManager | null): WriteResult {
   const absPath = resolve(rootDir, "AGENTS.md");
-  return writeMarkerFile(absPath, buildAgentsMdBody());
+  return writeMarkerFile(absPath, buildAgentsMdBody(detectedPm));
 }
 
 // ---------------------------------------------------------------------------
@@ -406,10 +421,7 @@ const GITATTRIBUTES_CONTENT = "** text eol=lf\n";
  * agent's Skill dist tree carries a `.gitattributes` pinning `** text eol=lf`.
  * Writes atomically via `atomicWriteFile`.
  */
-export function writeGitAttributes(
-  rootDir: string,
-  descriptor: AgentDescriptor,
-): WriteResult {
+export function writeGitAttributes(rootDir: string, descriptor: AgentDescriptor): WriteResult {
   const absPath = resolve(rootDir, descriptor.skillsPath, ".gitattributes");
 
   // Parent may not exist on a fresh project (Skill dist tree not yet
@@ -425,9 +437,7 @@ export function writeGitAttributes(
   } catch (e) {
     const err = e as NodeJS.ErrnoException;
     if (err.code !== "ENOENT") {
-      throw new Error(
-        `cannot read existing file at ${absPath}: ${err.message ?? String(e)}`,
-      );
+      throw new Error(`cannot read existing file at ${absPath}: ${err.message ?? String(e)}`);
     }
   }
 
@@ -466,9 +476,7 @@ function writeMarkerFile(absPath: string, body: string): WriteResult {
     if (err.code === "ENOENT") {
       existing = "";
     } else {
-      throw new Error(
-        `cannot read existing file at ${absPath}: ${err.message ?? String(e)}`,
-      );
+      throw new Error(`cannot read existing file at ${absPath}: ${err.message ?? String(e)}`);
     }
   }
   const { newContent } = applyMarkerBlock(existing, body);

--- a/src/init.ts
+++ b/src/init.ts
@@ -677,13 +677,14 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
     ? runRequestedIntegrations(abs, detection, options)
     : { failureCount: 0 };
 
-  // PM resolution priority for the hooks stage (contract §PM 検出優先度):
-  // (1) live detection this run, (2) the value already recorded in
-  // .artgraph.json (covers repos where lockfiles were removed/rotated after
-  // the initial init), (3) null → graceful skip.
-  const pmForHooks = detectedPm ?? config.packageManager ?? null;
+  // PM resolution priority shared by the hooks and agent-context stages
+  // (contract §PM 検出優先度): (1) live detection this run, (2) the value
+  // already recorded in .artgraph.json (covers repos where lockfiles were
+  // removed/rotated after the initial init), (3) null → graceful skip for
+  // hooks, bare-`artgraph` command examples for agent-context (#110).
+  const resolvedPm = detectedPm ?? config.packageManager ?? null;
   const hooksInstall = stages.hooks
-    ? installHooks(abs, pmForHooks, {
+    ? installHooks(abs, resolvedPm, {
         force: options.force,
         // E1: `explicitOptIn` is only meaningful under `--minimal`, where the
         // user has to opt IN to each stage. In default mode `--with-hooks` is
@@ -705,7 +706,7 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
   let agentContextWritten: { path: string; written: boolean }[] | undefined;
   if (agentContextStageActive) {
     agentContextWritten = [];
-    const ag: WriteResult = writeAgentsMd(abs);
+    const ag: WriteResult = writeAgentsMd(abs, resolvedPm);
     agentContextWritten.push({ path: ag.path, written: ag.written });
     if (agentsList.includes("claude")) {
       const w = writeWrapper(abs, "claude");

--- a/templates/agent-context/agents-md-snippet.md
+++ b/templates/agent-context/agents-md-snippet.md
@@ -1,5 +1,4 @@
-<!-- artgraph:begin -->
-<!-- artgraph: generated for packageManager=pnpm. If you switch package managers, re-run `pnpm exec artgraph init --force` to regenerate this block. -->
+{{PM_NOTICE}}
 ## artgraph — Cross-agent traceability
 
 artgraph manages the trace lock and provides 8 Skills for spec ↔ code ↔ test traceability.
@@ -12,7 +11,7 @@ artgraph manages the trace lock and provides 8 Skills for spec ↔ code ↔ test
 - `artgraph-impact` — file/symbol → REQs impact
 - `artgraph-plan-coverage` — reverse audit of tasks.md / plan.md
 - `artgraph-coverage` — per-REQ coverage status
-- `artgraph-verify` — `pnpm exec artgraph check --diff` self-check
+- `artgraph-verify` — `{{ARTGRAPH_EXEC}} check --diff` self-check
 - `artgraph-rename` — safe rename / split / merge of REQ IDs
 
 See `<agent_skills_path>/<skill-name>/SKILL.md` for each Skill's full description (where `<agent_skills_path>` is `.claude/skills/`, `.agents/skills/`, `.cursor/skills/`, `.github/skills/`, or `.kiro/skills/` depending on your agent).
@@ -20,15 +19,14 @@ See `<agent_skills_path>/<skill-name>/SKILL.md` for each Skill's full descriptio
 ### Common workflows
 
 - After editing `tasks.md` / `plan.md`: run **artgraph-plan-coverage** to catch implicit REQ impacts.
-- Before review: run **artgraph-verify** (`pnpm exec artgraph check --diff`).
+- Before review: run **artgraph-verify** (`{{ARTGRAPH_EXEC}} check --diff`).
 - When proposing a code change: invoke **artgraph-impact** with `path:symbol`.
 
 ### Quickstart
 
 ```bash
-pnpm exec artgraph init --agents=<list>   # provision Skills + agent-context
-pnpm exec artgraph doctor                 # diagnose distribution health
+{{ARTGRAPH_EXEC}} init --agents=<list>   # provision Skills + agent-context
+{{ARTGRAPH_EXEC}} doctor                 # diagnose distribution health
 ```
 
-For full CLI reference, run `pnpm exec artgraph --help` or see https://github.com/ShintaroMorimoto/artgraph.
-<!-- artgraph:end -->
+For full CLI reference, run `{{ARTGRAPH_EXEC}} --help` or see https://github.com/ShintaroMorimoto/artgraph.

--- a/tests/agent-context.test.ts
+++ b/tests/agent-context.test.ts
@@ -12,14 +12,7 @@
 
 import { describe, it, expect } from "vitest";
 import { createHash } from "node:crypto";
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  statSync,
-  writeFileSync,
-} from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
 import {
@@ -57,9 +50,7 @@ describe("applyMarkerBlock (T018)", () => {
     const existing = "# User content\n\nSome user prose.\n";
     const res = applyMarkerBlock(existing, "body");
     expect(res.found).toBe(false);
-    expect(res.newContent).toBe(
-      `${existing}\n\n${MARKER_BEGIN}\nbody\n${MARKER_END}\n`,
-    );
+    expect(res.newContent).toBe(`${existing}\n\n${MARKER_BEGIN}\nbody\n${MARKER_END}\n`);
     // User content survives byte-identical at the head.
     expect(res.newContent.startsWith(existing)).toBe(true);
   });
@@ -98,8 +89,7 @@ describe("applyMarkerBlock (T018)", () => {
 
   it("collapses duplicate blocks to a single canonical block (A2)", () => {
     const dup =
-      `${MARKER_BEGIN}\nfirst\n${MARKER_END}\n\n` +
-      `${MARKER_BEGIN}\nsecond\n${MARKER_END}\n`;
+      `${MARKER_BEGIN}\nfirst\n${MARKER_END}\n\n` + `${MARKER_BEGIN}\nsecond\n${MARKER_END}\n`;
     const res = applyMarkerBlock(dup, "replaced");
     expect(res.found).toBe(true);
     // The first block is rewritten canonically; every subsequent duplicate
@@ -169,8 +159,7 @@ describe("applyMarkerBlock (T018)", () => {
     // IDE autocorrect (Grammarly, macOS "smart capitalization") title-cases
     // the marker string. The `i` flag on MARKER_RE / BEGIN_RE / END_RE keeps
     // the block detectable, and the writer normalizes it back to lowercase.
-    const shouted =
-      "<!-- artgraph:Begin -->\nold body\n<!-- artgraph:END -->\n";
+    const shouted = "<!-- artgraph:Begin -->\nold body\n<!-- artgraph:END -->\n";
     const res = applyMarkerBlock(shouted, "canonical body");
     expect(res.found).toBe(true);
     expect(res.newContent).toContain(`${MARKER_BEGIN}\ncanonical body\n${MARKER_END}`);
@@ -258,7 +247,7 @@ describe("inspectMarkerBlock (T018)", () => {
 
 describe("buildAgentsMdBody (T019)", () => {
   it("contains all 8 Skill names from contracts/agent-context-format.md", () => {
-    const body = buildAgentsMdBody();
+    const body = buildAgentsMdBody("npm");
     for (const skill of [
       "artgraph-setup",
       "artgraph-detect",
@@ -274,7 +263,7 @@ describe("buildAgentsMdBody (T019)", () => {
   });
 
   it("contains common-workflows guidance and the quickstart code block", () => {
-    const body = buildAgentsMdBody();
+    const body = buildAgentsMdBody("npm");
     expect(body).toContain("Common workflows");
     expect(body).toContain("Quickstart");
     expect(body).toContain("```bash");
@@ -283,14 +272,69 @@ describe("buildAgentsMdBody (T019)", () => {
   });
 
   it("contains the canonical repository link for human readers", () => {
-    const body = buildAgentsMdBody();
+    const body = buildAgentsMdBody("npm");
     expect(body).toContain("https://github.com/ShintaroMorimoto/artgraph");
   });
 
   it("does not embed the marker literals (those are added by applyMarkerBlock)", () => {
-    const body = buildAgentsMdBody();
+    const body = buildAgentsMdBody("npm");
     expect(body).not.toContain(MARKER_BEGIN);
     expect(body).not.toContain(MARKER_END);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAgentsMdBody — PM-independent command examples (#110)
+// ---------------------------------------------------------------------------
+
+describe("buildAgentsMdBody — PM exec-prefix substitution (#110)", () => {
+  // Keep in sync with execPrefix() in src/package-manager.ts (contracts/
+  // package-manager.md §2). The body must quote each PM's real invocation, not
+  // the bare `artgraph` binary that only exists under a global install.
+  const EXPECTED_PREFIX = {
+    npm: "npx artgraph",
+    pnpm: "pnpm exec artgraph",
+    bun: "bunx artgraph",
+    deno: "deno run -A npm:artgraph/cli",
+  } as const;
+
+  for (const [pm, prefix] of Object.entries(EXPECTED_PREFIX)) {
+    it(`renders every command example with the ${pm} exec prefix`, () => {
+      const body = buildAgentsMdBody(pm as keyof typeof EXPECTED_PREFIX);
+      expect(body).toContain(`${prefix} init --agents=`);
+      expect(body).toContain(`${prefix} doctor`);
+      expect(body).toContain(`${prefix} check --diff`);
+      expect(body).toContain(`${prefix} --help`);
+    });
+
+    it(`renders the ${pm} PM notice with the regenerate hint`, () => {
+      const body = buildAgentsMdBody(pm as keyof typeof EXPECTED_PREFIX);
+      expect(body).toContain(`packageManager=${pm}`);
+      expect(body).toContain(`${prefix} init --force`);
+    });
+  }
+
+  it("falls back to the bare `artgraph` binary when no PM was detected", () => {
+    const body = buildAgentsMdBody(null);
+    expect(body).toContain("artgraph init --agents=");
+    expect(body).toContain("no package manager was detected");
+    expect(body).not.toContain("npx");
+    expect(body).not.toContain("pnpm exec");
+  });
+
+  it("leaves no unrendered {{…}} placeholders for any PM", () => {
+    for (const pm of ["npm", "pnpm", "bun", "deno", null] as const) {
+      const body = buildAgentsMdBody(pm);
+      expect(body, `unrendered placeholder for pm=${String(pm)}`).not.toMatch(/\{\{\s*\w+\s*\}\}/);
+    }
+  });
+
+  it("opens with the PM notice as an HTML comment (invisible in rendered Markdown)", () => {
+    const body = buildAgentsMdBody("pnpm");
+    expect(body.startsWith("<!-- artgraph:")).toBe(true);
+    expect(body.split("\n")[0]).toMatch(
+      /^<!-- artgraph: generated for packageManager=pnpm\. .* -->$/,
+    );
   });
 });
 
@@ -302,7 +346,7 @@ describe("writeAgentsMd (T019)", () => {
   it("creates AGENTS.md on a fresh project and writes the canonical body", () => {
     const project = createFreshProject();
     try {
-      const res = writeAgentsMd(project.dir);
+      const res = writeAgentsMd(project.dir, "npm");
       expect(res.written).toBe(true);
       expect(res.path).toBe(resolve(project.dir, "AGENTS.md"));
       expect(existsSync(res.path)).toBe(true);
@@ -322,16 +366,34 @@ describe("writeAgentsMd (T019)", () => {
   it("is idempotent on the second call (no rewrite, sha256 unchanged)", () => {
     const project = createFreshProject();
     try {
-      const first = writeAgentsMd(project.dir);
+      const first = writeAgentsMd(project.dir, "npm");
       expect(first.written).toBe(true);
       const hash1 = sha256(first.path);
 
-      const second = writeAgentsMd(project.dir);
+      const second = writeAgentsMd(project.dir, "npm");
       expect(second.written).toBe(false);
       expect(second.path).toBe(first.path);
       const hash2 = sha256(second.path);
 
       expect(hash2).toBe(hash1);
+    } finally {
+      project.cleanup();
+    }
+  });
+
+  it("refreshes the block when the detected PM changes between runs (#110)", () => {
+    const project = createFreshProject();
+    try {
+      const first = writeAgentsMd(project.dir, "npm");
+      expect(first.written).toBe(true);
+      expect(readFileSync(first.path, "utf-8")).toContain("npx artgraph doctor");
+
+      const second = writeAgentsMd(project.dir, "pnpm");
+      expect(second.written).toBe(true);
+
+      const onDisk = readFileSync(second.path, "utf-8");
+      expect(onDisk).toContain("pnpm exec artgraph doctor");
+      expect(onDisk).not.toContain("npx artgraph");
     } finally {
       project.cleanup();
     }
@@ -344,7 +406,7 @@ describe("writeAgentsMd (T019)", () => {
       const userContent = "# My project rules\n\nUse pnpm, not yarn.\n";
       writeFileSync(target, userContent, "utf-8");
 
-      const res = writeAgentsMd(project.dir);
+      const res = writeAgentsMd(project.dir, "npm");
       expect(res.written).toBe(true);
 
       const onDisk = readFileSync(target, "utf-8");
@@ -382,7 +444,7 @@ describe("writeWrapper(claude) (T020)", () => {
 
   it("body length is far shorter than AGENTS.md body (SC-003: no content duplication)", () => {
     const wrapper = buildClaudeWrapperBody();
-    const canonical = buildAgentsMdBody();
+    const canonical = buildAgentsMdBody("npm");
     expect(wrapper.length).toBeLessThan(canonical.length / 4);
     // Sanity ceiling — wrapper is a few short lines, not a chapter.
     expect(wrapper.length).toBeLessThan(300);
@@ -438,9 +500,7 @@ describe("writeWrapper(copilot) (T020)", () => {
 
       const res = writeWrapper(project.dir, "copilot");
       expect(res.written).toBe(true);
-      expect(res.path).toBe(
-        resolve(project.dir, ".github/copilot-instructions.md"),
-      );
+      expect(res.path).toBe(resolve(project.dir, ".github/copilot-instructions.md"));
       expect(existsSync(res.path)).toBe(true);
       expect(statSync(join(project.dir, ".github")).isDirectory()).toBe(true);
 
@@ -456,7 +516,7 @@ describe("writeWrapper(copilot) (T020)", () => {
 
   it("body length is far shorter than AGENTS.md body (SC-003)", () => {
     const wrapper = buildCopilotWrapperBody();
-    const canonical = buildAgentsMdBody();
+    const canonical = buildAgentsMdBody("npm");
     expect(wrapper.length).toBeLessThan(canonical.length / 4);
     expect(wrapper.length).toBeLessThan(300);
   });
@@ -510,8 +570,8 @@ describe("writeMarkerFile error surface (A-adj-3)", () => {
       writeFileSync(target, "hi\n", "utf-8");
       chmodSync(target, 0o000);
       try {
-        expect(() => writeAgentsMd(project.dir)).toThrow(/cannot read existing file/);
-        expect(() => writeAgentsMd(project.dir)).toThrow(target);
+        expect(() => writeAgentsMd(project.dir, "npm")).toThrow(/cannot read existing file/);
+        expect(() => writeAgentsMd(project.dir, "npm")).toThrow(target);
       } finally {
         try {
           chmodSync(target, 0o644);
@@ -536,9 +596,7 @@ describe("writeGitAttributes (OPS-2)", () => {
     try {
       const res = writeGitAttributes(project.dir, CLAUDE_DESCRIPTOR);
       expect(res.written).toBe(true);
-      expect(res.path).toBe(
-        resolve(project.dir, CLAUDE_DESCRIPTOR.skillsPath, ".gitattributes"),
-      );
+      expect(res.path).toBe(resolve(project.dir, CLAUDE_DESCRIPTOR.skillsPath, ".gitattributes"));
       expect(existsSync(res.path)).toBe(true);
       const onDisk = readFileSync(res.path, "utf-8");
       expect(onDisk).toBe("** text eol=lf\n");
@@ -597,9 +655,7 @@ describe("writeGitAttributes (OPS-2)", () => {
       try {
         const res = writeGitAttributes(project.dir, descriptor);
         expect(res.written).toBe(true);
-        expect(res.path).toBe(
-          resolve(project.dir, descriptor.skillsPath, ".gitattributes"),
-        );
+        expect(res.path).toBe(resolve(project.dir, descriptor.skillsPath, ".gitattributes"));
         expect(readFileSync(res.path, "utf-8")).toBe("** text eol=lf\n");
       } finally {
         project.cleanup();

--- a/tests/packaging.test.ts
+++ b/tests/packaging.test.ts
@@ -4,7 +4,10 @@ import { readdirSync, statSync, existsSync } from "node:fs";
 import { join, resolve, relative } from "node:path";
 
 const REPO_ROOT = resolve(import.meta.dirname, "..");
-const TEMPLATES_DIR = join(REPO_ROOT, "templates", "skills");
+// Whole templates/ tree: skills/ + hooks/settings.json.template (#109) +
+// agent-context/agents-md-snippet.md (#110). All are read at runtime by
+// `artgraph init`, so a file missing from the tarball is a hard init failure.
+const TEMPLATES_DIR = join(REPO_ROOT, "templates");
 const CLI_ENTRY = join(REPO_ROOT, "dist", "cli.js");
 
 function listAllTemplateFiles(): string[] {
@@ -30,19 +33,20 @@ function getPackedFiles(): string[] {
 }
 
 describe("npm packaging", () => {
-  it.skipIf(!existsSync(TEMPLATES_DIR))(
-    "ships every templates/skills/** file in the tarball",
-    () => {
-      const expected = listAllTemplateFiles();
-      expect(expected.length).toBeGreaterThan(0);
+  it.skipIf(!existsSync(TEMPLATES_DIR))("ships every templates/** file in the tarball", () => {
+    const expected = listAllTemplateFiles();
+    expect(expected.length).toBeGreaterThan(0);
+    // Runtime-critical templates that must never silently drop out of the
+    // walk (e.g. via a stray .npmignore or a directory rename).
+    expect(expected).toContain("templates/agent-context/agents-md-snippet.md");
+    expect(expected).toContain("templates/hooks/settings.json.template");
 
-      const packed = getPackedFiles();
+    const packed = getPackedFiles();
 
-      for (const file of expected) {
-        expect(packed, `expected ${file} in tarball`).toContain(file);
-      }
-    },
-  );
+    for (const file of expected) {
+      expect(packed, `expected ${file} in tarball`).toContain(file);
+    }
+  });
 
   it.skipIf(!existsSync(CLI_ENTRY))("ships dist/cli.js (entry point)", () => {
     const packed = getPackedFiles();


### PR DESCRIPTION
## Summary

Closes #110

`artgraph init` の agent-context stage が生成する AGENTS.md snippet を PM 非依存化しました。

**Issue 起票時からの前提変化**: #110 が指摘していた `installAgentContext` 空スタブは、spec 013 (#114) の landing で解消済み(AGENTS.md canonical + CLAUDE.md / copilot thin wrapper 構成、マーカー注入・冪等性・非マーカー部分の保持まで実装済み)。本 PR は #110 の残作業である **PM 非依存化** のみを実装します:

- `templates/agent-context/agents-md-snippet.md` を新設し、`buildAgentsMdBody()` を TS ハードコードから #109 の `renderTemplate` によるレンダリングへ切り替え
- コマンド例 (`init` / `doctor` / `check --diff` / `--help`) を init 時に検出した PM の `execPrefix()` (`{{ARTGRAPH_EXEC}}`) で置換
- block 先頭に PM-drift 気付き用の passive notice (`{{PM_NOTICE}}`) を追加(#110 の Default-Drift 導線)
- PM 未検出時は hooks (`skipped-no-pm`) と異なり bare `artgraph` にフォールバック(prose ガイドは global install 前提でも有用なため stage skip しない)
- PM 解決優先度 (live detection → `.artgraph.json#packageManager` → null) は hooks stage と共有 (`resolvedPm`)
- `contracts/agent-context-format.md` にレンダリング仕様を追記
- `docs/skills-guide.md` の stale な「agent context snippet 注入 (P1)」表記を除去(#139 の docs トリオ整合の一部を先行解消)
- packaging テストを `templates/skills` のみ → `templates/` 全域の tarball 同梱検証に拡大(hooks / agent-context テンプレの publish 漏れを CI で防止)
- dogfood: 本リポジトリの AGENTS.md を pnpm prefix で再生成

## Change type

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm -r test`)
- [x] Added tests where needed
- [x] Ran `pnpm -r knip` and `pnpm -r build`

追加テスト (`tests/agent-context.test.ts`):
- PM 4 種 (npm / pnpm / bun / deno) ごとの exec prefix 置換 + regenerate hint 付き notice の検証
- PM null フォールバック(bare `artgraph`、未検出文言)
- 未レンダリング `{{…}}` プレースホルダの残存なし
- PM 切替時に block が refresh されること(`written: true` + 新 prefix)
- 既存の冪等性テストは PM 固定で維持

手動確認: 本リポジトリ (pnpm) で `writeAgentsMd` を実行し、AGENTS.md の diff・2 回目実行の `written: false`(冪等)・CLAUDE.md wrapper 無変更を確認。`artgraph check --diff` は `drifted: []`。

注: `tests/agents/distribute.test.ts` の 4 件は本変更前から失敗する既存の環境依存 failure(root 実行では chmod による EACCES シミュレーションが無効)で、本 PR とは無関係です。

## Breaking change

- [ ] Yes (described below)
- [x] No

`buildAgentsMdBody` / `writeAgentsMd` のシグネチャは変わりますが、いずれも未公開の内部 API です。既存プロジェクトでは次回 `init` 実行時に AGENTS.md block が PM 付きコマンド例へ refresh されます(マーカー外は不変)。

## Notes

- `src/cli.ts` に残る hooks 系の stale 表記(「Stop hook lands in PR-B」「--with-hooks は no effect」— 実際は #129 で出荷済み)は agent-context と無関係のため本 PR ではスコープ外。#139 の docs トリオ回帰テストで対処するのが適切です。
- follow-up: #139 (README / docs / CLI description の三重整合を CI で担保)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jL6jYezMQLx9dWY5gVC5V

---
_Generated by [Claude Code](https://claude.ai/code/session_012jL6jYezMQLx9dWY5gVC5V)_