### PR TITLE
test: docs-trio-consistency / check-gate-no-regression のソースgrep検査をruntimeベースに置き換える

### DIFF
--- a/tests/check-gate-no-regression.test.ts
+++ b/tests/check-gate-no-regression.test.ts
@@ -14,23 +14,32 @@
 //       `DoctorFinding` / `AGENT_DESCRIPTORS` imports / symbol references).
 //       This is fast, deterministic, and survives refactors that rename
 //       file fixtures.
-//   (b) **Behavioural smoke** runs `check()` directly on a stub graph + lock
+//   (b) **Behavioural CLI check** (issue #175): runs the real
+//       `check --gate` command end-to-end via the `runCli()` harness and
+//       asserts its stdout/stderr never mention the doctor surface. This
+//       replaces a grep of `src/commands/check.ts`'s action body, which
+//       broke every time the check subcommand moved to a new file (#162)
+//       and only proved the source text was clean — not what a user
+//       actually sees when running the command.
+//   (c) **Behavioural smoke** runs `check()` directly on a stub graph + lock
 //       — the function is pure and takes no rootDir, so spec 013
 //       distribution files (`.claude/skills/...` etc.) cannot influence its
 //       outcome by construction. We assert the function signature stays free
 //       of any `rootDir` / `agents` parameter so the doctor cannot be
 //       wired in via an "implicit" surface either.
 //
-// The two together cover the spec intent without depending on a tmp
+// The three together cover the spec intent without depending on a tmp
 // project + multi-step setup: any wiring of doctor into check would either
-// require touching `src/check.ts` (caught by (a)) or expanding `check()`'s
-// signature (caught by (b)).
+// require touching `src/check.ts` (caught by (a)), leak into the CLI's
+// visible output (caught by (b)), or expand `check()`'s signature (caught
+// by (c)).
 
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { check } from "../src/check.js";
 import type { ArtifactGraph, LockFile } from "../src/types.js";
+import { run, cleanup } from "./helpers.js";
 
 const REPO_ROOT = resolve(import.meta.dirname, "..");
 
@@ -62,29 +71,20 @@ describe("check --gate non-regression (FR-012 後段)", () => {
     }
   });
 
-  it("src/commands/check.ts `check` action does not invoke runDoctor / DoctorFinding", () => {
-    // issue #162: the `check` subcommand moved from src/cli.ts into its own
-    // module. That module registers exactly one command, so — unlike the
-    // old single-file cli.ts — there is no second `program.command(...)`
-    // block to bound the slice against; the check block runs to EOF.
-    const cliSource = readFileSync(resolve(REPO_ROOT, "src/commands/check.ts"), "utf-8");
-    const checkStart = cliSource.indexOf('.command("check")');
-    expect(
-      checkStart,
-      "could not locate check subcommand in src/commands/check.ts",
-    ).toBeGreaterThan(0);
-    // Accept both top-level (`\nprogram`) and indented-inside-registerCommands
-    // (`\n  program`) — oxfmt normalises whichever style the surrounding scope
-    // uses, so pinning to one indentation would be a maintenance trap.
-    const nextProgramMatch = cliSource.slice(checkStart + 1).search(/\n[ \t]*program(\s|\.|\r?\n)/);
-    const checkEnd = nextProgramMatch >= 0 ? checkStart + 1 + nextProgramMatch : cliSource.length;
-    expect(checkEnd).toBeGreaterThan(checkStart);
-    const checkBlock = cliSource.slice(checkStart, checkEnd);
-
-    for (const needle of ["runDoctor", "DoctorFinding", "formatDoctorReport"]) {
+  it("`check --gate` output never mentions the doctor surface (#175)", async () => {
+    // The fixture project has real coverage gaps once the lock file is
+    // cleared, so --gate fails on its own merits (exit 2) — proving the
+    // assertion below isn't vacuously true on an all-clear run. Runs the
+    // real CLI end-to-end, so it stays correct no matter which file the
+    // check subcommand's implementation lives in.
+    cleanup();
+    const { stdout, stderr, exitCode } = await run(["check", "--gate"]);
+    expect(exitCode).toBe(2);
+    const combined = stdout + stderr;
+    for (const needle of ["doctor", "Doctor", "runDoctor", "DoctorFinding", "formatDoctorReport"]) {
       expect(
-        checkBlock.includes(needle),
-        `check subcommand must not call "${needle}" (FR-012)`,
+        combined.includes(needle),
+        `check --gate output must not mention "${needle}" (FR-012: doctor is independent of check --gate)`,
       ).toBe(false);
     }
   });

--- a/tests/docs-trio-consistency.test.ts
+++ b/tests/docs-trio-consistency.test.ts
@@ -1,28 +1,44 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { run } from "./helpers.js";
 
 // Docs-trio consistency metatest (#139).
 //
-// README.md, docs/skills-guide.md, and src/cli.ts all describe the default
-// stages of `artgraph init`, and nothing keeps them in sync automatically:
-// PR #103 advertised agent-context in the README before it shipped (H1),
-// and PR #129 shipped the Stop hook but left "lands in PR-B" in the CLI
-// help. This test pins the three sources to a single stage list and rejects
-// stale future-tense markers, so the next shipped-but-undocumented (or
-// documented-but-unshipped) stage fails CI instead of reaching users.
+// README.md, docs/skills-guide.md, and `artgraph init --help` all describe
+// the default stages of `artgraph init`, and nothing keeps them in sync
+// automatically: PR #103 advertised agent-context in the README before it
+// shipped (H1), and PR #129 shipped the Stop hook but left "lands in PR-B"
+// in the CLI help. This test pins the three sources to a single stage list
+// and rejects stale future-tense markers, so the next shipped-but-
+// undocumented (or documented-but-unshipped) stage fails CI instead of
+// reaching users.
 //
 // The stage list below is the test's single source of truth. Adding a new
 // init stage means updating it here, and the assertions then force the
-// README paragraph, the skills-guide section, and the cli.ts flag surface
-// to be updated in the same PR.
+// README paragraph, the skills-guide section, and the CLI help text to be
+// updated in the same PR.
+//
+// issue #175: the third source used to be a grep of `src/commands/init.ts`
+// (before that, `src/cli.ts` — issue #162 moved it). Reading the CLI
+// module's source text coupled this test to wherever the `init` command's
+// implementation happened to live, and it broke on pure file moves with no
+// behavior change. Running `artgraph init --help` through the in-process
+// `runCli()` harness instead checks what a user actually sees, and stays
+// correct regardless of how the command's implementation is split up.
 
 const ROOT = resolve(import.meta.dirname, "..");
 
 const readme = readFileSync(resolve(ROOT, "README.md"), "utf8");
 const skillsGuide = readFileSync(resolve(ROOT, "docs", "skills-guide.md"), "utf8");
-// issue #162: `init` moved from src/cli.ts into its own module.
-const cliSource = readFileSync(resolve(ROOT, "src", "commands", "init.ts"), "utf8");
+
+let helpText: string;
+
+beforeAll(async () => {
+  const { stdout, exitCode } = await run(["init", "--help"]);
+  expect(exitCode).toBe(0);
+  helpText = stdout;
+});
 
 type Stage = {
   id: string;
@@ -155,44 +171,43 @@ function skillsGuideStageBullets(): string {
   return bullets.join("\n");
 }
 
-/** Source text of one commander command block in src/commands/init.ts. */
-function cliCommandBlock(name: string): string {
-  const start = cliSource.indexOf(`.command("${name}")`);
-  if (start === -1) {
-    throw new Error(`src/commands/init.ts: .command("${name}") not found`);
-  }
-  const next = cliSource.indexOf('.command("', start + 1);
-  return cliSource.slice(start, next === -1 ? undefined : next);
-}
-
-/** The .description("...") string of the init command. */
+/**
+ * The free-text description paragraph of `artgraph init --help`: everything
+ * between the "Usage: ..." line and the "Options:" section, with wrapped
+ * lines rejoined into a single line (commander word-wraps to terminal
+ * width, which would otherwise split stage mentions across lines).
+ */
 function cliInitDescription(): string {
-  const match = cliCommandBlock("init").match(/\.description\(\s*"((?:[^"\\]|\\.)*)"/);
+  const match = helpText.match(/^Usage: artgraph init \[options\]\n\n([\s\S]*?)\n\nOptions:/m);
   if (!match) {
     throw new Error(
-      'src/commands/init.ts: init .description("...") not found or not a plain string',
+      "`artgraph init --help`: could not find the description paragraph between " +
+        '"Usage: artgraph init [options]" and "Options:". ' +
+        "If commander's help layout changed, update docs-trio-consistency.test.ts to match.",
     );
   }
-  return match[1];
+  return match[1].replace(/\s+/g, " ").trim();
 }
 
-/** All --flag names declared via .option() inside the init command block. */
+/** All --flag names listed in the "Options:" section of `artgraph init --help`. */
 function cliInitOptionFlags(): string[] {
-  const block = cliCommandBlock("init");
   const flags: string[] = [];
-  for (const m of block.matchAll(/\.option\(\s*"(--[a-z-]+)/g)) {
+  // Anchored to exactly two leading spaces so wrapped continuation lines
+  // (indented further, e.g. "...--agents (default\n  mode only...)") can't
+  // be mistaken for a flag declaration.
+  for (const m of helpText.matchAll(/^ {2}(--[a-z-]+)/gm)) {
     flags.push(m[1]);
   }
   return flags;
 }
 
-describe("docs-trio consistency: README / docs/skills-guide.md / src/cli.ts (#139)", () => {
+describe("docs-trio consistency: README / docs/skills-guide.md / `artgraph init --help` (#139)", () => {
   describe("every default stage is described by all three sources", () => {
     for (const stage of DEFAULT_STAGES) {
-      it(`stage "${stage.id}" appears in the cli.ts init description`, () => {
-        expect(enumerationSentence(cliInitDescription(), "src/cli.ts init description")).toMatch(
-          stage.mention,
-        );
+      it(`stage "${stage.id}" appears in the init --help description`, () => {
+        expect(
+          enumerationSentence(cliInitDescription(), "`artgraph init --help` description"),
+        ).toMatch(stage.mention);
       });
 
       it(`stage "${stage.id}" appears in the README default-setup enumeration`, () => {
@@ -208,7 +223,7 @@ describe("docs-trio consistency: README / docs/skills-guide.md / src/cli.ts (#13
   });
 
   describe("stage flag surface matches the stage list", () => {
-    it("cli.ts declares exactly the expected --no-* opt-outs on init", () => {
+    it("init --help declares exactly the expected --no-* opt-outs", () => {
       const expected = DEFAULT_STAGES.map((s) => s.optOut)
         .filter((f): f is string => f !== null)
         .sort();
@@ -218,7 +233,7 @@ describe("docs-trio consistency: README / docs/skills-guide.md / src/cli.ts (#13
       expect(actual).toEqual(expected);
     });
 
-    it("cli.ts declares no --with-* opt-ins on init (removed in #135)", () => {
+    it("init --help declares no --with-* opt-ins (removed in #135)", () => {
       expect(cliInitOptionFlags().filter((f) => f.startsWith("--with-"))).toEqual([]);
     });
 
@@ -240,7 +255,7 @@ describe("docs-trio consistency: README / docs/skills-guide.md / src/cli.ts (#13
     const sources: Array<[string, () => string]> = [
       ["README.md", () => readme],
       ["docs/skills-guide.md", () => skillsGuide],
-      ["src/commands/init.ts", () => cliSource],
+      ["`artgraph init --help`", () => helpText],
     ];
     for (const [label, read] of sources) {
       for (const marker of STALE_MARKERS) {


### PR DESCRIPTION
## Summary

- `tests/docs-trio-consistency.test.ts`: `src/commands/init.ts` のソーステキストを `indexOf` / `matchAll` でスライスして `.description(...)` / `.option(...)` を抽出していた部分を、`runCli()` ハーネス経由で実際に `artgraph init --help` を実行し、その標準出力を README / skills-guide と突き合わせる方式に置き換えました。
- `tests/check-gate-no-regression.test.ts`: `src/commands/check.ts` の `check` アクション本体をスライスして `runDoctor` 等の識別子を grep していたテストを、実際に `check --gate` を実行し、その出力(stdout + stderr)に doctor 関連の文言が含まれないことを確認する振る舞いテストに置き換えました(同ファイル3番目の `check()` 純粋関数テストと合わせて二重に保証)。

いずれも #162 (cli.ts の分割) で「コマンドの実装がどのファイルに存在するか」という実装配置に結合していた脆弱性を解消するもので、振る舞い自体は変えていません。

Closes #175

## Change type

- [x] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm test:unit`, `pnpm test:e2e` — 実行済み、全件成功)
- [x] Added tests: `docs-trio-consistency.test.ts` / `check-gate-no-regression.test.ts` の該当テストを runtime ベースに書き換え(新規テスト追加ではなく置き換え)
- [x] `pnpm knip` / `pnpm build` / `pnpm typecheck` 実行済み(問題なし)
- [x] 置き換えたテストが実際に回帰を検出できることを手動で確認(`init.ts` の description 文言を壊す / `check.ts` に doctor 関連の文言を仕込む、の両方でテストが red になることを確認後 revert)

## Breaking change

- [x] No

## Notes

- テスト対象を移動した2ファイル(`docs-trio-consistency.test.ts` / `check-gate-no-regression.test.ts`)以外のプロダクションコードは変更していません。


---
_Generated by [Claude Code](https://claude.ai/code/session_01SJjpmBovi59LaoASQRLQWL)_