### PR TITLE
fix(parser): computeLineHasCode で Unicode 空白 (U+3000 等) を空白扱いにする (closes #190)

### DIFF
--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -551,7 +551,11 @@ function computeLineHasCode(
     const end = line < numLines ? lineStarts[line] : content.length;
     for (let i = start; i < end; i++) {
       const ch = content[i];
-      if (ch === " " || ch === "\t" || ch === "\r" || ch === "\n") continue;
+      // Match any Unicode whitespace (\s covers U+3000 etc.) — otherwise a
+      // stray full-width space on an otherwise blank line stops the upward
+      // leading-trivia walk and a `// @impl` above it silently falls back to
+      // file attribution. See issue #190.
+      if (/\s/.test(ch)) continue;
       if (inComment[i]) continue;
       hasCode[line] = true;
       break;

--- a/tests/barrel-reexport.test.ts
+++ b/tests/barrel-reexport.test.ts
@@ -109,18 +109,28 @@ describe("#177 (a) leading-comment @impl binds to the following export symbol", 
     expect(implSourcesFor(parseOne("src/c.ts"), "REQ-004")).toEqual(["file:src/c.ts"]);
   });
 
-  it("treats a Unicode-whitespace-only line (U+3000, IME mishap) as blank so the walk reaches @impl (#190)", () => {
-    // A stray full-width space (U+3000) on an otherwise blank line between
-    // `// @impl` and `export …` used to be treated as a code line, stopping
-    // the upward walk and silently binding the tag to the file. `\s` matches
-    // U+3000 and the walk continues.
-    makeRepo({
-      "src/jp.ts": `// @impl REQ-701\n　\nexport function validateToken(t: string) {\n  return !!t;\n}\n`,
+  // A stray Unicode-whitespace-only line between `// @impl` and `export …`
+  // used to be treated as a code line, stopping the upward walk and silently
+  // binding the tag to the file. `\s` matches Unicode whitespace so the walk
+  // continues. Parameterized across representative code points that are the
+  // realistic pain sources: U+3000 (JP IME mishap), U+00A0 (non-breaking
+  // space from browser copy-paste), U+2028 (LSEP embedded in a string
+  // pasted from odd editors). Covers issue #190 more broadly than the
+  // single-char report and pins the guarantee across the whole `\s` class.
+  for (const [name, whitespace] of [
+    ["U+3000 (ideographic space)", "　"],
+    ["U+00A0 (no-break space)", " "],
+    ["U+2028 (line separator)", " "],
+  ] as const) {
+    it(`treats a ${name}-only line as blank so the walk reaches @impl (#190)`, () => {
+      makeRepo({
+        "src/jp.ts": `// @impl REQ-701\n${whitespace}\nexport function validateToken(t: string) {\n  return !!t;\n}\n`,
+      });
+      expect(implSourcesFor(parseOne("src/jp.ts"), "REQ-701")).toEqual([
+        "symbol:src/jp.ts#validateToken",
+      ]);
     });
-    expect(implSourcesFor(parseOne("src/jp.ts"), "REQ-701")).toEqual([
-      "symbol:src/jp.ts#validateToken",
-    ]);
-  });
+  }
 
   it("does not change the symbol node contentHash (hash span stays the declaration)", () => {
     // With and without a leading comment, `validateToken`'s hash is identical —

--- a/tests/barrel-reexport.test.ts
+++ b/tests/barrel-reexport.test.ts
@@ -109,6 +109,19 @@ describe("#177 (a) leading-comment @impl binds to the following export symbol", 
     expect(implSourcesFor(parseOne("src/c.ts"), "REQ-004")).toEqual(["file:src/c.ts"]);
   });
 
+  it("treats a Unicode-whitespace-only line (U+3000, IME mishap) as blank so the walk reaches @impl (#190)", () => {
+    // A stray full-width space (U+3000) on an otherwise blank line between
+    // `// @impl` and `export …` used to be treated as a code line, stopping
+    // the upward walk and silently binding the tag to the file. `\s` matches
+    // U+3000 and the walk continues.
+    makeRepo({
+      "src/jp.ts": `// @impl REQ-701\n　\nexport function validateToken(t: string) {\n  return !!t;\n}\n`,
+    });
+    expect(implSourcesFor(parseOne("src/jp.ts"), "REQ-701")).toEqual([
+      "symbol:src/jp.ts#validateToken",
+    ]);
+  });
+
   it("does not change the symbol node contentHash (hash span stays the declaration)", () => {
     // With and without a leading comment, `validateToken`'s hash is identical —
     // proves attribution widening never leaks into the hashed span (INV-L4 /


### PR DESCRIPTION
## Summary

`// @impl` の leading-comment 上方向 walk が空白1文字の行で誤って停止し、JP locale で全角空白(IME 誤打鍵)の混じった空行が「code あり」と判定されて tag が silent に file 帰属していた。

`ch === " " || ...` の ASCII 空白リストを `/\s/.test(ch)` に置換して Unicode 空白 (U+00A0 / U+2028 / U+2029 / U+3000 等) を空白扱いにする。

Closes #190

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm exec vitest run` — 1435 pass / 5 skip)
- [x] Added tests where needed — regression テスト: U+3000 のみの行を挟んだ `// @impl` + `export function` が `symbol:src/jp.ts#validateToken` に到達することを pin (`tests/barrel-reexport.test.ts`)
- [x] Ran typecheck (`pnpm exec tsc --noEmit`)

## Breaking change

- [ ] Yes (described below)
- [x] No

symbol contentHash / lock bytes 不変 (hash span は宣言のまま)。JP locale で silent に fail-open していた case が正しく symbol に bind するようになる。

## Notes

PR #180 (issue #177) からの follow-up。BND-Medium-5 / D8 として整理された低 severity のバグ。

---
_Generated by [Claude Code](https://claude.ai/code/session_016e4rKG12xb9oRvVNEPMCNA)_