### PR TITLE
chore(oss-hardening): pin CI actions to SHA, add Scorecard + npm publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
         # goal.
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -108,24 +108,24 @@ jobs:
       matrix:
         pm: [npm, pnpm, bun, deno]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
           cache: pnpm
 
       - if: matrix.pm == 'bun'
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           # Pin to the 1.3.x line the SC-006 research was validated against;
           # patch updates are still picked up automatically.
           bun-version: 1.3.x
 
       - if: matrix.pm == 'deno'
-        uses: denoland/setup-deno@v2
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
         with:
           # Pin to the 2.9.x line the SC-006 research was validated against;
           # patch updates are still picked up automatically.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: npm publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for npm Trusted Publishing: GitHub mints a short-lived OIDC
+      # token that npm exchanges for a publish credential scoped to this
+      # exact repo + workflow. No NPM_TOKEN secret is stored anywhere.
+      #
+      # One-time setup (npmjs.com, before this workflow can publish):
+      # Package settings -> Trusted Publisher -> GitHub Actions ->
+      #   repository: ShintaroMorimoto/artgraph
+      #   workflow filename: publish.yml
+      # If the `artgraph` package name has never been published before,
+      # npm may require a first manual `npm publish` to claim the name
+      # before Trusted Publisher can be configured — check npm's current
+      # docs at https://docs.npmjs.com/trusted-publishers if this step
+      # rejects an unpublished package name.
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      # Trusted Publishing requires a recent npm CLI (>=11.5.1); Node 22's
+      # bundled npm may be older, so make sure we're on latest.
+      - run: npm install -g npm@latest
+
+      # `npm publish` runs the `prepublishOnly` script (rm dist / build /
+      # check-versions / test:unit / test:e2e) automatically as an npm
+      # lifecycle hook — no separate step needed here.
+      - name: Publish
+        run: npm publish --access public --provenance

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,48 @@
+name: Scorecard supply-chain analysis
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '30 1 * * 6'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publishes the score to the public Scorecard API / badge.
+          # Requires the repo to be public — a private repo silently
+          # fails this step, which is expected while pre-launch.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@e8e8e51caba890f74f97e228d00b0b81b666ee4c # v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -78,11 +78,6 @@ Continue with **Quickstart** below.
 
 ## Quickstart
 
-> **Pre-release**: artgraph is not yet on npm. Until `v0.1.0` ships, install from the GitHub repo
-> (e.g. `npm install -D ShintaroMorimoto/artgraph` / `pnpm add -D github:ShintaroMorimoto/artgraph` /
-> `bun add -d github:ShintaroMorimoto/artgraph`). The plain `artgraph` registry name in the commands
-> below will start resolving once the first release is published.
-
 > **Platforms**: macOS and Linux — including **WSL2** on Windows. Native Windows
 > (PowerShell / cmd) is **not supported**; see the [Windows note](#windows-note).
 


### PR DESCRIPTION
## Summary

Prep work toward going public + shipping `v0.1.0` to npm (#121), covering the code-side parts of #90 and #121:

- Pin all third-party Actions in `ci.yml` by commit SHA instead of mutable major-version tags (`actions/checkout`, `pnpm/action-setup`, `actions/setup-node`, `oven-sh/setup-bun`, `denoland/setup-deno`). SHAs were resolved directly from each action's current tag via `git ls-remote`. Dependabot will keep proposing SHA bumps going forward (`github-actions` ecosystem is already configured in `dependabot.yml`).
- Add `.github/workflows/scorecard.yml` (OpenSSF Scorecard). `publish_results: true` only takes effect once the repo is public — the public Scorecard API/badge doesn't track private repos.
- Add `.github/workflows/publish.yml` for npm release, using **npm Trusted Publishing (OIDC)** instead of a stored `NODE_AUTH_TOKEN` secret — no long-lived npm credential is ever persisted in GitHub. Requires a one-time Trusted Publisher link on npmjs.com (repo + workflow filename) before first use; see in-file comment for the fallback if that can't be configured pre-first-publish.
- Drop the README "Pre-release: not yet on npm" notice ahead of the `v0.1.0` release.

Related issues: #90 (workflow hardening), #121 (npm publish / pre-release removal).

## Change type

- [x] chore / build / ci (toolchain)
- [x] docs (documentation only) — README pre-release notice

## Testing

- [x] Existing tests pass (`pnpm test:unit`, `pnpm test:e2e` — all green via pre-push hook)
- [x] Ran `pnpm knip` and `pnpm typecheck`
- [x] Validated new/edited YAML workflow syntax
- [ ] Added tests — not applicable (CI/workflow config + docs only, no application code changed)

## Breaking change

- [x] No

## Notes

- `scorecard.yml`'s SARIF upload and `publish.yml`'s npm Trusted Publishing both assume the repo has gone public and the relevant GitHub security features (Code scanning) have been enabled — tracked separately under #89/#88.
- The Tag ruleset for `v*` mentioned in #90 is a GitHub Settings UI action, not a code change, and is expected to be blocked until the repo is public (same Rulesets gate as #88).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LmFS9csq9jFCihjtucaT2J)_