### PR TITLE
perf(cli): lazy command imports + incremental parse cache (~9x warm-run speedup)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,10 @@
     "typecheck": "tsc --noEmit",
     "knip": "knip",
     "check-versions": "node scripts/check-extension-version.mjs",
-    "prepare": "test -f dist/cli.js || tsc",
+    "prepare": "lefthook install > /dev/null 2>&1 || true",
     "demo:record": "node scripts/record-tag-zero-demo.mjs",
     "demo:svg": "svg-term --in docs/demo/tag-zero.cast --out docs/demo/tag-zero.svg --window --width 96 --height 45 --padding 12",
     "demo": "pnpm build && pnpm demo:record && pnpm demo:svg",
-    "prepare": "lefthook install > /dev/null 2>&1 || true",
     "prepublishOnly": "rm -rf dist && tsc && pnpm check-versions && pnpm test:unit && pnpm test:e2e"
   },
   "repository": {
@@ -59,6 +58,7 @@
   "license": "MIT",
   "dependencies": {
     "commander": "^13.1.0",
+    "fast-glob": "^3.3.3",
     "glob": "^11.0.2",
     "mdast-util-to-string": "^4.0.0",
     "remark-parse": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       commander:
         specifier: ^13.1.0
         version: 13.1.0
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
       glob:
         specifier: ^11.0.2
         version: 11.1.0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,10 +4,15 @@ import { Command, CommanderError, Option } from "commander";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { loadConfig } from "./config.js";
-import { scan, reconcile } from "./scan.js";
-import { impact, resolveStartIds, resolveOriginReqs } from "./graph/traverse.js";
-import { extractFiles, type SymbolEntry } from "./parsers/sdd-files.js";
+
+// Command implementations are imported lazily (`await import(...)`) inside
+// each action handler instead of statically here. The scan/parse stack pulls
+// in ts-morph (~300 ms module load alone), which every invocation — including
+// `--version` and `--help` — used to pay up front. Only commander, node
+// builtins, and the two data-only modules needed to render help text
+// (agents/descriptors, agents/parse-agents) stay static. Types are erased at
+// compile time, so `import type` is free.
+import type { SymbolEntry } from "./parsers/sdd-files.js";
 
 // spec 016 (R-003) — direct CLI / hook-pretool / --diff inputs come in as raw
 // strings (file paths or `path:symbol` declarations). lift each into the
@@ -34,43 +39,27 @@ function pathsToEntries(paths: string[]): SymbolEntry[] {
     return { path: p, line: 1 };
   });
 }
-import { formatGraphText, formatGraphJSON } from "./graph/format.js";
-import type { NodeKind } from "./types.js";
+import type { NodeKind, ArtgraphConfig, TestResultMap } from "./types.js";
 import type { BuildWarning } from "./graph/builder.js";
-import { check } from "./check.js";
-import { computeCoverage } from "./coverage.js";
-import { readLock } from "./lock.js";
-import { getGitDiffFiles } from "./diff.js";
-import {
-  parseHookInput,
-  extractFilePaths,
-  toRelativePath,
-  formatAdditionalContext,
-  buildHookOutput,
-} from "./hook-pretool.js";
-import type { ArtgraphConfig, TestResultMap } from "./types.js";
-import { runInit } from "./init.js";
-import { DistributionError } from "./agents/distribute.js";
-import { runPlanCoverage } from "./plan-coverage/index.js";
-import { resolveSpecDir } from "./plan-coverage/spec-resolver.js";
-import { loadTestResults } from "./test-results.js";
-import { executeRename, executeSplit, executeMerge } from "./rename-executor.js";
 import type { RenameResult } from "./rename-executor.js";
-import {
-  getProviderStatuses,
-  listProviders,
-  registerBuiltinProviders,
-  runIntegrate,
-} from "./integrate/index.js";
 import type { IntegrateResult, IntegrationProviderId } from "./types.js";
 import { parseAgentsList, AgentsParseError } from "./agents/parse-agents.js";
 import { AGENT_IDS, type AgentId } from "./agents/descriptors.js";
-import { runDoctor, formatDoctorReportJson, formatDoctorReportText } from "./doctor.js";
 
-// Wire up the built-in integration providers (speckit / kiro) before
-// commander parses argv. Today the registration body is empty (T014); US1
-// / US2 fill it in.
-registerBuiltinProviders();
+// Lazily load the integrate surface and wire up the built-in providers
+// (speckit / kiro) exactly once per process. `registerProvider` throws on a
+// duplicate id, and `runCli` builds a fresh commander tree per call within
+// one process, so the once-guard preserves the old "register at module load"
+// semantics without paying the integrate/yaml import on every invocation.
+let builtinProvidersRegistered = false;
+async function loadIntegrate(): Promise<typeof import("./integrate/index.js")> {
+  const mod = await import("./integrate/index.js");
+  if (!builtinProvidersRegistered) {
+    mod.registerBuiltinProviders();
+    builtinProvidersRegistered = true;
+  }
+  return mod;
+}
 
 // Test seam: when set, hook-pretool reads this string instead of process.stdin.
 // Lets `runCli({stdin})` drive hook-pretool entirely in-process without having
@@ -96,13 +85,14 @@ function registerCommands(program: Command): void {
   // `.artgraph.json` `testResultPaths` field, then load them. Returns undefined
   // when neither is set so callers fall back to legacy (verifies-edge-only)
   // coverage. Shared by `scan`, `check`, and `coverage`.
-  function resolveTestResults(
+  async function resolveTestResults(
     opts: { testResults?: string[] },
     config: ArtgraphConfig,
     rootDir: string,
-  ): TestResultMap | undefined {
+  ): Promise<TestResultMap | undefined> {
     const paths = opts.testResults ?? config.testResultPaths;
     if (paths && paths.length > 0) {
+      const { loadTestResults } = await import("./test-results.js");
       return loadTestResults(paths, rootDir);
     }
     return undefined;
@@ -158,8 +148,11 @@ function registerCommands(program: Command): void {
       `Comma-separated Tier 1 agent ids to target (${[...AGENT_IDS].sort().join(", ")}). Required for Skills / agent-context distribution.`,
     )
     .option("--format <format>", "Output format: json | text", "text")
-    .action((opts) => {
+    .action(async (opts) => {
       const rootDir = process.cwd();
+      const { listProviders } = await loadIntegrate();
+      const { runInit } = await import("./init.js");
+      const { DistributionError } = await import("./agents/distribute.js");
 
       // Parse --integrations first so the M24 conflict check below can also
       // flag `--no-integrate` combined with a non-empty `--integrations=<list>`
@@ -510,7 +503,7 @@ function registerCommands(program: Command): void {
           // Skip Tips entirely if the user already requested one-shot integration —
           // the per-tool sections above already cover discovery.
           if (!integrations) {
-            printIntegrationTips(rootDir);
+            await printIntegrationTips(rootDir);
           }
         }
 
@@ -603,7 +596,8 @@ function registerCommands(program: Command): void {
    * detected but not yet installed (FR-012/013). Silent when nothing is
    * pending so a fully-integrated repo doesn't see stale hints.
    */
-  function printIntegrationTips(rootDir: string): void {
+  async function printIntegrationTips(rootDir: string): Promise<void> {
+    const { getProviderStatuses } = await loadIntegrate();
     const statuses = getProviderStatuses(rootDir);
     for (const s of statuses) {
       if (!s.detected || s.installed) continue;
@@ -629,12 +623,14 @@ function registerCommands(program: Command): void {
     .option("--format <format>", "Output format: json | text", "text")
     .option("--test-results <paths...>", "Test result files (Vitest JSON / JUnit XML)")
     .addOption(new Option("--mode <mode>", "Analysis mode").choices(["file", "symbol"]))
-    .action((opts) => {
+    .action(async (opts) => {
       const rootDir = process.cwd();
+      const { loadConfig } = await import("./config.js");
+      const { scan } = await import("./scan.js");
       const config = applyMode(loadConfig(rootDir), opts.mode);
       const result = scan(rootDir, config);
 
-      const testResults = resolveTestResults(opts, config, rootDir);
+      const testResults = await resolveTestResults(opts, config, rootDir);
       let testResultStats:
         | { totalTests: number; passedTests: number; failedTests: number }
         | undefined;
@@ -777,7 +773,7 @@ function registerCommands(program: Command): void {
     .option("--depth <depth>", "Limit BFS traversal depth")
     .option("--format <format>", "Output format: json | text", "text")
     .addOption(new Option("--mode <mode>", "Analysis mode").choices(["file", "symbol"]))
-    .action((targets: string[], opts) => {
+    .action(async (targets: string[], opts) => {
       const rootDir = process.cwd();
 
       // spec 016 T026 / contracts/cli-flags.md §2 — validation order:
@@ -826,6 +822,10 @@ function registerCommands(program: Command): void {
         process.exit(1);
       }
 
+      const { loadConfig } = await import("./config.js");
+      const { scan } = await import("./scan.js");
+      const { readLock } = await import("./lock.js");
+      const { impact, resolveStartIds, resolveOriginReqs } = await import("./graph/traverse.js");
       const config = applyMode(loadConfig(rootDir), opts.mode);
       const { graph } = scan(rootDir, config);
       const lock = readLock(rootDir, config.lockFile);
@@ -848,6 +848,7 @@ function registerCommands(program: Command): void {
           process.exit(1);
         }
         const text = readFileSync(sourcePath, "utf-8");
+        const { extractFiles } = await import("./parsers/sdd-files.js");
         const extracted = extractFiles(text, { graph, repoRoot: rootDir });
         // SPEC-2: surface every `unresolvedFilePath` diagnostic as a warning so
         // typos in a `Files:` section (e.g. `src/auht.ts`) don't silently fall
@@ -870,6 +871,7 @@ function registerCommands(program: Command): void {
         entries = extracted.entries;
         inputDisplayLabels = entries.map((e) => (e.symbol ? `${e.path}:${e.symbol}` : e.path));
       } else if (opts.diff) {
+        const { getGitDiffFiles } = await import("./diff.js");
         const diffFiles = getGitDiffFiles(rootDir);
         if (diffFiles.length === 0) {
           // E4: this used to always print plain text + exit 0, ignoring
@@ -1013,8 +1015,11 @@ function registerCommands(program: Command): void {
       "--require-files-section",
       "Emit a missingFilesSection diagnostic for every task block without a Files: header",
     )
-    .action((opts) => {
+    .action(async (opts) => {
       const rootDir = process.cwd();
+      const { resolveSpecDir } = await import("./plan-coverage/spec-resolver.js");
+      const { loadConfig } = await import("./config.js");
+      const { runPlanCoverage } = await import("./plan-coverage/index.js");
 
       // Resolve spec dir per the contract precedence.
       const resolved = resolveSpecDir({
@@ -1104,16 +1109,22 @@ function registerCommands(program: Command): void {
     .option("--format <format>", "Output format: json | text", "text")
     .option("--test-results <paths...>", "Test result files (Vitest JSON / JUnit XML)")
     .addOption(new Option("--mode <mode>", "Analysis mode").choices(["file", "symbol"]))
-    .action((opts) => {
+    .action(async (opts) => {
       const rootDir = process.cwd();
+      const { loadConfig } = await import("./config.js");
+      const { scan } = await import("./scan.js");
+      const { readLock } = await import("./lock.js");
+      const { check } = await import("./check.js");
       const config = applyMode(loadConfig(rootDir), opts.mode);
       const { graph, warnings } = scan(rootDir, config);
       const lock = readLock(rootDir, config.lockFile);
 
-      const testResults = resolveTestResults(opts, config, rootDir);
+      const testResults = await resolveTestResults(opts, config, rootDir);
 
       let scopedNodeIds: Set<string> | undefined;
       if (opts.diff) {
+        const { getGitDiffFiles } = await import("./diff.js");
+        const { impact, resolveStartIds } = await import("./graph/traverse.js");
         const diffFiles = getGitDiffFiles(rootDir);
         if (diffFiles.length === 0) {
           // E4: same fix as `impact --diff` — don't ignore `--format json` on
@@ -1185,8 +1196,10 @@ function registerCommands(program: Command): void {
     .addOption(
       new Option("--format <format>", "Output format").choices(["text", "json"]).default("text"),
     )
-    .action((opts) => {
+    .action(async (opts) => {
       const rootDir = process.cwd();
+      const { runDoctor, formatDoctorReportJson, formatDoctorReportText } =
+        await import("./doctor.js");
       // E-adj-A5: parseAgentsFlag centralizes the parseAgentsList catch — same
       // as init's --agents branch. `init` and `doctor` used to inline a byte-
       // identical try/catch; migrating doctor onto the helper keeps them in
@@ -1221,12 +1234,15 @@ function registerCommands(program: Command): void {
     )
     .option("--test-results <paths...>", "Test result files (Vitest JSON / JUnit XML)")
     .addOption(new Option("--mode <mode>", "Analysis mode").choices(["file", "symbol"]))
-    .action((opts) => {
+    .action(async (opts) => {
       const rootDir = process.cwd();
+      const { loadConfig } = await import("./config.js");
+      const { scan } = await import("./scan.js");
+      const { computeCoverage } = await import("./coverage.js");
       const config = applyMode(loadConfig(rootDir), opts.mode);
       const { graph } = scan(rootDir, config);
 
-      const testResults = resolveTestResults(opts, config, rootDir);
+      const testResults = await resolveTestResults(opts, config, rootDir);
       const entries = computeCoverage(graph, testResults);
 
       if (opts.format === "json") {
@@ -1240,8 +1256,10 @@ function registerCommands(program: Command): void {
     .command("reconcile")
     .description("Update the lock file to match current state")
     .addOption(new Option("--mode <mode>", "Analysis mode").choices(["file", "symbol"]))
-    .action((opts) => {
+    .action(async (opts) => {
       const rootDir = process.cwd();
+      const { loadConfig } = await import("./config.js");
+      const { scan, reconcile } = await import("./scan.js");
       const config = applyMode(loadConfig(rootDir), opts.mode);
       const { graph } = scan(rootDir, config);
       reconcile(rootDir, config, graph);
@@ -1261,8 +1279,11 @@ function registerCommands(program: Command): void {
         "task",
       ]),
     )
-    .action((opts) => {
+    .action(async (opts) => {
       const rootDir = process.cwd();
+      const { loadConfig } = await import("./config.js");
+      const { scan } = await import("./scan.js");
+      const { formatGraphText, formatGraphJSON } = await import("./graph/format.js");
       const config = loadConfig(rootDir);
       const { graph } = scan(rootDir, config);
 
@@ -1281,6 +1302,13 @@ function registerCommands(program: Command): void {
     .action(async () => {
       const startTime = process.hrtime.bigint();
       const rootDir = process.cwd();
+      const {
+        parseHookInput,
+        extractFilePaths,
+        toRelativePath,
+        formatAdditionalContext,
+        buildHookOutput,
+      } = await import("./hook-pretool.js");
 
       try {
         let stdinText: string;
@@ -1316,6 +1344,7 @@ function registerCommands(program: Command): void {
 
         let config;
         try {
+          const { loadConfig } = await import("./config.js");
           config = loadConfig(rootDir);
         } catch (e) {
           const msg = e instanceof Error ? e.message : String(e);
@@ -1326,6 +1355,7 @@ function registerCommands(program: Command): void {
 
         let graph;
         try {
+          const { scan } = await import("./scan.js");
           const scanResult = scan(rootDir, config);
           graph = scanResult.graph;
         } catch (e) {
@@ -1335,6 +1365,7 @@ function registerCommands(program: Command): void {
           return;
         }
 
+        const { impact, resolveStartIds } = await import("./graph/traverse.js");
         const { startIds } = resolveStartIds(graph, pathsToEntries(relativePaths));
         if (startIds.length === 0) {
           process.stdout.write(JSON.stringify(buildHookOutput("artgraph impact: (none)")));
@@ -1345,6 +1376,7 @@ function registerCommands(program: Command): void {
 
         let lock;
         try {
+          const { readLock } = await import("./lock.js");
           lock = readLock(rootDir, config.lockFile);
         } catch (e) {
           const msg = e instanceof Error ? e.message : String(e);
@@ -1572,13 +1604,14 @@ function registerCommands(program: Command): void {
     .addOption(
       new Option("--format <format>", "Output format").choices(["text", "json"]).default("text"),
     )
-    .action((tool: string, opts) => {
+    .action(async (tool: string, opts) => {
       const rootDir = process.cwd();
+      const { runIntegrate } = await loadIntegrate();
 
       // Sub-command dispatch: `integrate list` reuses the same option surface
       // (only --format applies; the rest are ignored for `list`).
       if (tool === "list") {
-        runIntegrateList(rootDir, opts.format);
+        await runIntegrateList(rootDir, opts.format);
         return;
       }
 
@@ -1615,7 +1648,8 @@ function registerCommands(program: Command): void {
       }
     });
 
-  function runIntegrateList(rootDir: string, format: string): void {
+  async function runIntegrateList(rootDir: string, format: string): Promise<void> {
+    const { getProviderStatuses } = await loadIntegrate();
     const statuses = getProviderStatuses(rootDir);
 
     if (format === "json") {
@@ -1721,8 +1755,9 @@ function registerCommands(program: Command): void {
     .addOption(
       new Option("--format <format>", "Output format").choices(["json", "text"]).default("text"),
     )
-    .action((opts) => {
+    .action(async (opts) => {
       const rootDir = process.cwd();
+      const { executeRename, executeSplit, executeMerge } = await import("./rename-executor.js");
       const format: "json" | "text" = opts.format;
       const baseOpts = { dryRun: !!opts.dryRun, format, rootDir };
 
@@ -1977,5 +2012,10 @@ function resolveEntryHref(): string {
 }
 if (import.meta.url === resolveEntryHref()) {
   const program = buildProgram();
-  program.parse();
+  // parseAsync (not parse): action handlers are async since the lazy-import
+  // refactor, and commander's sync parse() would return before they finish.
+  // Matches the parseAsync semantics runCli has always used. A rejected
+  // handler surfaces as a top-level-await rejection — stack trace + exit 1 —
+  // same outcome as the old sync-throw-through-parse() path.
+  await program.parseAsync();
 }

--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -1,8 +1,21 @@
 import { resolve, relative, basename, dirname } from "node:path";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { globSync } from "glob";
-import { parseMarkdown, type ParseWarning, type InlineLinkRef } from "../parsers/markdown.js";
-import { createTSParser } from "../parsers/typescript.js";
+import {
+  parseMarkdownContent,
+  type ParseWarning,
+  type InlineLinkRef,
+} from "../parsers/markdown.js";
+import { globCodeFiles, parseTSFilePaths } from "../parsers/typescript.js";
+import {
+  computeCacheFingerprint,
+  hashContent,
+  importTargetsExist,
+  readParseCache,
+  writeParseCache,
+  type MdFragment,
+  type TsFragment,
+} from "../parse-cache.js";
 import type {
   ArtifactGraph,
   GraphNode,
@@ -80,6 +93,14 @@ export function buildGraph(
   const RESERVED_PREFIXES = ["doc:", "file:", "test:", "symbol:"];
   const parseWarnings: ParseWarning[] = [];
 
+  // Incremental parse cache (see src/parse-cache.ts). Fragments are a pure
+  // memo of per-file parser output; every assembly step below (collision
+  // remap, dedup, sorting, warning conversion) still runs fresh each build,
+  // so a warm build is structurally identical to a cold one.
+  const cacheFingerprint = computeCacheFingerprint(config);
+  const prevCache = readParseCache(rootDir, cacheFingerprint);
+  const nextMd: Record<string, MdFragment> = {};
+
   // Pass 1: collect all req nodes and detect collisions
   const collected: CollectedReq[] = [];
   const nonReqNodes: GraphNode[] = [];
@@ -89,14 +110,30 @@ export function buildGraph(
   for (const specDirName of config.specDirs) {
     const specFiles = globSync(resolve(rootDir, specDirName, "**/*.md"));
     for (const file of specFiles) {
-      const result = parseMarkdown(file, {
-        rootDir,
-        specDirPrefix: specDirName,
-        reqPatterns: config.reqPatterns,
-        taskConventions: config.taskConventions,
-        disableBuiltinTaskConventions: config.disableBuiltinTaskConventions,
-      });
       const relFile = relative(rootDir, file);
+      const mdSource = readFileSync(file, "utf-8");
+      const mdHash = hashContent(mdSource);
+      // Key by specDir too: a file nested under two specDirs is parsed once
+      // per dir with a different `specDirPrefix` (and thus a different doc id).
+      const mdKey = `${specDirName}|${relFile}`;
+      const mdHit = prevCache?.data.md[mdKey];
+      const result =
+        mdHit && mdHit.contentHash === mdHash
+          ? mdHit
+          : parseMarkdownContent(mdSource, file, {
+              rootDir,
+              specDirPrefix: specDirName,
+              reqPatterns: config.reqPatterns,
+              taskConventions: config.taskConventions,
+              disableBuiltinTaskConventions: config.disableBuiltinTaskConventions,
+            });
+      nextMd[mdKey] = {
+        contentHash: mdHash,
+        nodes: result.nodes,
+        edges: result.edges,
+        warnings: result.warnings,
+        inlineLinks: result.inlineLinks,
+      };
       const specDir = extractSpecDir(relFile, config.specDirs);
       // Compute what the auto-generated doc ID would be for this file
       const specDirRelPath = relFile.startsWith(specDirName + "/")
@@ -253,15 +290,62 @@ export function buildGraph(
     edges.push({ ...edge, target: remappedTarget });
   }
 
-  // Parse TypeScript files
+  // Parse TypeScript files — incrementally when the parse cache holds valid
+  // fragments. The file set comes from globCodeFiles (the exact fast-glob
+  // call ts-morph makes inside addSourceFilesAtPaths), so hit and miss paths
+  // see the same files a full ts-morph scan would. Only changed files are
+  // handed to ts-morph; a fully-warm run never loads it at all.
   const codePatterns = [...config.include, ...config.testPatterns];
-  const tsParser = createTSParser(
-    rootDir,
-    codePatterns,
-    config.mode ?? "file",
-    config.reqPatterns?.codeId,
+  const tsMode = config.mode ?? "file";
+  const codeId = config.reqPatterns?.codeId;
+  const codeFiles = globCodeFiles(rootDir, codePatterns);
+  const relCodeFiles = codeFiles.map((f) => relative(rootDir, f));
+
+  // TS fragments are only reusable while the import-resolution environment is
+  // unchanged: tsconfig content, analysis mode, codeId token, and the matched
+  // file set (an added/removed file can change how an UNCHANGED file's import
+  // specifier resolves). Any difference invalidates every TS fragment.
+  const tsconfigPath = resolve(rootDir, "tsconfig.json");
+  const tsconfigHash = existsSync(tsconfigPath)
+    ? hashContent(readFileSync(tsconfigPath, "utf-8"))
+    : "no-tsconfig";
+  const tsEnvKey = hashContent(
+    JSON.stringify([tsconfigHash, tsMode, codeId ?? null, [...relCodeFiles].sort()]),
   );
-  const tsResult = tsParser.parse();
+  const tsFragmentsValid = prevCache !== undefined && prevCache.data.tsEnvKey === tsEnvKey;
+
+  const nextTs: Record<string, TsFragment> = {};
+  const fragmentByFile = new Map<string, TsFragment>();
+  const missPaths: string[] = [];
+  const missHashes = new Map<string, string>();
+  for (let i = 0; i < codeFiles.length; i++) {
+    const content = readFileSync(codeFiles[i], "utf-8");
+    const contentHash = hashContent(content);
+    const hit = tsFragmentsValid ? prevCache!.data.ts[relCodeFiles[i]] : undefined;
+    if (hit && hit.contentHash === contentHash && importTargetsExist(hit.edges, rootDir)) {
+      fragmentByFile.set(codeFiles[i], hit);
+    } else {
+      missPaths.push(codeFiles[i]);
+      missHashes.set(codeFiles[i], contentHash);
+    }
+  }
+  if (missPaths.length > 0) {
+    const parsed = parseTSFilePaths(rootDir, missPaths, tsMode, codeId);
+    for (const [abs, frag] of parsed) {
+      fragmentByFile.set(abs, {
+        contentHash: missHashes.get(abs)!,
+        nodes: frag.nodes,
+        edges: frag.edges,
+      });
+    }
+  }
+  const tsResult: { nodes: GraphNode[]; edges: GraphEdge[] } = { nodes: [], edges: [] };
+  for (let i = 0; i < codeFiles.length; i++) {
+    const frag = fragmentByFile.get(codeFiles[i])!;
+    tsResult.nodes.push(...frag.nodes);
+    tsResult.edges.push(...frag.edges);
+    nextTs[relCodeFiles[i]] = frag;
+  }
 
   for (const node of tsResult.nodes) {
     addNodeWithDupCheck(nodes, node, warnings);
@@ -555,6 +639,15 @@ export function buildGraph(
   // Rebuilding the Map with sorted entries is the minimal surface change.
   const sortedNodes = new Map(
     [...nodes.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+  );
+
+  // Persist the fragments BEFORE returning so later mutation of the returned
+  // graph by a caller can never leak into the cache file. No-ops when the
+  // cache is disabled or nothing changed; never throws.
+  writeParseCache(
+    rootDir,
+    { fingerprint: cacheFingerprint, tsEnvKey, md: nextMd, ts: nextTs },
+    prevCache?.raw,
   );
 
   return { graph: { nodes: sortedNodes, edges: dedupedEdges }, warnings };

--- a/src/parse-cache.ts
+++ b/src/parse-cache.ts
@@ -1,0 +1,161 @@
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { atomicWriteFile } from "./integrate/atomic-write.js";
+import type { ArtgraphConfig, GraphEdge, GraphNode } from "./types.js";
+import type { InlineLinkRef, ParseWarning } from "./parsers/markdown.js";
+
+// Incremental parse cache: memoizes per-file parser output (markdown fragments
+// and TypeScript fragments) keyed by content hash, so `scan`/`check`/`impact`
+// only re-parse files that actually changed. The cache is a pure memo of
+// parser results — graph assembly (collision remap, dedup, sorting) always
+// runs fresh in buildGraph, so a warm build is structurally identical to a
+// cold one (INV-L4 lock byte-identity is preserved by construction).
+//
+// Storage: <root>/node_modules/.cache/artgraph/parse-cache.json. The cache is
+// only written when <root>/node_modules already exists — a project without it
+// (Deno layouts, test fixtures copied to tmp dirs) silently runs the cold
+// path every time, exactly as before this cache existed. Set ARTGRAPH_CACHE=0
+// to disable reads and writes entirely.
+//
+// Invalidation:
+//   - whole cache: artgraph version / parser-relevant config fingerprint
+//   - all TS fragments: tsconfig.json content, mode, codeId, or the matched
+//     file set changing (add/remove can change import resolution of files
+//     whose own content did not change)
+//   - single fragment: content hash mismatch, or (TS) an import-edge target
+//     that no longer exists on disk
+//
+// Known limit (documented, vanishingly rare with explicit-extension ESM
+// specifiers): creating a NEW file outside the include/testPatterns set that
+// shadows how an unchanged file's import specifier resolves is not detected.
+// Deletions are caught by the existsSync validation; additions/removals
+// inside the matched set are caught by the file-set key.
+
+export interface MdFragment {
+  contentHash: string;
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  warnings: ParseWarning[];
+  inlineLinks: InlineLinkRef[];
+}
+
+export interface TsFragment {
+  contentHash: string;
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export interface ParseCacheData {
+  schemaVersion: number;
+  fingerprint: string;
+  tsEnvKey: string;
+  /** key: `${specDirName}|${relPath}` (a file nested under two specDirs parses per-dir) */
+  md: Record<string, MdFragment>;
+  /** key: rootDir-relative path */
+  ts: Record<string, TsFragment>;
+}
+
+const SCHEMA_VERSION = 1;
+const CACHE_RELDIR = join("node_modules", ".cache", "artgraph");
+const CACHE_FILENAME = "parse-cache.json";
+
+export function hashContent(content: string): string {
+  return createHash("sha256").update(content).digest("hex").slice(0, 16);
+}
+
+function cacheEnabled(rootDir: string): boolean {
+  if (process.env.ARTGRAPH_CACHE === "0") return false;
+  return existsSync(resolve(rootDir, "node_modules"));
+}
+
+function cachePath(rootDir: string): string {
+  return resolve(rootDir, CACHE_RELDIR, CACHE_FILENAME);
+}
+
+// Version stamp for the whole-cache fingerprint. Reading package.json (one
+// level above dist/) beats hardcoding a second copy of the version string;
+// on any read failure fall back to a constant that still yields a stable
+// fingerprint for this installation.
+function artgraphVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf-8"));
+    return typeof pkg.version === "string" ? pkg.version : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+// Hash of every config field that changes PARSER output (graph-assembly-only
+// options like docGraph.* are deliberately excluded — they are re-applied to
+// the fragments on every build). mode/codeId/file-set live in the TS env key.
+export function computeCacheFingerprint(config: ArtgraphConfig): string {
+  return hashContent(
+    JSON.stringify([
+      SCHEMA_VERSION,
+      artgraphVersion(),
+      config.reqPatterns ?? null,
+      config.taskConventions ?? null,
+      config.disableBuiltinTaskConventions ?? null,
+    ]),
+  );
+}
+
+export interface LoadedParseCache {
+  data: ParseCacheData;
+  /** raw file text, kept so an unchanged cache skips the disk write */
+  raw: string;
+}
+
+export function readParseCache(rootDir: string, fingerprint: string): LoadedParseCache | undefined {
+  if (!cacheEnabled(rootDir)) return undefined;
+  try {
+    const raw = readFileSync(cachePath(rootDir), "utf-8");
+    const data = JSON.parse(raw) as ParseCacheData;
+    if (data.schemaVersion !== SCHEMA_VERSION) return undefined;
+    if (data.fingerprint !== fingerprint) return undefined;
+    if (typeof data.tsEnvKey !== "string" || !data.md || !data.ts) return undefined;
+    return { data, raw };
+  } catch {
+    // Missing or corrupt cache — cold path. Never let the cache break a scan.
+    return undefined;
+  }
+}
+
+export function writeParseCache(
+  rootDir: string,
+  cache: Omit<ParseCacheData, "schemaVersion">,
+  prevRaw?: string,
+): void {
+  if (!cacheEnabled(rootDir)) return;
+  try {
+    const serialized = JSON.stringify({ schemaVersion: SCHEMA_VERSION, ...cache });
+    if (serialized === prevRaw) return; // nothing changed — skip the write
+    mkdirSync(resolve(rootDir, CACHE_RELDIR), { recursive: true });
+    atomicWriteFile(cachePath(rootDir), serialized);
+  } catch {
+    // Cache persistence is best-effort; a failed write must not fail the scan.
+  }
+}
+
+// Validate a cached TS fragment's import edges against the file system: a
+// deleted import target changes what the parser would emit for this file even
+// though the file's own content is unchanged. `imports` edge targets are
+// `file:<rel>` or `symbol:<rel>#<name>`.
+export function importTargetsExist(edges: GraphEdge[], rootDir: string): boolean {
+  for (const edge of edges) {
+    if (edge.kind !== "imports") continue;
+    let rel: string;
+    if (edge.target.startsWith("file:")) {
+      rel = edge.target.slice("file:".length);
+    } else if (edge.target.startsWith("symbol:")) {
+      const body = edge.target.slice("symbol:".length);
+      const hashIdx = body.lastIndexOf("#");
+      rel = hashIdx === -1 ? body : body.slice(0, hashIdx);
+    } else {
+      continue;
+    }
+    if (!existsSync(resolve(rootDir, rel))) return false;
+  }
+  return true;
+}

--- a/src/parsers/markdown.ts
+++ b/src/parsers/markdown.ts
@@ -117,7 +117,7 @@ export interface InlineLinkRef {
   rawHref: string;
 }
 
-interface ParsedSpec {
+export interface ParsedSpec {
   nodes: GraphNode[];
   edges: GraphEdge[];
   warnings: ParseWarning[];
@@ -125,13 +125,25 @@ interface ParsedSpec {
 }
 
 export function parseMarkdown(filePath: string, options?: ParseMarkdownOptions): ParsedSpec {
+  return parseMarkdownContent(readFileSync(filePath, "utf-8"), filePath, options);
+}
+
+// Content-level entry point: identical to `parseMarkdown` but takes the file
+// text instead of reading it. The parse-cache path reads (and hashes) each
+// spec file once to decide hit/miss, so on a miss it hands the already-read
+// source here rather than paying a second read.
+export function parseMarkdownContent(
+  source: string,
+  filePath: string,
+  options?: ParseMarkdownOptions,
+): ParsedSpec {
   // Normalize line endings so downstream offsets, regexes, and hashes see a
   // single `\n` regardless of how the file was checked out (CRLF on Windows
   // git workspaces, lone CR from legacy editors). Without this, an authored
   // `(depends_on: X)\r\n` line bypasses ANNOTATION_RE_LINE in the rewriter
   // while still being parsed as an annotation here — i.e. parser/rewriter
   // parity breaks on CRLF files (meta-review additional F4).
-  const raw = readFileSync(filePath, "utf-8").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const raw = source.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
   const rootDir = options?.rootDir;
   const specDirPrefix = options?.specDirPrefix;
   const relPath = rootDir ? relative(rootDir, filePath) : filePath;

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -1,9 +1,21 @@
-import { Project, type SourceFile } from "ts-morph";
+import type { Project, SourceFile } from "ts-morph";
 import { createHash } from "node:crypto";
+import { createRequire } from "node:module";
 import { existsSync } from "node:fs";
 import { resolve, relative } from "node:path";
+import fastGlob from "fast-glob";
 import type { GraphNode, GraphEdge } from "../types.js";
 import { NAMESPACED_ID_TOKEN } from "../req-id.js";
+
+// ts-morph is a CJS package and by far the heaviest import in the CLI
+// (~300 ms module load). Loading it lazily via createRequire keeps this
+// module's import cheap and — combined with the parse cache — lets a
+// fully-warm scan skip ts-morph entirely. `require` of a CJS dep is
+// synchronous, so callers (buildGraph is sync) don't need to change shape.
+const requireCjs = createRequire(import.meta.url);
+function loadTsMorph(): typeof import("ts-morph") {
+  return requireCjs("ts-morph") as typeof import("ts-morph");
+}
 
 // Default requirement-ID *token* used when no custom `reqPatterns.codeId` is set.
 // The token matches the whole ID (e.g. `FR-001`, `auth/AUTH-2`, `Requirement-3`).
@@ -35,7 +47,7 @@ function buildIdMatchers(codeId?: string): IdMatchers {
   };
 }
 
-interface ParsedTS {
+export interface ParsedTS {
   nodes: GraphNode[];
   edges: GraphEdge[];
 }
@@ -46,17 +58,21 @@ interface SymbolRange {
   endLine: number;
 }
 
+function buildProjectOptions(rootDir: string) {
+  const tsconfigPath = resolve(rootDir, "tsconfig.json");
+  return existsSync(tsconfigPath)
+    ? { tsConfigFilePath: tsconfigPath, skipAddingFilesFromTsConfig: true }
+    : { skipAddingFilesFromTsConfig: true };
+}
+
 export function createTSParser(
   rootDir: string,
   patterns: string[],
   mode: "file" | "symbol" = "file",
   codeId?: string,
 ) {
-  const tsconfigPath = resolve(rootDir, "tsconfig.json");
-  const projectOpts = existsSync(tsconfigPath)
-    ? { tsConfigFilePath: tsconfigPath, skipAddingFilesFromTsConfig: true }
-    : { skipAddingFilesFromTsConfig: true };
-  const project = new Project(projectOpts);
+  const { Project: TsProject } = loadTsMorph();
+  const project = new TsProject(buildProjectOptions(rootDir));
 
   for (const pattern of patterns) {
     project.addSourceFilesAtPaths(resolve(rootDir, pattern));
@@ -64,6 +80,41 @@ export function createTSParser(
 
   const matchers = buildIdMatchers(codeId);
   return { project, parse: () => parseProject(project, rootDir, mode, matchers) };
+}
+
+// Resolve the code-file set for `patterns` with the exact glob call ts-morph's
+// RealFileSystemHost makes inside `addSourceFilesAtPaths` (fast-glob, cwd =
+// process.cwd(), absolute results). The parse-cache path discovers the file
+// set through this helper so warm runs see byte-for-byte the same set a full
+// ts-morph scan would, without loading ts-morph.
+export function globCodeFiles(rootDir: string, patterns: string[]): string[] {
+  return fastGlob.sync(
+    patterns.map((p) => resolve(rootDir, p).replace(/\\/g, "/")),
+    { cwd: resolve(), absolute: true },
+  );
+}
+
+// Parse exactly the given files (used by the parse-cache path to reparse only
+// changed files). Files are all added to one Project before parsing, mirroring
+// createTSParser's add-all-then-parse flow; import resolution consults the
+// real file system, so targets outside `filePaths` still resolve the same way
+// they do in a full scan. Returns a fragment per input path.
+export function parseTSFilePaths(
+  rootDir: string,
+  filePaths: string[],
+  mode: "file" | "symbol" = "file",
+  codeId?: string,
+): Map<string, ParsedTS> {
+  const { Project: TsProject } = loadTsMorph();
+  const project = new TsProject(buildProjectOptions(rootDir));
+  const matchers = buildIdMatchers(codeId);
+
+  const sourceFiles = filePaths.map((p) => project.addSourceFileAtPath(p));
+  const out = new Map<string, ParsedTS>();
+  for (let i = 0; i < filePaths.length; i++) {
+    out.set(filePaths[i], parseTSSourceFile(sourceFiles[i], rootDir, mode, matchers));
+  }
+  return out;
 }
 
 function parseProject(
@@ -76,30 +127,46 @@ function parseProject(
   const edges: GraphEdge[] = [];
 
   for (const sourceFile of project.getSourceFiles()) {
-    const filePath = sourceFile.getFilePath();
-    const relPath = relative(rootDir, filePath);
-
-    const fileContent = sourceFile.getFullText();
-    const fileHash = hash(fileContent);
-
-    const isTest = /\.(test|spec)\.(ts|tsx)$/.test(filePath);
-
-    nodes.push({
-      id: `file:${relPath}`,
-      kind: isTest ? "test" : "file",
-      filePath: relPath,
-      contentHash: fileHash,
-    });
-
-    let symbolRanges: SymbolRange[] = [];
-
-    if (mode === "symbol" && !isTest) {
-      symbolRanges = extractSymbols(sourceFile, relPath, nodes);
-    }
-
-    extractImports(sourceFile, relPath, rootDir, edges, mode, isTest);
-    extractImplTags(fileContent, relPath, isTest, edges, mode, symbolRanges, matchers);
+    const parsed = parseTSSourceFile(sourceFile, rootDir, mode, matchers);
+    nodes.push(...parsed.nodes);
+    edges.push(...parsed.edges);
   }
+
+  return { nodes, edges };
+}
+
+function parseTSSourceFile(
+  sourceFile: SourceFile,
+  rootDir: string,
+  mode: "file" | "symbol",
+  matchers: IdMatchers,
+): ParsedTS {
+  const nodes: GraphNode[] = [];
+  const edges: GraphEdge[] = [];
+
+  const filePath = sourceFile.getFilePath();
+  const relPath = relative(rootDir, filePath);
+
+  const fileContent = sourceFile.getFullText();
+  const fileHash = hash(fileContent);
+
+  const isTest = /\.(test|spec)\.(ts|tsx)$/.test(filePath);
+
+  nodes.push({
+    id: `file:${relPath}`,
+    kind: isTest ? "test" : "file",
+    filePath: relPath,
+    contentHash: fileHash,
+  });
+
+  let symbolRanges: SymbolRange[] = [];
+
+  if (mode === "symbol" && !isTest) {
+    symbolRanges = extractSymbols(sourceFile, relPath, nodes);
+  }
+
+  extractImports(sourceFile, relPath, rootDir, edges, mode, isTest);
+  extractImplTags(fileContent, relPath, isTest, edges, mode, symbolRanges, matchers);
 
   return { nodes, edges };
 }

--- a/tests/parse-cache.test.ts
+++ b/tests/parse-cache.test.ts
@@ -1,0 +1,168 @@
+// Incremental parse cache (src/parse-cache.ts). The cache memoizes per-file
+// parser fragments under node_modules/.cache/artgraph/parse-cache.json; these
+// tests pin the contract that a warm build is OBSERVABLY IDENTICAL to a cold
+// one (graph nodes/edges, lock bytes) and that every invalidation path falls
+// back to a correct re-parse.
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { join } from "node:path";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync, appendFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { buildGraph } from "../src/graph/builder.js";
+import { buildLockFromGraph } from "../src/lock.js";
+import type { ArtifactGraph, ArtgraphConfig } from "../src/types.js";
+
+const config: ArtgraphConfig = {
+  include: ["src/**/*.ts"],
+  specDirs: ["specs"],
+  testPatterns: ["tests/**/*.test.ts"],
+  lockFile: ".trace.lock",
+};
+
+const CACHE_REL = join("node_modules", ".cache", "artgraph", "parse-cache.json");
+
+// Serialize everything a downstream consumer can observe. Map iteration order
+// is part of the contract (builder sorts nodes/edges), so JSON order captures
+// it too. `lastReconciled` is stamped with the wall clock on every
+// buildLockFromGraph call, so normalize it — everything else in the lock must
+// be byte-identical between warm and cold builds.
+function snapshotGraph(graph: ArtifactGraph): string {
+  const lock = buildLockFromGraph(graph);
+  for (const entry of Object.values(lock)) {
+    entry.lastReconciled = "<normalized>";
+  }
+  return JSON.stringify({
+    nodes: [...graph.nodes.entries()],
+    edges: graph.edges,
+    lock,
+  });
+}
+
+// Reference result: what a cache-less build of the CURRENT tree produces.
+function buildWithoutCache(dir: string): string {
+  process.env.ARTGRAPH_CACHE = "0";
+  try {
+    return snapshotGraph(buildGraph(dir, config).graph);
+  } finally {
+    delete process.env.ARTGRAPH_CACHE;
+  }
+}
+
+describe("parse cache", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "artgraph-parse-cache-"));
+    mkdirSync(join(tmp, "specs", "feat"), { recursive: true });
+    mkdirSync(join(tmp, "src"), { recursive: true });
+    mkdirSync(join(tmp, "tests"), { recursive: true });
+    writeFileSync(
+      join(tmp, "specs", "feat", "spec.md"),
+      "# Feat\n\n- REQ-001: first requirement\n- REQ-002: second requirement\n",
+    );
+    writeFileSync(join(tmp, "src", "b.ts"), "export const b = 1;\n");
+    writeFileSync(
+      join(tmp, "src", "a.ts"),
+      '// @impl REQ-001\nimport { b } from "./b.js";\nexport const a = b;\n',
+    );
+    writeFileSync(
+      join(tmp, "tests", "a.test.ts"),
+      '// [REQ-001]\nimport { a } from "../src/a.js";\nexport const t = a;\n',
+    );
+    // The cache only activates when node_modules exists (real installs have
+    // one; tmp fixtures normally don't — that keeps every other suite on the
+    // cold path). Opt this fixture in explicitly.
+    mkdirSync(join(tmp, "node_modules"));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    delete process.env.ARTGRAPH_CACHE;
+  });
+
+  it("writes the cache file under node_modules/.cache and reuses it warm", () => {
+    const cold = snapshotGraph(buildGraph(tmp, config).graph);
+    expect(existsSync(join(tmp, CACHE_REL))).toBe(true);
+
+    const warm = snapshotGraph(buildGraph(tmp, config).graph);
+    expect(warm).toBe(cold);
+  });
+
+  it("warm build equals a cache-disabled build (nodes, edges, lock bytes)", () => {
+    buildGraph(tmp, config); // populate cache
+    const warm = snapshotGraph(buildGraph(tmp, config).graph);
+    expect(warm).toBe(buildWithoutCache(tmp));
+  });
+
+  it("does not create a cache file when node_modules is absent", () => {
+    rmSync(join(tmp, "node_modules"), { recursive: true, force: true });
+    buildGraph(tmp, config);
+    expect(existsSync(join(tmp, CACHE_REL))).toBe(false);
+  });
+
+  it("does not create a cache file when ARTGRAPH_CACHE=0", () => {
+    process.env.ARTGRAPH_CACHE = "0";
+    buildGraph(tmp, config);
+    expect(existsSync(join(tmp, CACHE_REL))).toBe(false);
+  });
+
+  it("picks up a changed TS file (new @impl edge) on a warm build", () => {
+    buildGraph(tmp, config); // populate cache
+    appendFileSync(join(tmp, "src", "b.ts"), "// @impl REQ-002\n");
+
+    const { graph } = buildGraph(tmp, config);
+    const edge = graph.edges.find(
+      (e) => e.source === "file:src/b.ts" && e.target === "REQ-002" && e.kind === "implements",
+    );
+    expect(edge).toBeDefined();
+    expect(snapshotGraph(graph)).toBe(buildWithoutCache(tmp));
+  });
+
+  it("picks up a changed spec file (new req node) on a warm build", () => {
+    buildGraph(tmp, config); // populate cache
+    appendFileSync(join(tmp, "specs", "feat", "spec.md"), "- REQ-003: third requirement\n");
+
+    const { graph } = buildGraph(tmp, config);
+    expect(graph.nodes.has("REQ-003")).toBe(true);
+    expect(snapshotGraph(graph)).toBe(buildWithoutCache(tmp));
+  });
+
+  it("invalidates TS fragments when a file is deleted (import edge to it disappears)", () => {
+    const { graph: before } = buildGraph(tmp, config); // populate cache
+    expect(
+      before.edges.some((e) => e.source === "file:src/a.ts" && e.target === "file:src/b.ts"),
+    ).toBe(true);
+
+    rmSync(join(tmp, "src", "b.ts"));
+    const { graph } = buildGraph(tmp, config);
+    expect(
+      graph.edges.some((e) => e.source === "file:src/a.ts" && e.target === "file:src/b.ts"),
+    ).toBe(false);
+    expect(graph.nodes.has("file:src/b.ts")).toBe(false);
+    expect(snapshotGraph(graph)).toBe(buildWithoutCache(tmp));
+  });
+
+  it("invalidates when the analysis config changes (mode file -> symbol)", () => {
+    buildGraph(tmp, config); // populate cache in file mode
+    const symbolConfig: ArtgraphConfig = { ...config, mode: "symbol" };
+
+    const { graph } = buildGraph(tmp, symbolConfig);
+    expect(graph.nodes.has("symbol:src/a.ts#a")).toBe(true);
+
+    process.env.ARTGRAPH_CACHE = "0";
+    const reference = snapshotGraph(buildGraph(tmp, symbolConfig).graph);
+    delete process.env.ARTGRAPH_CACHE;
+    expect(snapshotGraph(graph)).toBe(reference);
+  });
+
+  it("falls back to a cold parse when the cache file is corrupt", () => {
+    buildGraph(tmp, config); // populate cache
+    writeFileSync(join(tmp, CACHE_REL), "{ not json !!");
+
+    const { graph } = buildGraph(tmp, config);
+    expect(snapshotGraph(graph)).toBe(buildWithoutCache(tmp));
+    // and the corrupt file was replaced with a fresh valid cache
+    const warmAgain = snapshotGraph(buildGraph(tmp, config).graph);
+    expect(warmAgain).toBe(snapshotGraph(graph));
+  });
+});


### PR DESCRIPTION
## Summary

Two performance changes, developed after CPU-profiling `artgraph check` (this repo: 115 TS files / 117 md files) showed ~55% of the 3.4 s wall clock going to ts-morph, ~20% to markdown parsing, and ~12% to eager module loading — while graph assembly itself was under 20 ms.

**1. Lazy command imports (`src/cli.ts`)** — heavy modules (the scan/ts-morph chain, init, doctor, integrate, rename-executor, plan-coverage, …) move from top-level static imports into `await import()` inside each commander action. All actions are now async and the bin entry switches from `program.parse()` to `await program.parseAsync()` (matching the `parseAsync` semantics `runCli` has always used). `registerBuiltinProviders()` moves into a once-guarded lazy loader.

**2. Incremental parse cache (`src/parse-cache.ts`)** — per-file parser fragments (markdown + TypeScript) are memoized in `node_modules/.cache/artgraph/parse-cache.json` keyed by content hash, so `scan`/`check`/`impact`/`hook-pretool` re-parse only changed files. Graph assembly (collision remap, dedup, sorting) still runs fresh every build, so a warm build is structurally identical to a cold one — INV-L4 lock byte-identity holds by construction.

Key design points:
- Cache activates only when `<root>/node_modules` exists (tmp-dir test fixtures and Deno layouts silently stay on the cold path); `ARTGRAPH_CACHE=0` disables it. Corrupt/missing cache falls back to a cold parse; writes are atomic and best-effort.
- TS fragments are invalidated by tsconfig content, mode, codeId, or any change to the matched file set (an added/removed file can change how an unchanged file's import resolves); cached import edges are additionally validated with `existsSync`.
- File discovery on the cache path uses the exact fast-glob call ts-morph's `RealFileSystemHost` makes inside `addSourceFilesAtPaths`, so hit and miss paths see the same file set (fast-glob becomes a direct dependency; it was already in the tree via ts-morph).
- ts-morph (CJS) is now loaded lazily via `createRequire`, keeping `buildGraph` sync — a fully-warm run never loads ts-morph at all. `parseMarkdown` gains a content-level sibling `parseMarkdownContent`; the path-based signature is unchanged.

Measured (this repo):

| command | before | after |
|---|---|---|
| `--version` | 504 ms | 64 ms |
| `check` / `scan` / `impact` / `hook-pretool` | ~3.4 s | ~380–400 ms warm (cold path unchanged) |

Follow-up for the remaining cold-path cost: #159 (replace ts-morph with a lighter extraction layer).

## Change type

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — unit 1445 + e2e 36 + perf 3, **zero existing test files modified**
- [x] Added tests where needed — `tests/parse-cache.test.ts` (9 tests): warm==cold graph/lock identity, changed-file pickup (TS and md), file-deletion / config-change / corrupt-cache invalidation, node_modules-absent and `ARTGRAPH_CACHE=0` opt-outs
- [x] Ran `pnpm -r knip` and `pnpm -r build`

Manual verification: byte-compared cold vs warm `check` output, cold vs warm `reconcile` lock bytes, and warm-after-edit vs `ARTGRAPH_CACHE=0` graph JSON — all identical.

## Breaking change

- [ ] Yes (described below)
- [x] No

Observable additions only: a cache file appears under `node_modules/.cache/artgraph/` (already gitignored), and `ARTGRAPH_CACHE=0` is a new escape hatch.

## Notes

- Known cache limit (documented in `src/parse-cache.ts`): creating a NEW file outside `include`/`testPatterns` that shadows how an unchanged file's import specifier resolves is not detected. Deletions and any change inside the matched set are caught.
- Design/profiling notes live in the two commit messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uz31hsyr5khfmL57iVisq

---
_Generated by [Claude Code](https://claude.ai/code/session_017uz31hsyr5khfmL57iVisq)_