### PR TITLE
test(docs): docs トリオ整合回帰テスト新設 + cli.ts の stale 表記修正 (closes #139)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -111,7 +111,7 @@ function registerCommands(program: Command): void {
   program
     .command("init")
     .description(
-      "Initialize artgraph for this project (default: config + scan + Skills + auto-integrate detected SDD tools + AGENTS.md / wrapper injection; Stop hook lands in PR-B). Use --minimal for bare config only.",
+      "Initialize artgraph for this project (default: config + scan + Skills + auto-integrate detected SDD tools + Stop hook + AGENTS.md / wrapper injection). Use --minimal for bare config only.",
     )
     .option(
       "--force",
@@ -125,7 +125,7 @@ function registerCommands(program: Command): void {
       "Skip Skills distribution to the selected --agents (default mode only — already off under --minimal)",
     )
     .option("--no-integrate", "Skip SDD-tool auto-integration (default mode only)")
-    .option("--no-hooks", "Skip Stop hook installation (default mode only; P1 deliverable)")
+    .option("--no-hooks", "Skip Stop hook installation (default mode only)")
     .option("--no-agent-context", "Skip AGENTS.md / wrapper injection (default mode only)")
     // Stage opt-ins (used with --minimal)
     .option(
@@ -133,7 +133,7 @@ function registerCommands(program: Command): void {
       "Distribute Skills to the selected --agents canonical paths (use with --minimal)",
     )
     .option("--with-integrate", "Auto-integrate detected SDD tools (use with --minimal)")
-    .option("--with-hooks", "Install Stop hook (use with --minimal; P1 deliverable, no effect yet)")
+    .option("--with-hooks", "Install Stop hook into .claude/settings.json (use with --minimal)")
     .option(
       "--with-agent-context",
       "Inject AGENTS.md + wrapper(s) for the selected --agents (use with --minimal)",
@@ -200,10 +200,10 @@ function registerCommands(program: Command): void {
       // `agentsRequired` is false under `--minimal`, so the missing-`--agents`
       // gate below never fired, and the distribution stage skipped itself
       // with zero agents and zero warning. That's the same "no-op combination"
-      // family the mutex-conflict detector above already guards against, and
-      // it's asymmetric with `--with-hooks`, which at least WARNs about being
-      // a no-op. Treat it as a hard error, consistent with the
-      // AGENTS_REQUIRED_ERROR path used everywhere else --agents is missing.
+      // family the mutex-conflict detector above already guards against.
+      // Treat it as a hard error, consistent with the AGENTS_REQUIRED_ERROR
+      // path used everywhere else --agents is missing. (`--with-hooks` is
+      // exempt: the hooks stage needs no --agents to land real output.)
       if (
         opts.minimal === true &&
         (opts.withSkills === true || opts.withAgentContext === true) &&
@@ -213,16 +213,6 @@ function registerCommands(program: Command): void {
           "ERROR: --with-skills / --with-agent-context under --minimal requires --agents=<list>; otherwise this is a no-op.",
         );
         process.exit(1);
-      }
-
-      // C1: --with-hooks is accepted (so the flag surface is stable for PR-B)
-      // but currently no-op. Warn so the user doesn't think they got hooks
-      // without checking output. --with-agent-context now lands real output
-      // (AGENTS.md + wrappers, spec 013 T021); the warning was removed.
-      if (opts.withHooks === true) {
-        console.error(
-          "WARNING: --with-hooks is a P1 deliverable; the flag has no effect in this release.",
-        );
       }
 
       // M12: surface valid provider ids when the user fat-fingers an

--- a/tests/docs-trio-consistency.test.ts
+++ b/tests/docs-trio-consistency.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Docs-trio consistency metatest (#139).
+//
+// README.md, docs/skills-guide.md, and src/cli.ts all describe the default
+// stages of `artgraph init`, and nothing keeps them in sync automatically:
+// PR #103 advertised agent-context in the README before it shipped (H1),
+// and PR #129 shipped the Stop hook but left "lands in PR-B" in the CLI
+// help. This test pins the three sources to a single stage list and rejects
+// stale future-tense markers, so the next shipped-but-undocumented (or
+// documented-but-unshipped) stage fails CI instead of reaching users.
+//
+// The stage list below is the test's single source of truth. Adding a new
+// init stage means updating it here — and the assertions then force the
+// README paragraph, the skills-guide section, and the cli.ts flag surface
+// to be updated in the same PR.
+
+const ROOT = resolve(import.meta.dirname, "..");
+
+const readme = readFileSync(resolve(ROOT, "README.md"), "utf8");
+const skillsGuide = readFileSync(resolve(ROOT, "docs", "skills-guide.md"), "utf8");
+const cliSource = readFileSync(resolve(ROOT, "src", "cli.ts"), "utf8");
+
+type Stage = {
+  id: string;
+  /** How the stage is spelled when the docs enumerate the default setup. */
+  mention: RegExp;
+  /** Default-mode opt-out flag; null for stages without one (config). */
+  optOut: string | null;
+  /** --minimal opt-in flag; null for stages without one (config, scan). */
+  optIn: string | null;
+  /**
+   * Whether README / skills-guide list the opt-out flag. `--no-scan` exists
+   * on the CLI but is deliberately not part of the documented opt-out list.
+   */
+  optOutDocumented: boolean;
+};
+
+const DEFAULT_STAGES: Stage[] = [
+  { id: "config", mention: /config/i, optOut: null, optIn: null, optOutDocumented: false },
+  { id: "scan", mention: /scan/i, optOut: "--no-scan", optIn: null, optOutDocumented: false },
+  {
+    id: "skills",
+    mention: /Skills/,
+    optOut: "--no-skills",
+    optIn: "--with-skills",
+    optOutDocumented: true,
+  },
+  {
+    id: "integrate",
+    mention: /integrate/i,
+    optOut: "--no-integrate",
+    optIn: "--with-integrate",
+    optOutDocumented: true,
+  },
+  {
+    id: "hooks",
+    mention: /Stop hook/,
+    optOut: "--no-hooks",
+    optIn: "--with-hooks",
+    optOutDocumented: true,
+  },
+  {
+    id: "agent-context",
+    mention: /AGENTS\.md/,
+    optOut: "--no-agent-context",
+    optIn: "--with-agent-context",
+    optOutDocumented: true,
+  },
+];
+
+// Markers that only ever appear when a doc describes a stage as future work.
+// Every historical drift incident used one of these spellings; if a new one
+// slips through, add it here.
+const STALE_MARKERS = [
+  /PR-B/,
+  /P1 deliverable/i,
+  /no effect yet/i,
+  /coming in PR/i,
+  /lands in PR/i,
+  /\(P1\)/,
+];
+
+/** The one README paragraph that enumerates the full default setup. */
+function readmeDefaultSetupParagraph(): string {
+  const match = readme.match(/^`artgraph init` runs the full setup:.*$/m);
+  if (!match) {
+    throw new Error(
+      "README.md: could not find the default-setup paragraph " +
+        '(a line starting with "`artgraph init` runs the full setup:"). ' +
+        "If the Quickstart wording changed, update docs-trio-consistency.test.ts to match.",
+    );
+  }
+  return match[0];
+}
+
+/** The skills-guide section describing `init` default behavior. */
+function skillsGuideInitSection(): string {
+  // Heading is "## `init` のデフォルト挙動" — anchor on the ASCII prefix so
+  // this file stays ASCII-only.
+  const match = skillsGuide.match(/^## `init` [^\n]*\n([\s\S]*?)(?=^## )/m);
+  if (!match) {
+    throw new Error(
+      "docs/skills-guide.md: could not find the `init` default-behavior section " +
+        '(a "## `init` ..." heading). ' +
+        "If the section was renamed, update docs-trio-consistency.test.ts to match.",
+    );
+  }
+  return match[1];
+}
+
+/** Source text of one commander command block in src/cli.ts. */
+function cliCommandBlock(name: string): string {
+  const start = cliSource.indexOf(`.command("${name}")`);
+  if (start === -1) {
+    throw new Error(`src/cli.ts: .command("${name}") not found`);
+  }
+  const next = cliSource.indexOf('.command("', start + 1);
+  return cliSource.slice(start, next === -1 ? undefined : next);
+}
+
+/** The .description("...") string of the init command. */
+function cliInitDescription(): string {
+  const match = cliCommandBlock("init").match(/\.description\(\s*"((?:[^"\\]|\\.)*)"/);
+  if (!match) {
+    throw new Error('src/cli.ts: init .description("...") not found or not a plain string');
+  }
+  return match[1];
+}
+
+/** All --flag names declared via .option() inside the init command block. */
+function cliInitOptionFlags(): string[] {
+  const block = cliCommandBlock("init");
+  const flags: string[] = [];
+  for (const m of block.matchAll(/\.option\(\s*"(--[a-z-]+)/g)) {
+    flags.push(m[1]);
+  }
+  return flags;
+}
+
+describe("docs-trio consistency: README / docs/skills-guide.md / src/cli.ts (#139)", () => {
+  describe("every default stage is described by all three sources", () => {
+    for (const stage of DEFAULT_STAGES) {
+      it(`stage "${stage.id}" appears in the cli.ts init description`, () => {
+        expect(cliInitDescription()).toMatch(stage.mention);
+      });
+
+      it(`stage "${stage.id}" appears in the README default-setup paragraph`, () => {
+        expect(readmeDefaultSetupParagraph()).toMatch(stage.mention);
+      });
+
+      it(`stage "${stage.id}" appears in the skills-guide init section`, () => {
+        expect(skillsGuideInitSection()).toMatch(stage.mention);
+      });
+    }
+  });
+
+  describe("stage flag surface matches the stage list", () => {
+    it("cli.ts declares exactly the expected --no-* opt-outs on init", () => {
+      const expected = DEFAULT_STAGES.map((s) => s.optOut)
+        .filter((f): f is string => f !== null)
+        // Not a stage opt-out, but declared on init alongside them.
+        .concat(["--no-integrate-gate"])
+        .sort();
+      const actual = cliInitOptionFlags()
+        .filter((f) => f.startsWith("--no-"))
+        .sort();
+      expect(actual).toEqual(expected);
+    });
+
+    it("cli.ts declares exactly the expected --with-* opt-ins on init", () => {
+      const expected = DEFAULT_STAGES.map((s) => s.optIn)
+        .filter((f): f is string => f !== null)
+        .sort();
+      const actual = cliInitOptionFlags()
+        .filter((f) => f.startsWith("--with-"))
+        .sort();
+      expect(actual).toEqual(expected);
+    });
+
+    for (const stage of DEFAULT_STAGES.filter((s) => s.optOutDocumented)) {
+      it(`opt-out ${stage.optOut} is documented in README and skills-guide`, () => {
+        expect(readmeDefaultSetupParagraph()).toContain(stage.optOut);
+        expect(skillsGuideInitSection()).toContain(stage.optOut);
+      });
+    }
+
+    it("all three sources mention --minimal as the bare-config escape hatch", () => {
+      expect(cliInitDescription()).toContain("--minimal");
+      expect(readmeDefaultSetupParagraph()).toContain("--minimal");
+      expect(skillsGuideInitSection()).toContain("--minimal");
+    });
+  });
+
+  describe("no stale future-work markers in any of the three sources", () => {
+    const sources: Array<[string, () => string]> = [
+      ["README.md", () => readme],
+      ["docs/skills-guide.md", () => skillsGuide],
+      ["src/cli.ts", () => cliSource],
+    ];
+    for (const [label, read] of sources) {
+      for (const marker of STALE_MARKERS) {
+        it(`${label} does not contain ${marker}`, () => {
+          const text = read();
+          const hit = text.match(marker);
+          if (hit) {
+            const line = text.slice(0, hit.index).split("\n").length;
+            expect.fail(
+              `${label}:${line} contains stale marker ${marker}: "${hit[0]}". ` +
+                "A shipped feature is still described as future work (or vice " +
+                "versa) — update the doc, or ship the feature before advertising it.",
+            );
+          }
+        });
+      }
+    }
+  });
+});

--- a/tests/docs-trio-consistency.test.ts
+++ b/tests/docs-trio-consistency.test.ts
@@ -13,7 +13,7 @@ import { resolve } from "node:path";
 // documented-but-unshipped) stage fails CI instead of reaching users.
 //
 // The stage list below is the test's single source of truth. Adding a new
-// init stage means updating it here — and the assertions then force the
+// init stage means updating it here, and the assertions then force the
 // README paragraph, the skills-guide section, and the cli.ts flag surface
 // to be updated in the same PR.
 
@@ -83,32 +83,81 @@ const STALE_MARKERS = [
   /\(P1\)/,
 ];
 
-/** The one README paragraph that enumerates the full default setup. */
+/**
+ * The one README paragraph that enumerates the full default setup. Matches
+ * up to the next blank line (not a single physical line) so a hard-wrap of
+ * the paragraph doesn't silently truncate the extracted text and turn the
+ * downstream assertions into misleading "docs regressed" failures.
+ */
 function readmeDefaultSetupParagraph(): string {
-  const match = readme.match(/^`artgraph init` runs the full setup:.*$/m);
+  const match = readme.match(
+    /^`artgraph init` runs the full setup:[\s\S]*?(?=\n\s*\n|(?![\s\S]))/m,
+  );
   if (!match) {
     throw new Error(
       "README.md: could not find the default-setup paragraph " +
-        '(a line starting with "`artgraph init` runs the full setup:"). ' +
+        '(a paragraph starting with "`artgraph init` runs the full setup:"). ' +
         "If the Quickstart wording changed, update docs-trio-consistency.test.ts to match.",
     );
   }
   return match[0];
 }
 
-/** The skills-guide section describing `init` default behavior. */
+/**
+ * Slice the stage enumeration out of an enumeration-bearing text: everything
+ * up to the first sentence break. Stage-mention assertions must run against
+ * this slice, not the full paragraph, because incidental later mentions in
+ * the same paragraph (e.g. "--no-hooks" or "share the Stop hook with
+ * teammates") would otherwise keep /Stop hook/ green after the stage was
+ * dropped from the enumeration itself.
+ */
+function enumerationSentence(text: string, label: string): string {
+  const end = text.indexOf(". ");
+  if (end === -1) {
+    throw new Error(
+      `${label}: expected a sentence break after the stage enumeration; ` +
+        "if the wording changed, update docs-trio-consistency.test.ts to match.",
+    );
+  }
+  return text.slice(0, end);
+}
+
+/**
+ * The skills-guide section describing `init` default behavior. The heading
+ * text after "## `init` " is Japanese; anchoring on the ASCII prefix keeps
+ * the regex free of non-ASCII characters and survives heading-wording edits.
+ * The terminator accepts either the next "## " heading or end-of-file, so
+ * the extraction keeps working if the section is moved to the end.
+ */
 function skillsGuideInitSection(): string {
-  // Heading is "## `init` のデフォルト挙動" — anchor on the ASCII prefix so
-  // this file stays ASCII-only.
-  const match = skillsGuide.match(/^## `init` [^\n]*\n([\s\S]*?)(?=^## )/m);
+  const match = skillsGuide.match(/^## `init` [^\n]*\n([\s\S]*?)(?=^## |(?![\s\S]))/m);
   if (!match) {
     throw new Error(
       "docs/skills-guide.md: could not find the `init` default-behavior section " +
         '(a "## `init` ..." heading). ' +
-        "If the section was renamed, update docs-trio-consistency.test.ts to match.",
+        "If the section was renamed or restructured, update docs-trio-consistency.test.ts to match.",
     );
   }
   return match[1];
+}
+
+/**
+ * Only the "- " stage bullet lines of the skills-guide init section. The
+ * section also documents the opt-out flags in a table, so matching stage
+ * mentions against the whole section would let flag names (--no-integrate,
+ * "bare config") mask a stage dropped from the bullet list.
+ */
+function skillsGuideStageBullets(): string {
+  const bullets = skillsGuideInitSection()
+    .split("\n")
+    .filter((line) => line.startsWith("- "));
+  if (bullets.length === 0) {
+    throw new Error(
+      "docs/skills-guide.md: the `init` section no longer contains a '- ' stage " +
+        "bullet list; update docs-trio-consistency.test.ts to match.",
+    );
+  }
+  return bullets.join("\n");
 }
 
 /** Source text of one commander command block in src/cli.ts. */
@@ -144,15 +193,19 @@ describe("docs-trio consistency: README / docs/skills-guide.md / src/cli.ts (#13
   describe("every default stage is described by all three sources", () => {
     for (const stage of DEFAULT_STAGES) {
       it(`stage "${stage.id}" appears in the cli.ts init description`, () => {
-        expect(cliInitDescription()).toMatch(stage.mention);
+        expect(enumerationSentence(cliInitDescription(), "src/cli.ts init description")).toMatch(
+          stage.mention,
+        );
       });
 
-      it(`stage "${stage.id}" appears in the README default-setup paragraph`, () => {
-        expect(readmeDefaultSetupParagraph()).toMatch(stage.mention);
+      it(`stage "${stage.id}" appears in the README default-setup enumeration`, () => {
+        expect(
+          enumerationSentence(readmeDefaultSetupParagraph(), "README default-setup paragraph"),
+        ).toMatch(stage.mention);
       });
 
-      it(`stage "${stage.id}" appears in the skills-guide init section`, () => {
-        expect(skillsGuideInitSection()).toMatch(stage.mention);
+      it(`stage "${stage.id}" appears in the skills-guide stage bullet list`, () => {
+        expect(skillsGuideStageBullets()).toMatch(stage.mention);
       });
     }
   });
@@ -210,7 +263,7 @@ describe("docs-trio consistency: README / docs/skills-guide.md / src/cli.ts (#13
             expect.fail(
               `${label}:${line} contains stale marker ${marker}: "${hit[0]}". ` +
                 "A shipped feature is still described as future work (or vice " +
-                "versa) — update the doc, or ship the feature before advertising it.",
+                "versa); update the doc, or ship the feature before advertising it.",
             );
           }
         });


### PR DESCRIPTION
## Summary

Closes #139

README / docs/skills-guide.md / src/cli.ts の 3 面 (docs トリオ) はどれも `artgraph init` の default 挙動を説明するが、同期を保証する仕組みがなかった (PR #129 の H1 finding)。本 PR で:

**1. `src/cli.ts` の stale 表記 4 箇所を修正** (issue コメントで記録されたもの)

- init description の「Stop hook lands in PR-B」→ Stop hook を default stage として明記 (#109 で出荷済み)
- `--no-hooks` / `--with-hooks` の「P1 deliverable (, no effect yet)」→ 実挙動に合わせて更新
- 「--with-hooks has no effect」の runtime WARNING を削除 — `--minimal --with-hooks` は実際に `installHooks()` を実行するため (src/init.ts の stage gate 参照)、hooks がインストールされたのに「効果なし」と誤認させる実害があった

**2. `tests/docs-trio-consistency.test.ts` を新設** (issue の案 A)

テスト内の stage 一覧 (config / scan / skills / integrate / hooks / agent-context) を単一の情報源に:

- README の default-setup 段落 / skills-guide の `init` セクション / cli.ts の init description が全 default stage に言及していることを assert
- init の `--no-*` / `--with-*` フラグ面が stage 一覧と set 一致することを assert — 新 stage 追加時に docs トリオ 3 面の同時更新を強制
- 「PR-B」「P1 deliverable」「no effect yet」「(P1)」等の stale future-work マーカーが 3 面に混入したらファイル名・行番号付きで fail

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [x] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm -r test`)
- [x] Added tests where needed
- [x] Ran `pnpm -r knip` and `pnpm -r build`

- 新テスト 43 件パス。mutation 検証として「lands in PR-B」を一時的に戻し、行番号付きで fail することを確認済み
- typecheck / oxlint / oxfmt / knip / e2e (36) / 関連 unit (cli, hooks-merge, init 計 233) すべてパス
- `tests/agents/distribute.test.ts` の 4 件はローカル (root 実行) 環境でのみ失敗する既存の環境起因 (chmod による EACCES 再現が root では機能しない)。クリーンな HEAD でも同様に失敗することを確認済みで、本 PR とは無関係

## Breaking change

- [ ] Yes (described below)
- [x] No

## Notes

- Acceptance criteria 対応: docs トリオ突き合わせテスト ✅ / P1 未着 stage の default 混入検出 (stale マーカー + フラグ面 set 一致) ✅ / CI 回帰保護 (既存 vitest CI に乗るため追加設定不要) ✅
- `--no-scan` は CLI に存在するが README / skills-guide の opt-out 一覧には意図的に載っていないため、テストでは `optOutDocumented: false` として cli.ts 側のみ assert

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcaJEeVxjySQ8GizFdR97p

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcaJEeVxjySQ8GizFdR97p)_