### PR TITLE
fix(parser): TSImportEqualsDeclaration を extractImports に追加し fail-open を閉じる (closes #187)

### DIFF
--- a/src/parse-cache.ts
+++ b/src/parse-cache.ts
@@ -60,7 +60,11 @@ export interface ParseCacheData {
 // now binds to symbols; named/aliased barrel re-exports materialize
 // per-symbol nodes/edges). Bumping the version cold-invalidates every cached
 // fragment so a warm cache from a pre-fix build cannot serve stale edges.
-const SCHEMA_VERSION = 2;
+// v3 (issue #187): `extractImports` now emits a file-grain import edge for
+// `import = require(...)` / `export import = require(...)` — previously
+// these produced no edges at all. Bump so a warm cache from a pre-fix
+// build cannot serve stale empty edges for files that use CJS-style TS.
+const SCHEMA_VERSION = 3;
 const CACHE_RELDIR = join("node_modules", ".cache", "artgraph");
 const CACHE_FILENAME = "parse-cache.json";
 

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -796,6 +796,20 @@ function extractImports(
         // grain by the builder's phantom-repair pass (issue #177 follow-up
         // tracks true per-symbol star precision).
         reexportRefs.push({ specifier: stmt.source.value, named: [] });
+      } else if (
+        stmt.type === "TSImportEqualsDeclaration" &&
+        stmt.moduleReference.type === "TSExternalModuleReference"
+      ) {
+        // `import m = require("./m")` (CJS-style TS). Treat as a namespace
+        // import so symbol mode falls back to a file-grain edge — the
+        // require target has no named specifiers to route per-symbol
+        // through, and its origin uses `export =` which we cannot bind to
+        // a specific export name. This closes the pre-existing fail-open
+        // where consumer edges were empty entirely (issue #187).
+        const specifier = stmt.moduleReference.expression?.value;
+        if (typeof specifier === "string") {
+          importRefs.push({ specifier, hasDefault: false, hasNamespace: true, named: [] });
+        }
       }
     }
   } else {

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -796,19 +796,40 @@ function extractImports(
         // grain by the builder's phantom-repair pass (issue #177 follow-up
         // tracks true per-symbol star precision).
         reexportRefs.push({ specifier: stmt.source.value, named: [] });
-      } else if (
-        stmt.type === "TSImportEqualsDeclaration" &&
-        stmt.moduleReference.type === "TSExternalModuleReference"
-      ) {
+      } else {
         // `import m = require("./m")` (CJS-style TS). Treat as a namespace
         // import so symbol mode falls back to a file-grain edge — the
         // require target has no named specifiers to route per-symbol
-        // through, and its origin uses `export =` which we cannot bind to
-        // a specific export name. This closes the pre-existing fail-open
-        // where consumer edges were empty entirely (issue #187).
-        const specifier = stmt.moduleReference.expression?.value;
-        if (typeof specifier === "string") {
-          importRefs.push({ specifier, hasDefault: false, hasNamespace: true, named: [] });
+        // through, and its origin uses `export =` which extractSymbols
+        // does not materialize (no local symbols on TSExportAssignment),
+        // so the origin's `@impl` stays at file grain regardless. Closes
+        // issue #187's fail-open.
+        //
+        // The declaration appears in TWO AST shapes: as a top-level
+        // `TSImportEqualsDeclaration`, and — when written as `export
+        // import m = require(...)` — wrapped in `ExportNamedDeclaration
+        // { declaration: TSImportEqualsDeclaration, source: null }`. The
+        // wrapped form is not caught by the earlier `stmt.source` branch
+        // (source is null) so it needs its own path here.
+        //
+        // Known limit: files with fatal syntax errors take the
+        // `staticImports` fallback below, and oxc's module record only
+        // tracks ESM shape — CJS-style `import = require` in a broken
+        // file still fails open. Acceptable regression baseline: the
+        // pre-fix behavior was ALWAYS fail-open, so this is strictly no
+        // worse.
+        const eq =
+          stmt.type === "TSImportEqualsDeclaration"
+            ? stmt
+            : stmt.type === "ExportNamedDeclaration" &&
+                stmt.declaration?.type === "TSImportEqualsDeclaration"
+              ? stmt.declaration
+              : undefined;
+        if (eq && eq.moduleReference.type === "TSExternalModuleReference") {
+          const specifier = eq.moduleReference.expression?.value;
+          if (typeof specifier === "string") {
+            importRefs.push({ specifier, hasDefault: false, hasNamespace: true, named: [] });
+          }
         }
       }
     }

--- a/tests/barrel-reexport.test.ts
+++ b/tests/barrel-reexport.test.ts
@@ -567,3 +567,37 @@ describe("#177 INV-L4 — barrel graphs are byte-stable across builds", () => {
     expect(importEdge?.target).toBe("symbol:src/star.ts#validateToken");
   });
 });
+
+// ---------------------------------------------------------------------------
+// #187 — TSImportEqualsDeclaration (CJS-style TS) fail-open closed
+// ---------------------------------------------------------------------------
+
+describe("#187 CJS-style TS: import = require() emits at least a file-grain import edge", () => {
+  it("produces a file-grain imports edge from consumer to the required module (was silently []) — closes fail-open", () => {
+    // `import m = require("./m")` used to be handled by neither
+    // ImportDeclaration nor Export*Declaration branches of extractImports,
+    // so the consumer ended up with edges=[] and no path to the origin's
+    // REQs. The new TSImportEqualsDeclaration branch now maps it to a
+    // namespace-style file-grain edge — enough to close the total
+    // fail-open. Per-symbol resolution stays out of scope (`export =`
+    // has no export name to route through).
+    makeRepo({
+      "src/m.ts": "// @impl REQ-011\nconst foo = () => 1;\nexport = foo;\n",
+      "src/c.ts": 'import m = require("./m");\nexport const use = m;\n',
+    });
+    const frag = parseOne("src/c.ts");
+    const importEdges = frag.edges.filter(
+      (e) => e.kind === "imports" && e.source === "file:src/c.ts",
+    );
+    expect(importEdges.map((e) => e.target)).toEqual(["file:src/m.ts"]);
+  });
+
+  it("BFS from consumer reaches REQ-011 on the origin (file-grain)", () => {
+    const root = makeRepo({
+      "specs/req.md": "# R\n\n- REQ-011: cjs style\n",
+      "src/m.ts": "// @impl REQ-011\nconst foo = () => 1;\nexport = foo;\n",
+      "src/c.ts": 'import m = require("./m");\nexport const use = m;\n',
+    });
+    expect(impactReqs(root, "src/c.ts")).toEqual(["REQ-011"]);
+  });
+});

--- a/tests/barrel-reexport.test.ts
+++ b/tests/barrel-reexport.test.ts
@@ -600,4 +600,21 @@ describe("#187 CJS-style TS: import = require() emits at least a file-grain impo
     });
     expect(impactReqs(root, "src/c.ts")).toEqual(["REQ-011"]);
   });
+
+  it('also handles `export import m = require("./m")` (wrapped in ExportNamedDeclaration)', () => {
+    // OXC wraps this form as `ExportNamedDeclaration { declaration:
+    // TSImportEqualsDeclaration, source: null }`. A branch that only
+    // matched top-level `TSImportEqualsDeclaration` missed it and the
+    // consumer edge list came back empty — the same fail-open the plain
+    // form used to have. Pin the wrapped form so we don't regress.
+    makeRepo({
+      "src/m.ts": "// @impl REQ-012\nconst foo = () => 1;\nexport = foo;\n",
+      "src/c.ts": 'export import m = require("./m");\nexport const use = m;\n',
+    });
+    const frag = parseOne("src/c.ts");
+    const importEdges = frag.edges.filter(
+      (e) => e.kind === "imports" && e.source === "file:src/c.ts",
+    );
+    expect(importEdges.map((e) => e.target)).toEqual(["file:src/m.ts"]);
+  });
 });


### PR DESCRIPTION
## Summary

`import m = require("./m")` は symbol mode の extractImports が ImportDeclaration / Export*Declaration のみ handle していたため edge を一切生成せず、consumer から origin の REQ に **完全に到達不能** (true fail-open) だった。oxc 移行 (#159) 以前からの pre-existing。

`TSImportEqualsDeclaration` + `moduleReference.type === TSExternalModuleReference` の分岐を追加し namespace-style (file 粒度) の ImportRef を push。symbol mode の namespace 経路 (line 841-847) が `file:<target>` edge を張り、BFS が origin の @impl 主張に到達できる。

`export =` 側は origin symbol に export 名を bind できない (`default`/named いずれでもない) ため per-symbol は本 PR の対象外。file 粒度で fail-open を閉じるのが最小 fix。

Closes #187

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm exec vitest run` — 1436 pass / 5 skip)
- [x] Added tests where needed — 2件: (1) parseOne fragment で `file:src/m.ts` edge が 1本張ること、(2) buildGraph + impact() で consumer から REQ-011 に到達すること (`tests/barrel-reexport.test.ts`)
- [x] Ran typecheck (`pnpm exec tsc --noEmit`)

## Breaking change

- [ ] Yes (described below)
- [x] No

従来 edge=[] だった CJS-style TS consumer が file 粒度で REQ に到達するようになる。gate が「今まで見えなかった依存」を検出できるようになるが、これは意図した挙動。

## Notes

PR #180 (issue #177) からの follow-up (隣接 issue)。Cluster C2 (Confirmed High, frequency 補正で実運用頻度は低)。`export =` 側 origin の per-symbol 化は要検討で本 PR には含めず。

---
_Generated by [Claude Code](https://claude.ai/code/session_016e4rKG12xb9oRvVNEPMCNA)_