### PR TITLE
feat(doctor): agents-md-body-stale finding を追加 (canonical body sha 比較)

### DIFF
--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -25,7 +25,8 @@ import {
   type AgentId,
   findDescriptor,
 } from "./agents/descriptors.js";
-import { inspectMarkerBlock } from "./agents/agent-context.js";
+import { buildAgentsMdBody, inspectMarkerBlock } from "./agents/agent-context.js";
+import { detectPackageManager } from "./package-manager.js";
 import { readSkillSource, type SkillSource } from "./agents/source.js";
 
 /** Skip files larger than this when hashing / walking (C-adj-1). Prevents an
@@ -52,6 +53,7 @@ export type DoctorFindingKind =
   | "agents-md-present"
   | "agents-md-missing"
   | "agents-md-marker-broken"
+  | "agents-md-body-stale"
   | "wrapper-present"
   | "wrapper-missing"
   | "wrapper-no-import"
@@ -116,9 +118,12 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
   // action wraps this call in a try/catch so the message surfaces as
   // `Error: ...` (C1).
   const source: SkillSource = readSkillSource(SKILLS_TEMPLATE_DIR);
-  const canonicalTopLevels = new Set<string>(
-    source.entries.map((e) => e.topLevel),
-  );
+  const canonicalTopLevels = new Set<string>(source.entries.map((e) => e.topLevel));
+
+  // Detect the current PM up front so `addAgentsMdFindings` can compare the
+  // AGENTS.md marker body against the canonical `buildAgentsMdBody(detectedPm)`.
+  // Quiet mode — doctor never prints its own PM detection warning.
+  const detectedPm = detectPackageManager(rootAbs, { quiet: true });
 
   // Step 1 — detect agents.
   //   - explicit `opts.agents`: trust the caller; the CLI parser has already
@@ -217,7 +222,7 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
   }
 
   // Step 4 — AGENTS.md (single shared resource; `agent: null`).
-  addAgentsMdFindings(rootAbs, findings);
+  addAgentsMdFindings(rootAbs, detectedPm, findings);
 
   // Step 5 — wrappers (claude / copilot only).
   for (const descriptor of detectedDescriptors) {
@@ -232,10 +237,7 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
   const passCount = findings.filter((f) => f.severity === "pass").length;
   const failCount = findings.length - passCount;
   const agents = [
-    ...new Set([
-      ...detectedDescriptors.map((d) => d.id),
-      ...absentDescriptors.map((d) => d.id),
-    ]),
+    ...new Set([...detectedDescriptors.map((d) => d.id), ...absentDescriptors.map((d) => d.id)]),
   ].sort();
 
   return {
@@ -349,9 +351,7 @@ function addExtraneousFindings(
   // Within each canonical top-level dir, every file MUST match a canonical
   // relPath; mismatches (old version remnants, manually added files) are
   // reported as `extraneous-file`.
-  const canonicalTopLevels = new Set<string>(
-    source.entries.map((e) => e.topLevel),
-  );
+  const canonicalTopLevels = new Set<string>(source.entries.map((e) => e.topLevel));
   const canonical = new Set<string>();
   for (const entry of source.entries) {
     for (const file of entry.files) {
@@ -406,7 +406,11 @@ function addExtraneousFindings(
   }
 }
 
-function addAgentsMdFindings(rootAbs: string, out: DoctorFinding[]): void {
+function addAgentsMdFindings(
+  rootAbs: string,
+  detectedPm: ReturnType<typeof detectPackageManager>,
+  out: DoctorFinding[],
+): void {
   const absPath = resolve(rootAbs, "AGENTS.md");
   // C3 / C-adj-4 — single defensive readFileSync so an ENOENT race with a
   // concurrent rm surfaces as `agents-md-missing`, and an EACCES surfaces as
@@ -455,6 +459,38 @@ function addAgentsMdFindings(rootAbs: string, out: DoctorFinding[]): void {
       message: `AGENTS.md artgraph marker block is broken. Re-run \`artgraph init --agents=<list> --force\` to repair.`,
     });
     return;
+  }
+  // Compare the marker-block body to the canonical rendering for the
+  // currently detected PM. If they differ, the user's AGENTS.md is running
+  // an outdated snippet (the template changed since their last `init`) —
+  // flag it so they know to re-run `init --force`. Severity is `pass`
+  // (NOTICE-style) so a plain artgraph upgrade doesn't silently break CI
+  // gates that treat any `fail` finding as a hard stop.
+  const currentBody = health.bodyText ?? "";
+  let canonicalBody: string | null = null;
+  try {
+    canonicalBody = buildAgentsMdBody(detectedPm);
+  } catch {
+    // Packaging fault reading the template — do not synthesize a false
+    // stale finding. `readSkillSource` above will surface the packaging
+    // error on the same path elsewhere.
+    canonicalBody = null;
+  }
+  if (canonicalBody !== null) {
+    const currentHash = createHash("sha256").update(currentBody).digest("hex");
+    const canonicalHash = createHash("sha256").update(canonicalBody).digest("hex");
+    if (currentHash !== canonicalHash) {
+      out.push({
+        severity: "pass",
+        agent: null,
+        kind: "agents-md-body-stale",
+        path: "AGENTS.md",
+        expected: canonicalHash,
+        actual: currentHash,
+        message: `NOTICE: AGENTS.md artgraph marker block body is out of date. Re-run \`artgraph init --agents=<list> --force\` to refresh it against the current template.`,
+      });
+      return;
+    }
   }
   out.push({
     severity: "pass",
@@ -564,9 +600,7 @@ export function formatDoctorReportText(report: DoctorReport): string {
 
   if (report.findings.length === 0) {
     // No distribution detected → soft-success path (per FR-011 + quickstart §3-5).
-    lines.push(
-      "No Tier 1 distribution detected. Run `artgraph init --agents=<list>` to set up.",
-    );
+    lines.push("No Tier 1 distribution detected. Run `artgraph init --agents=<list>` to set up.");
     return lines.join("\n");
   }
 
@@ -589,7 +623,9 @@ export function formatDoctorReportText(report: DoctorReport): string {
       for (const f of failures) {
         lines.push(`  ✗ ${f.path}    (${f.kind})`);
         if (f.kind === "skill-file-drift" && f.expected && f.actual) {
-          lines.push(`       expected: ${f.expected.slice(0, 12)}…  actual: ${f.actual.slice(0, 12)}…`);
+          lines.push(
+            `       expected: ${f.expected.slice(0, 12)}…  actual: ${f.actual.slice(0, 12)}…`,
+          );
         } else if (f.expected !== null && f.actual !== null) {
           lines.push(`       expected: ${f.expected}  actual: ${f.actual}`);
         }
@@ -722,9 +758,10 @@ function toPosix(p: string): string {
 }
 
 function toRepoRel(rootAbs: string, abs: string): string {
-  const stripped = abs.startsWith(rootAbs + sep) || abs.startsWith(rootAbs + "/")
-    ? abs.slice(rootAbs.length + 1)
-    : abs;
+  const stripped =
+    abs.startsWith(rootAbs + sep) || abs.startsWith(rootAbs + "/")
+      ? abs.slice(rootAbs.length + 1)
+      : abs;
   return toPosix(stripped);
 }
 
@@ -742,14 +779,10 @@ function brokenMarkerDescription(
   const endCount = Array.from(content.matchAll(END_RE_G)).length;
   if (!h.hasBegin && !h.hasEnd) return "no markers found";
   if (h.hasBegin && !h.hasEnd) {
-    return beginCount === 1
-      ? "1 begin marker without end"
-      : `${beginCount} begin markers, 0 ends`;
+    return beginCount === 1 ? "1 begin marker without end" : `${beginCount} begin markers, 0 ends`;
   }
   if (!h.hasBegin && h.hasEnd) {
-    return endCount === 1
-      ? "1 end marker without begin"
-      : `0 begins, ${endCount} end markers`;
+    return endCount === 1 ? "1 end marker without begin" : `0 begins, ${endCount} end markers`;
   }
   return `markers present but unpaired (${beginCount} begins, ${endCount} ends)`;
 }

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -273,6 +273,78 @@ describe("runDoctor — FAIL: agents-md-missing / agents-md-marker-broken", () =
   });
 });
 
+describe("runDoctor — agents-md-body-stale", () => {
+  let proj: ReturnType<typeof createFreshProject>;
+
+  beforeEach(() => {
+    proj = createFreshProject();
+    initProject(proj.dir, ["claude"]);
+  });
+
+  afterEach(() => {
+    proj.cleanup();
+  });
+
+  it("does NOT emit agents-md-body-stale on a fresh init (canonical body matches)", () => {
+    const report = runDoctor({ rootDir: proj.dir });
+    const stale = report.findings.filter((f) => f.kind === "agents-md-body-stale");
+    expect(stale.length, JSON.stringify(stale, null, 2)).toBe(0);
+    // And `agents-md-present` still fires as a pass.
+    expect(findFinding(report.findings, (f) => f.kind === "agents-md-present")).toBeDefined();
+  });
+
+  it("emits agents-md-body-stale (severity: pass, NOTICE) when the marker body drifts", () => {
+    // Simulate an outdated snippet from a previous artgraph release —
+    // marker structure intact, body content drifted.
+    const agentsMd = join(proj.dir, "AGENTS.md");
+    const body = readFileSync(agentsMd, "utf-8");
+    const drifted = body.replace(
+      /(<!--\s*artgraph:begin\s*-->)([\s\S]*?)(<!--\s*artgraph:end\s*-->)/,
+      "$1\n<!-- stale body from an older artgraph release -->\n$3",
+    );
+    writeFileSync(agentsMd, drifted, "utf-8");
+
+    const report = runDoctor({ rootDir: proj.dir });
+    const stale = findFinding(report.findings, (f) => f.kind === "agents-md-body-stale");
+    expect(stale, JSON.stringify(report.findings, null, 2)).toBeDefined();
+    // Severity is pass so a plain artgraph upgrade doesn't silently break CI
+    // gates that treat any `fail` finding as a hard stop.
+    expect(stale!.severity).toBe("pass");
+    expect(stale!.agent).toBeNull();
+    expect(stale!.path).toBe("AGENTS.md");
+    expect(stale!.message).toContain("NOTICE");
+    expect(stale!.message).toContain("--force");
+    // expected/actual are sha256 hex digests for downstream diffing.
+    expect(stale!.expected).toMatch(/^[0-9a-f]{64}$/);
+    expect(stale!.actual).toMatch(/^[0-9a-f]{64}$/);
+    expect(stale!.expected).not.toBe(stale!.actual);
+    // Regression guard: stale body MUST NOT flip doctor exit code.
+    expect(report.summary.failCount).toBe(0);
+    // And `agents-md-present` must NOT also fire — the stale finding is
+    // returned in its place (early return in addAgentsMdFindings).
+    expect(report.findings.filter((f) => f.kind === "agents-md-present").length).toBe(0);
+  });
+
+  it("does not emit agents-md-body-stale when AGENTS.md is missing or marker is broken", () => {
+    // Missing → agents-md-missing takes over.
+    rmSync(join(proj.dir, "AGENTS.md"));
+    const rMissing = runDoctor({ rootDir: proj.dir });
+    expect(rMissing.findings.filter((f) => f.kind === "agents-md-body-stale").length).toBe(0);
+    expect(findFinding(rMissing.findings, (f) => f.kind === "agents-md-missing")).toBeDefined();
+
+    // Broken marker → agents-md-marker-broken takes over.
+    initProject(proj.dir, ["claude"]);
+    const agentsMd = join(proj.dir, "AGENTS.md");
+    const body = readFileSync(agentsMd, "utf-8");
+    writeFileSync(agentsMd, body.replace(/<!--\s*artgraph:end\s*-->/g, ""), "utf-8");
+    const rBroken = runDoctor({ rootDir: proj.dir });
+    expect(rBroken.findings.filter((f) => f.kind === "agents-md-body-stale").length).toBe(0);
+    expect(
+      findFinding(rBroken.findings, (f) => f.kind === "agents-md-marker-broken"),
+    ).toBeDefined();
+  });
+});
+
 describe("runDoctor — empty / no distribution detected", () => {
   let proj: ReturnType<typeof createFreshProject>;
 


### PR DESCRIPTION
## Summary

- `artgraph doctor` は AGENTS.md marker block の構造 (`hasMatchedPair`) しか検査しておらず、body の内容が canonical template から drift していても素通りしていた
- artgraph の template 更新後、既存プロジェクトが `init --force` を再実行しない限り、AGENTS.md の body は古いまま残る。doctor はこれを検出できなかった
- 新しい `agents-md-body-stale` finding を追加: `detectPackageManager` で現在の PM を検出し、`buildAgentsMdBody(pm)` で canonical body を再生成、marker block 内の `bodyText` と sha256 で比較。不一致なら `agents-md-body-stale` を emit

## 経緯

本来は PR #153 (issue #130 対応) の敵対的レビューで見つかった E3 の指摘として実装したものです。PR #153 は、レビュー後に判明した前提の誤り (GitHub Copilot の Agent Skills 機能が `.github/skills/` を公式 discovery パスとして既にサポートしていた) により close しましたが、この `agents-md-body-stale` finding 自体はその前提と無関係な汎用改善のため、独立した PR として切り出しました。

## 設計

- severity は `fail` ではなく **`pass`** (NOTICE-style): artgraph の通常アップグレードでテンプレートが更新されただけで、既存ユーザの CI ゲート (`--gate` で fail を hard stop 扱いする運用) を無告知に壊さないための配慮
- message で `artgraph init --agents=<list> --force` を促す
- AGENTS.md が欠如 / marker 破損の場合は既存の `agents-md-missing` / `agents-md-marker-broken` が優先され、`agents-md-body-stale` は出さない (early return)

## Test plan
- [x] `pnpm exec tsc --noEmit` — exit 0
- [x] `pnpm exec vitest run tests/doctor.test.ts` — 31/31 pass (3 件新規: fresh init で fires しない / body drift で fires + severity pass + failCount 0 / AGENTS.md 欠如・marker 破損時は出ない)
- [x] `pnpm exec vitest run` (full) — 1521/1521 pass
- [x] `pnpm exec vitest run --config vitest.e2e.config.ts` — 全 pass
- [x] lefthook pre-push (knip / test-e2e / test-unit / typecheck) — 全 pass

## Note

- `src/doctor.ts` 内の一部無関係箇所 (`toRepoRel` / `brokenMarkerDescription` / `formatDoctorReportText` 等) に oxfmt由来の整形差分が混入していますが、意味的な変更はありません (直近の依存更新 #169 で oxfmt のフォーマット挙動が僅かに変わったことによる drift)
- `node dist/cli.js check --diff --gate` は `src/doctor.ts` に触れる diff で pre-existing の spec 未タグ付け債務 (spec 016 / 012 等、本 PR と無関係) により exit 2 になることを確認済みです。本 PR の変更が原因ではなく、`src/doctor.ts` への空行のみの無害な変更でも同じ exit 2 が再現することを検証済み — 別途調査が必要な既存の問題です

🤖 Generated with [Claude Code](https://claude.com/claude-code)