### PR TITLE
fix(release): release-please bootstrap-sha を現在の main tip に更新

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,7 @@
       "package-name": "artgraph",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
-      "bootstrap-sha": "43c31b29c54fc409f56a84e7eed983713151eba3",
+      "bootstrap-sha": "ffe249b7d25f070ad8becf119e40147675c69e38",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## Summary
- `release-please-config.json` の `bootstrap-sha` が dangling な SHA を指したままだった問題を修正
- 履歴書き換え（docs/internal 退避のための filter-repo 実行 + その後の別作業によるさらなる rewrite）で、参照先コミットが現在の `main` 履歴から失われていた
- `bootstrap-sha` を現在の `main` tip (`ffe249b`) に更新し、release-please が次回実行時に正しく基準点を認識できるようにする

## Test plan
- [ ] release-please workflow が次に main へ push された時、Release PR が正常に生成されることを確認