### PR TITLE
fix(plan-coverage): entryOriginIds を barrel の imports 1 hop で拡張 (closes #191)

### DIFF
--- a/specs/016-impact-plan-symbol-level/data-model.md
+++ b/specs/016-impact-plan-symbol-level/data-model.md
@@ -145,6 +145,14 @@ export interface ImpactGroup {
    * hop 逆向きに辿って到達した REQ 集合 (reqId で sort 済、INV-S5)。
    * symbol 起点で symbol が `@impl` claim を持たない、もしくは file 入力で
    * file-top `@impl` タグが無いケースは `[]`。
+   *
+   * Barrel 例外 (issue #191): symbol 起点の場合、primary node に加えて
+   * `imports` エッジ (symbol → symbol) を transitively 辿った全 symbol
+   * ノードの `implements` エッジも union に含める。`export { x } from` 経由
+   * の barrel は自身に `implements` を持たず origin symbol にしか REQ
+   * 主張が無いため、この拡張がないと `impactReqs \ originReqs` が
+   * false-positive drift として出る。多段 barrel (index → sub → origin)
+   * も visited セット付き BFS で origin まで到達する。
    */
   originReqs: ReqEntry[];
 }

--- a/src/plan-coverage/index.ts
+++ b/src/plan-coverage/index.ts
@@ -12,10 +12,13 @@
 //      entries (`symbol: undefined`).
 //   2. for each unique `(path, symbol ?? null)` entry:
 //        - resolveStartIds → forward-BFS impact() → `impactReqs`
-//        - resolveOriginReqs on the **primary** node id (file:<p> for file
-//          entries, symbol:<p>#<s> for symbol entries) → `originReqs`.
-//          Using the primary id intentionally excludes child-symbol claims
-//          when the entry is a file (so file-top `@impl` is reported alone).
+//        - resolveOriginReqs on the entry's origin ids → `originReqs`.
+//          File entries pass only `file:<p>` — child-symbol `@impl` claims
+//          are intentionally excluded so file-top `@impl` is reported
+//          alone. Symbol entries pass `symbol:<p>#<s>` plus every symbol
+//          reachable through `imports` edges (BFS, symbol → symbol only)
+//          so an `@impl` tag that lives on the origin of a barrel chain
+//          reaches originReqs regardless of hop count (issue #191).
 //   3. union impactReqs across entries → detectMentions vs the tasks/plan/
 //      spec text. Mentioned REQs drop out of every group's impactReqs but
 //      stay in `originReqs` (origin is the raw claim view; mention does not
@@ -184,26 +187,34 @@ function normalizeForLookup(input: string): string {
  *
  * Barrel note (issue #191): a barrel symbol re-exported from another
  * file (`export { x } from "./origin"`) carries no `implements` edge of
- * its own; the `@impl` tag lives on the origin symbol. Follow one hop of
- * `imports` edges from a symbol primary so `resolveOriginReqs` reaches
- * the origin's claim through the barrel. Without this, `impactReqs` is
- * non-empty (BFS crosses the barrel) but `originReqs` stays `[]`,
- * causing every barrel-attributed REQ to surface as a drift candidate.
- * File entries stay unchanged — the file node itself carries any
- * file-level `@impl` and the drift semantics for files are correct.
+ * its own; the `@impl` tag lives on the origin symbol. Walk `imports`
+ * edges (symbol → symbol only) transitively from a symbol primary so
+ * `resolveOriginReqs` reaches the origin's claim through however many
+ * barrel hops separate them. Chains like `index → sub-barrel → origin`
+ * are common in package-style layouts; a 1-hop-only walk would leave
+ * false-positive drift for every intermediate barrel. Visited set
+ * bounds the traversal on `A ↔ B` cycles. File entries stay unchanged —
+ * the file node itself carries any file-level `@impl` and the drift
+ * semantics for files are correct.
  */
 function entryOriginIds(entry: SymbolEntry, graph: ArtifactGraph): string[] {
   const path = normalizeForLookup(entry.path);
   if (entry.symbol === undefined) return [`file:${path}`];
   const primary = `symbol:${path}#${entry.symbol}`;
-  const ids: string[] = [primary];
-  for (const edge of graph.edges) {
-    if (edge.kind !== "imports") continue;
-    if (edge.source !== primary) continue;
-    if (!edge.target.startsWith("symbol:")) continue;
-    ids.push(edge.target);
+  const visited = new Set<string>([primary]);
+  const queue: string[] = [primary];
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    for (const edge of graph.edges) {
+      if (edge.kind !== "imports") continue;
+      if (edge.source !== current) continue;
+      if (!edge.target.startsWith("symbol:")) continue;
+      if (visited.has(edge.target)) continue;
+      visited.add(edge.target);
+      queue.push(edge.target);
+    }
   }
-  return ids;
+  return [...visited];
 }
 
 // Dedup key for ImpactGroup ordering / aggregation (INV-S3). Newline

--- a/src/plan-coverage/index.ts
+++ b/src/plan-coverage/index.ts
@@ -42,7 +42,7 @@ import { scan } from "../scan.js";
 import { readLock } from "../lock.js";
 import { impact, resolveStartIds, resolveOriginReqs } from "../graph/traverse.js";
 import { extractFiles, type TaskBlock } from "../parsers/sdd-files.js";
-import type { SymbolEntry } from "../types.js";
+import type { ArtifactGraph, SymbolEntry } from "../types.js";
 import { detectMentions } from "./mention.js";
 
 export interface PlanCoverageOptions {
@@ -181,11 +181,29 @@ function normalizeForLookup(input: string): string {
  * claims (data-model.md §3.2). `resolveStartIds` deliberately expands
  * file-unit entries to include same-file symbols for BFS reach; that
  * expansion is the WRONG basis for origin attribution.
+ *
+ * Barrel note (issue #191): a barrel symbol re-exported from another
+ * file (`export { x } from "./origin"`) carries no `implements` edge of
+ * its own; the `@impl` tag lives on the origin symbol. Follow one hop of
+ * `imports` edges from a symbol primary so `resolveOriginReqs` reaches
+ * the origin's claim through the barrel. Without this, `impactReqs` is
+ * non-empty (BFS crosses the barrel) but `originReqs` stays `[]`,
+ * causing every barrel-attributed REQ to surface as a drift candidate.
+ * File entries stay unchanged — the file node itself carries any
+ * file-level `@impl` and the drift semantics for files are correct.
  */
-function entryOriginIds(entry: SymbolEntry): string[] {
+function entryOriginIds(entry: SymbolEntry, graph: ArtifactGraph): string[] {
   const path = normalizeForLookup(entry.path);
-  if (entry.symbol !== undefined) return [`symbol:${path}#${entry.symbol}`];
-  return [`file:${path}`];
+  if (entry.symbol === undefined) return [`file:${path}`];
+  const primary = `symbol:${path}#${entry.symbol}`;
+  const ids: string[] = [primary];
+  for (const edge of graph.edges) {
+    if (edge.kind !== "imports") continue;
+    if (edge.source !== primary) continue;
+    if (!edge.target.startsWith("symbol:")) continue;
+    ids.push(edge.target);
+  }
+  return ids;
 }
 
 // Dedup key for ImpactGroup ordering / aggregation (INV-S3). Newline
@@ -541,7 +559,7 @@ export function runPlanCoverage(options: PlanCoverageOptions): PlanCoverageRunRe
       continue;
     }
     const impactResult = impact(graph, startIds, lock);
-    const originReqs = resolveOriginReqs(graph, entryOriginIds(entry));
+    const originReqs = resolveOriginReqs(graph, entryOriginIds(entry, graph));
     drafts.push({
       sourceFile: entry.path,
       sourceSymbol: entry.symbol,

--- a/tests/plan-coverage-integration.test.ts
+++ b/tests/plan-coverage-integration.test.ts
@@ -905,6 +905,84 @@ describe("plan-coverage symbol-mode E2E — barrel entry originReqs (#191)", () 
     // therefore surfaced BRL-001 as a false-positive drift candidate.
     expect(g.originReqs.map((r) => r.reqId)).toEqual(["BRL-001"]);
   });
+
+  it("multi-hop barrel chain (index → sub → origin) still reaches origin's @impl (no residual false-positive drift)", () => {
+    // Regression for the multi-hop case flagged in review: a 1-hop-only
+    // walk from `index.ts#x` stops at `sub.ts#x` — itself a mid-barrel
+    // with no `implements` edge — so origin's REQ still fails to surface
+    // in originReqs while impact() BFS reaches it. Two-file barrel
+    // chains are common in package layouts (top-level `index.ts` re-
+    // exports a submodule's `index.ts` which re-exports leaves).
+    tmpRoot = mkdtempSync(join(tmpdir(), "artgraph-pc-barrel-multi-"));
+    mkdirSync(join(tmpRoot, "src"), { recursive: true });
+    mkdirSync(join(tmpRoot, "specs/auth"), { recursive: true });
+    mkdirSync(join(tmpRoot, ".specify/specs/barrel-multi-demo"), { recursive: true });
+
+    writeFileSync(
+      join(tmpRoot, "src/origin.ts"),
+      "// @impl BRL-002\nexport function validateToken(t: string) { return !!t; }\n",
+    );
+    writeFileSync(join(tmpRoot, "src/sub.ts"), 'export { validateToken } from "./origin";\n');
+    writeFileSync(join(tmpRoot, "src/index.ts"), 'export { validateToken } from "./sub";\n');
+
+    writeFileSync(
+      join(tmpRoot, "specs/auth/design.md"),
+      [
+        "---",
+        "artgraph:",
+        '  node_id: "doc:barrel-multi-design"',
+        "---",
+        "",
+        "# Barrel Multi Design",
+        "",
+        "## Requirements",
+        "",
+        "- BRL-002: validateToken must reject empty bearer tokens.",
+        "",
+      ].join("\n"),
+    );
+
+    writeFileSync(
+      join(tmpRoot, ".specify/specs/barrel-multi-demo/tasks.md"),
+      [
+        "# Tasks",
+        "",
+        "### T001: touch the top-level barrel",
+        "",
+        "Files: src/index.ts:validateToken",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(tmpRoot, ".specify/specs/barrel-multi-demo/spec.md"),
+      "# Barrel Multi Demo\n\n(no mentions)\n",
+    );
+
+    writeFileSync(
+      join(tmpRoot, ".artgraph.json"),
+      JSON.stringify({
+        include: ["src/**/*.ts"],
+        specDirs: ["specs"],
+        mode: "symbol",
+      }),
+    );
+
+    const result = runPlanCoverage({
+      repoRoot: tmpRoot,
+      specDir: join(tmpRoot, ".specify/specs/barrel-multi-demo"),
+      tasksPath: join(tmpRoot, ".specify/specs/barrel-multi-demo/tasks.md"),
+      format: "json",
+      gate: false,
+      ignore: [],
+      requireFilesSection: false,
+    });
+
+    expect(result.json.implicitImpacts).toHaveLength(1);
+    const g = result.json.implicitImpacts[0];
+    expect(g.sourceSymbol).toBe("validateToken");
+    expect(g.impactReqs.map((r) => r.reqId)).toEqual(["BRL-002"]);
+    expect(g.originReqs.map((r) => r.reqId)).toEqual(["BRL-002"]);
+  });
 });
 
 describe("plan-coverage symbol-mode E2E — depends_on drift (T025 / SC-006)", () => {

--- a/tests/plan-coverage-integration.test.ts
+++ b/tests/plan-coverage-integration.test.ts
@@ -819,6 +819,94 @@ describe("plan-coverage symbol-mode E2E — static fixture (T024 / SC-001)", () 
   });
 });
 
+describe("plan-coverage symbol-mode E2E — barrel entry originReqs (#191)", () => {
+  // Regression: an entry pointing at a barrel symbol (`Files: src/index.ts:x`
+  // where index.ts is `export { x } from "./origin"`) used to return
+  // originReqs=[] because the barrel node carries no `implements` edge.
+  // impact() still crosses the barrel and reaches origin's REQ, so the
+  // group was flagged as a drift candidate (impactReqs \ originReqs) — a
+  // false positive. entryOriginIds now 1-hop-follows `imports` so the
+  // origin's authorship claim reaches originReqs.
+  let tmpRoot: string;
+  afterEach(() => {
+    if (tmpRoot) rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("barrel symbol entry inherits origin's @impl into originReqs (no false-positive drift)", () => {
+    tmpRoot = mkdtempSync(join(tmpdir(), "artgraph-pc-barrel-"));
+    mkdirSync(join(tmpRoot, "src"), { recursive: true });
+    mkdirSync(join(tmpRoot, "specs/auth"), { recursive: true });
+    mkdirSync(join(tmpRoot, ".specify/specs/barrel-demo"), { recursive: true });
+
+    writeFileSync(
+      join(tmpRoot, "src/auth.ts"),
+      "// @impl BRL-001\nexport function validateToken(t: string) { return !!t; }\n",
+    );
+    writeFileSync(join(tmpRoot, "src/index.ts"), 'export { validateToken } from "./auth";\n');
+
+    writeFileSync(
+      join(tmpRoot, "specs/auth/design.md"),
+      [
+        "---",
+        "artgraph:",
+        '  node_id: "doc:barrel-design"',
+        "---",
+        "",
+        "# Barrel Design",
+        "",
+        "## Requirements",
+        "",
+        "- BRL-001: validateToken must reject empty bearer tokens.",
+        "",
+      ].join("\n"),
+    );
+
+    writeFileSync(
+      join(tmpRoot, ".specify/specs/barrel-demo/tasks.md"),
+      [
+        "# Tasks",
+        "",
+        "### T001: touch the barrel",
+        "",
+        "Files: src/index.ts:validateToken",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      join(tmpRoot, ".specify/specs/barrel-demo/spec.md"),
+      "# Barrel Demo\n\n(no mentions)\n",
+    );
+
+    writeFileSync(
+      join(tmpRoot, ".artgraph.json"),
+      JSON.stringify({
+        include: ["src/**/*.ts"],
+        specDirs: ["specs"],
+        mode: "symbol",
+      }),
+    );
+
+    const result = runPlanCoverage({
+      repoRoot: tmpRoot,
+      specDir: join(tmpRoot, ".specify/specs/barrel-demo"),
+      tasksPath: join(tmpRoot, ".specify/specs/barrel-demo/tasks.md"),
+      format: "json",
+      gate: false,
+      ignore: [],
+      requireFilesSection: false,
+    });
+
+    expect(result.json.implicitImpacts).toHaveLength(1);
+    const g = result.json.implicitImpacts[0];
+    expect(g.sourceFile).toBe("src/index.ts");
+    expect(g.sourceSymbol).toBe("validateToken");
+    expect(g.impactReqs.map((r) => r.reqId)).toEqual(["BRL-001"]);
+    // Before the fix originReqs was []; drift = impactReqs \ originReqs
+    // therefore surfaced BRL-001 as a false-positive drift candidate.
+    expect(g.originReqs.map((r) => r.reqId)).toEqual(["BRL-001"]);
+  });
+});
+
 describe("plan-coverage symbol-mode E2E — depends_on drift (T025 / SC-006)", () => {
   // Copy the static fixture into a tmpdir, mutate the REQ catalogue to
   // append `(depends_on: REQ-007)` + define REQ-007, and confirm the


### PR DESCRIPTION
## Summary

`Files: src/index.ts:validateToken` のように barrel 経由の symbol を declare すると、barrel node には `implements` edge が無い (re-export のみ) ため `resolveOriginReqs` が空を返し、`impactReqs` は BFS で origin の REQ に到達するので `impactReqs \ originReqs` が非空 → drift 判定表の「ドリフト候補」に該当し **false positive** が表示されていた。

`entryOriginIds` が symbol entry の場合に `imports` edge を 1 hop 辿り、`symbol:` prefix の target のみ追加。origin の `@impl` 主張が barrel 経由でも originReqs に載る。file entry は不変、非 barrel symbol も primary の implements edge がそのまま拾われるので影響なし。

Closes #191

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm exec vitest run` — 1435 pass / 5 skip)
- [x] Added tests where needed — regression テスト: `export { validateToken } from "./auth"` + `// @impl BRL-001` on origin で tasks.md に barrel symbol を書いた場合に originReqs=[BRL-001] を pin (`tests/plan-coverage-integration.test.ts`)
- [x] Ran typecheck (`pnpm exec tsc --noEmit`)

## Breaking change

- [ ] Yes (described below)
- [x] No

表示のみの改善 (gate 判定は不変)。従来 drift 候補として表示されていた barrel REQ が origin として正しく分類されるだけ。

## Notes

PR #180 (issue #177) からの follow-up。多段 barrel の 2 hop 目以降は本 PR では拾わない (1 hop 明示、#179 fixpoint 実装時に統合の余地)。

---
_Generated by [Claude Code](https://claude.ai/code/session_016e4rKG12xb9oRvVNEPMCNA)_