### PR TITLE
feat(ci): CodeQL code scanning workflow を追加

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '30 3 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: github/codeql-action/init@e8e8e51caba890f74f97e228d00b0b81b666ee4c # v3
+        with:
+          languages: javascript-typescript
+
+      - uses: github/codeql-action/analyze@e8e8e51caba890f74f97e228d00b0b81b666ee4c # v3
+        with:
+          category: '/language:javascript-typescript'


### PR DESCRIPTION
## Summary
- public リポジトリで無料になった GHAS を利用し、JavaScript/TypeScript 向け CodeQL 解析を追加
- main push / PR / 週次スケジュール（毎週月曜 3:30 UTC）でスキャン
- `github/codeql-action` は scorecard.yml の upload-sarif と同一 SHA (v3) で pin

Closes #89（CodeQL 以外の項目は既に enabled 済み）

## Test plan
- [ ] PR マージ後、Actions タブで CodeQL workflow が実行されることを確認
- [ ] Security > Code scanning alerts に結果が反映されることを確認