### PR TITLE
fix(graph): scan --output に既存ファイル警告 + stale vendor 掃除を追加 (closes #170)

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,15 @@ artgraph scan --output ./graph-out
 present to color drift/orphan/uncovered nodes; a missing lock just renders
 without that extra state.
 
+`--output` only ever writes `index.html`, `app.js`, and `vendor/cytoscape.min.js`
+into the target directory, and refuses to run if it finds anything else there
+(e.g. you pointed `--output` at a GitHub Pages `docs/` dir or the repo root by
+mistake) — pass `--force` to overwrite anyway. The `vendor/` subdirectory is
+always wiped and rewritten from scratch, so stale artifacts from a previous
+`artgraph` version never accumulate across repeated `--output` runs. The write
+itself is not atomic — a crash mid-export can leave a partial `outputDir` — the
+same trade-off other static-site generators (VitePress, TypeDoc, Sphinx) make.
+
 ## `artgraph doctor` — cross-agent distribution health check
 
 Diagnoses whether the SKILL.md files distributed by `artgraph init --agents=<list>`

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -14,6 +14,10 @@ export function registerScanCommand(program: Command): void {
     .option("--port <n>", "Port for --serve (default 3737)", (v) => Number.parseInt(v, 10))
     .option("--host <h>", "Host for --serve (default 127.0.0.1)")
     .option("--output <dir>", "Emit a static HTML export into <dir>")
+    .option(
+      "--force",
+      "Overwrite --output's target directory even if it contains files artgraph doesn't manage",
+    )
     .action(async (opts) => {
       const rootDir = process.cwd();
       const { loadConfig } = await import("../config.js");
@@ -61,7 +65,13 @@ export function registerScanCommand(program: Command): void {
 
         if (opts.output) {
           const outputDir = resolve(rootDir, opts.output);
-          await writeStaticExport({ data, outputDir });
+          try {
+            await writeStaticExport({ data, outputDir, force: Boolean(opts.force) });
+          } catch (e) {
+            const msg = e instanceof Error ? e.message : String(e);
+            console.error(`error: ${msg}`);
+            process.exit(1);
+          }
           console.error(`artgraph scan: static export written to ${outputDir}`);
           return;
         }

--- a/src/graph/serve.ts
+++ b/src/graph/serve.ts
@@ -1,5 +1,14 @@
 import { createServer, type Server } from "node:http";
-import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { resolve } from "node:path";
 import type { RenderData } from "./render.js";
 import { renderTemplate } from "../template.js";
@@ -18,6 +27,12 @@ export interface ServeHandle {
 export interface ExportOptions {
   data: RenderData;
   outputDir: string;
+  /**
+   * Overwrite `outputDir` even if it contains files artgraph doesn't manage
+   * (issue #170 D1). Without this, `writeStaticExport` refuses to write into
+   * a non-empty, non-artgraph-owned directory.
+   */
+  force?: boolean;
 }
 
 const DEFAULT_PORT = 3737;
@@ -230,12 +245,51 @@ export async function startServer(opts: ServeOptions): Promise<ServeHandle> {
   });
 }
 
+const MANAGED_OUTPUT_ENTRIES = new Set(["index.html", "app.js", "vendor"]);
+
+// D1 (issue #170): `writeStaticExport` used to overwrite index.html / app.js /
+// vendor/cytoscape.min.js unconditionally, so pointing `--output` at the wrong
+// directory (GitHub Pages' `docs/`, or repo root) could silently replace
+// unrelated files — confirmed in practice against a dir containing
+// `USER-IMPORTANT-INDEX.md`. This lists anything at the top level of
+// `outputDir` that isn't one of the three artgraph-managed paths so the
+// caller can refuse unless `--force`. `vendor` only counts as managed when it
+// is actually a directory — a file/symlink squatting on that name is
+// suspicious and gets flagged too.
+function findUnmanagedTopLevelEntries(outputDir: string): string[] {
+  if (!existsSync(outputDir)) return [];
+  return readdirSync(outputDir).filter((entry) => {
+    if (entry !== "vendor") return !MANAGED_OUTPUT_ENTRIES.has(entry);
+    return !lstatSync(resolve(outputDir, entry)).isDirectory();
+  });
+}
+
 export async function writeStaticExport(opts: ExportOptions): Promise<void> {
-  const { data, outputDir } = opts;
+  const { data, outputDir, force } = opts;
+
+  const unmanaged = findUnmanagedTopLevelEntries(outputDir);
+  if (unmanaged.length > 0 && !force) {
+    throw new Error(
+      `artgraph scan: ${outputDir} contains file(s) artgraph doesn't manage (${unmanaged.join(", ")}). ` +
+        "Pass --force to overwrite anyway, or point --output at an empty/dedicated directory.",
+    );
+  }
+
   const html = readIndexHtml(data);
   mkdirSync(outputDir, { recursive: true });
-  mkdirSync(resolve(outputDir, "vendor"), { recursive: true });
+
+  // D2 (issue #170): once we get here, vendor/ is entirely artgraph-owned —
+  // wipe it before rewriting instead of layering the current cytoscape build
+  // on top of whatever an older artgraph version left behind (e.g. a
+  // differently-named vendor bundle from a prior release). Keeps repeated
+  // `--output` runs in a CI pipe from accumulating stale vendor artifacts.
+  // `rmSync` doesn't follow symlinks, so a `vendor` symlink is unlinked, not
+  // traversed, before `mkdirSync` recreates it as a real directory.
+  const vendorDir = resolve(outputDir, "vendor");
+  rmSync(vendorDir, { recursive: true, force: true });
+  mkdirSync(vendorDir, { recursive: true });
+
   writeFileSync(resolve(outputDir, "index.html"), html, "utf-8");
   copyFileSync(APP_JS_PATH, resolve(outputDir, "app.js"));
-  copyFileSync(VENDOR_JS_PATH, resolve(outputDir, "vendor/cytoscape.min.js"));
+  copyFileSync(VENDOR_JS_PATH, resolve(vendorDir, "cytoscape.min.js"));
 }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -401,6 +401,58 @@ describe("CLI: scan graph payload", () => {
       rmSync(outDir, { recursive: true, force: true });
     }
   });
+
+  // issue #170 D1: --output used to overwrite whatever sat at index.html /
+  // app.js / vendor/cytoscape.min.js without checking what else lived in the
+  // directory. Pointing --output at the wrong dir (GitHub Pages' docs/, repo
+  // root) could silently replace unrelated files.
+  it("T-graph-serve-3: --output refuses a dir with unmanaged files, --force overrides", async () => {
+    const outDir = mkdtempSync(join(tmpdir(), "artgraph-graph-unmanaged-"));
+    try {
+      writeFileSync(join(outDir, "USER-IMPORTANT-INDEX.md"), "do not touch\n");
+
+      const refused = await run(["scan", "--output", outDir]);
+      expect(refused.exitCode).toBe(1);
+      expect(refused.stderr).toMatch(/doesn't manage/);
+      expect(refused.stderr).toContain("USER-IMPORTANT-INDEX.md");
+      expect(refused.stderr).toMatch(/--force/);
+      // Refusal must be fail-fast: no export files written alongside the
+      // untouched user file.
+      expect(existsSync(join(outDir, "index.html"))).toBe(false);
+      expect(existsSync(join(outDir, "USER-IMPORTANT-INDEX.md"))).toBe(true);
+
+      const forced = await run(["scan", "--output", outDir, "--force"]);
+      expect(forced.exitCode).toBe(0);
+      expect(existsSync(join(outDir, "index.html"))).toBe(true);
+      // --force overwrites the managed export paths but must not delete
+      // unrelated files sitting alongside them.
+      expect(existsSync(join(outDir, "USER-IMPORTANT-INDEX.md"))).toBe(true);
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
+
+  // issue #170 D2: a stale vendor/ file from a previous artgraph release (or
+  // a differently-named vendor bundle) must not survive a re-export — the
+  // vendor/ subdirectory is fully artgraph-owned and gets wiped + rewritten
+  // on every --output run. `vendor` itself is a D1-managed top-level entry,
+  // so this cleanup happens without needing --force — a CI pipe that reruns
+  // `--output` on the same dir every build must not have to pass --force
+  // just to keep vendor/ tidy.
+  it("T-graph-serve-4: --output clears stale vendor/ artifacts on re-run, no --force needed", async () => {
+    const outDir = mkdtempSync(join(tmpdir(), "artgraph-graph-stale-vendor-"));
+    try {
+      mkdirSync(join(outDir, "vendor"), { recursive: true });
+      writeFileSync(join(outDir, "vendor", "old-cytoscape.min.js"), "stale\n");
+
+      const { exitCode } = await run(["scan", "--output", outDir]);
+      expect(exitCode).toBe(0);
+      expect(existsSync(join(outDir, "vendor", "cytoscape.min.js"))).toBe(true);
+      expect(existsSync(join(outDir, "vendor", "old-cytoscape.min.js"))).toBe(false);
+    } finally {
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

PR #155 敵対的レビュー Cluster D の follow-up(D1/D2)。Closes #170.

- **D1**: `writeStaticExport` が `index.html` / `app.js` / `vendor/cytoscape.min.js` 以外のファイルを無警告で上書きしていた問題を修正。`--output` 先のトップレベルに artgraph が管理しないファイルが1つでもあれば拒否するガードを追加し、`--force` で上書き許可するようにした(`init`/`integrate` で既に使われている `--force` の慣習に合わせた)。
- **D2**: `vendor/` サブディレクトリは書き込み前にまるごと削除・再作成するようにし、過去の artgraph バージョンが残した stale artifact(例: リネームされた vendor バンドル)が repeated `--output` 実行で蓄積しないようにした。こちらは `vendor` 自体がトップレベルの管理対象パスなので `--force` なしでも毎回クリーンになる(CI パイプで繰り返し `--output` を叩く用途を想定)。
- **D3**(atomic書き込み)は見送り。README にトレードオフとして明記(VitePress/TypeDoc/Sphinx等の同格ツールも同様の非atomic書き込みを採用)。

なお issue タイトルの `artgraph graph --output` は現行コマンド名 `artgraph scan --output` の旧称(`graph` コマンドは `scan` に統合済み)。対象コード(`writeStaticExport`)自体は現行 main に対して指摘通り有効だったため、その前提で対応した。

## Change type

- [x] fix (bug fix)

## Testing

- [x] Existing tests pass (`pnpm -r test` — unit 1404 / e2e 36、全green)
- [x] Added tests: `T-graph-serve-3`(管理外ファイルがある場合の拒否 + `--force` 上書き)、`T-graph-serve-4`(stale vendor ファイルの自動掃除)
- [x] `pnpm typecheck` / `pnpm knip` / `pnpm build` すべて通過(pre-push hook 経由で確認済み)
- [x] 実際に `dist/cli.js` を手動実行し、拒否メッセージ・`--force` 上書き・vendor 掃除の3パターンを確認

## Breaking change

- [ ] Yes
- [x] No

`--output` を新規ディレクトリ、または index.html/app.js/vendor/cytoscape.min.js のみのディレクトリに向けている既存ユーザーには挙動変化なし。それ以外のファイルが混在するディレクトリに向けていたユーザーのみ、次回実行時に `--force` が必要になる。

## Notes

D3(atomic書き込み)は今回のスコープ外。必要であれば別issueとして切り出す想定。


---
_Generated by [Claude Code](https://claude.ai/code/session_017M6Q1o6qrsvJ2efK5SobeX)_