### PR TITLE
docs(windows): native Windows を v0.x で明示的に非対応と宣言 (closes #137)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         node: ['22']
-        # Windows was included briefly (PR #114 OPS-3) but 80+ pre-existing
-        # tests fail on Windows (path-sep / EPERM / package-manager detection).
-        # Tracked in follow-up issue #137; restore `windows-latest` here once
-        # those are fixed.
+        # Native Windows is explicitly OUT OF SCOPE for v0.x (#137 decision;
+        # see README "Windows note"): the CLI / hooks / tests assume POSIX,
+        # and WSL2 is the supported path on Windows. windows-latest was
+        # trialled in PR #114 (OPS-3) — 80+ tests fail on path-sep / EPERM /
+        # package-manager detection. Re-add only if native support becomes a
+        # goal.
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Continue with **Quickstart** below.
 > `bun add -d github:ShintaroMorimoto/artgraph`). The plain `artgraph` registry name in the commands
 > below will start resolving once the first release is published.
 
+> **Platforms**: macOS and Linux — including **WSL2** on Windows. Native Windows
+> (PowerShell / cmd) is **not supported**; see the [Windows note](#windows-note).
+
 ```bash
 # Pick your package manager (npm / pnpm / Bun / Deno all supported; Yarn falls back to pnpm)
 npm install -D artgraph && npx artgraph init --agents=claude       # pick your agent(s)
@@ -124,7 +127,9 @@ If you use Claude Code, you can skip the manual install entirely — type `/artg
 
 ### Windows note
 
-On Windows, artgraph distributes a `.gitattributes` file into each `<agent-skills-path>/` that forces LF for the tracked files. Do NOT set `core.autocrlf=true` globally — if `.gitattributes` is not committed, `artgraph doctor` may report drift after checkout. Alternatively add `.claude/skills/** text eol=lf` (and equivalents for other agents) to your repo's `.gitattributes`.
+**Native Windows (PowerShell / cmd) is not a supported platform.** The artgraph CLI, the generated Stop hook, and the distributed Skills all assume a POSIX environment. On Windows, run artgraph inside **WSL2** (recommended) — all supported package managers and Tier 1 agents work there. Git Bash may handle basic commands but is untested and unsupported. This is a deliberate v0.x scope decision ([#137](https://github.com/ShintaroMorimoto/artgraph/issues/137)); native Windows support may be revisited if there is demand.
+
+Even when artgraph itself runs inside WSL2, teammates checking the repo out on native Windows still interact with the distributed files: artgraph distributes a `.gitattributes` file into each `<agent-skills-path>/` that forces LF for the tracked files. Do NOT set `core.autocrlf=true` globally — if `.gitattributes` is not committed, `artgraph doctor` may report drift after checkout. Alternatively add `.claude/skills/** text eol=lf` (and equivalents for other agents) to your repo's `.gitattributes`.
 
 Selecting `--agents=copilot` creates `.github/skills/` in your repo. If your project uses CODEOWNERS / branch protection for `.github/`, coordinate with your team before running `artgraph init --agents=copilot`.
 


### PR DESCRIPTION
## Summary

Closes #137

#137 が提示していた意思決定「Windows 対応を修正する / 明示的に非対応と宣言する」を、**後者(明示的に非対応)で確定**させる docs-only の変更です。

- **README Quickstart** に Platforms note を追加: macOS / Linux(WSL2 含む)がサポート対象、native Windows (PowerShell / cmd) は非対応で Windows note へ誘導
- **README Windows note** を非対応宣言に書き換え:
  - CLI / Stop hook / 配布 Skills が POSIX 前提であることを明記
  - Windows では **WSL2 を推奨経路**として案内
  - Git Bash は「動くかもしれないが未検証・非サポート」と明示
  - v0.x の意図的なスコープ判断であり、需要があれば再検討の余地がある旨を記載
  - 既存の `.gitattributes` / CRLF ガイダンスは「artgraph 自体は WSL2 で動かしていても、native Windows で checkout するチームメイトがいるケース向け」として文脈を明確化して存置
- **ci.yml** の matrix コメントを更新: 「#137 が修正されたら `windows-latest` を戻す」→「方針として除外。native 対応が goal になった場合のみ再追加」

#137 の当初対応方針 1〜4(`atomicWriteFile` の Windows 堅牢化、`detectPackageManager` の path 検出強化、テスト期待値の正規化、Windows CI 復帰)は**実施しません**。

## Change type

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [x] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm -r test`)
- [ ] Added tests where needed (docs のみのため対象なし)
- [x] Ran `pnpm -r knip` and `pnpm -r build`

コード変更なし (README + workflow コメントのみ)。pre-push hook (typecheck / knip / test:unit / test:e2e) 通過済み。

## Breaking change

- [ ] Yes (described below)
- [x] No

## Notes

- `package.json` に `"os": ["!win32"]` は**意図的に追加していません** — npm レベルで install を硬直的にブロックすると Git Bash 等での部分利用まで壊すため、docs での宣言に留めています。
- **#142 (Skills の POSIX shell 前提 / Kiro Desktop on Windows ガイダンス) は本 PR とは独立に存続**します。#142 は Skill *実行* レイヤの詳細ガイダンス(Kiro CLI in WSL2 への誘導等)で、#141 の semantic prose refactor の帰結にも依存するため、本 PR の posture 宣言とは別に扱うのが適切です。本 PR の README 文言は #142 の「Windows-native full support は非目標のまま」という方針整理と整合しています。
- CI badge の対象 (ubuntu / macos) と README の宣言が一致した状態になります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jL6jYezMQLx9dWY5gVC5V

---
_Generated by [Claude Code](https://claude.ai/code/session_012jL6jYezMQLx9dWY5gVC5V)_