### PR TITLE
fix(test): baseline.test.ts の macOS tmpdir symlink 起因の CI 誤爆を修正

### DIFF
--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync, utimesSync } from "node:fs";
+import {
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  utimesSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -199,7 +207,13 @@ describe("pruneStaleWorktrees liveness (A1)", () => {
     // Named after OUR OWN pid — trivially alive for the whole test, so this
     // exercises the general `isProcessAlive` liveness check (not just the
     // `pid === process.pid` fast path).
-    const liveWt = track(mkdtempSync(join(tmpdir(), `artgraph-baseline-${process.pid}-`)));
+    // realpathSync: on macOS, tmpdir() is under a symlink (/var/folders/...
+    // -> /private/var/folders/...); `git worktree add` records the
+    // resolved path, so comparing against the raw mkdtemp path would
+    // spuriously fail `baselineWorktrees()`'s `toContain` checks below.
+    const liveWt = track(
+      realpathSync(mkdtempSync(join(tmpdir(), `artgraph-baseline-${process.pid}-`))),
+    );
     execFileSync("git", ["worktree", "add", "--detach", liveWt, "HEAD"], {
       cwd: dir,
       stdio: "pipe",
@@ -218,7 +232,9 @@ describe("pruneStaleWorktrees liveness (A1)", () => {
     const config = loadConfig(dir);
     // No liveness signal available for this naming — must be judged on
     // mtime alone, and "just created" must never be reclaimed.
-    const staleWt = track(mkdtempSync(join(tmpdir(), "artgraph-baseline-")));
+    // realpathSync: see the liveWt comment above — git resolves symlinked
+    // tmpdirs (macOS) before recording the worktree path.
+    const staleWt = track(realpathSync(mkdtempSync(join(tmpdir(), "artgraph-baseline-"))));
     execFileSync("git", ["worktree", "add", "--detach", staleWt, "HEAD"], {
       cwd: dir,
       stdio: "pipe",


### PR DESCRIPTION
## Summary
- `tests/baseline.test.ts` の `pruneStaleWorktrees liveness (A1)` テスト2件が macOS CI でのみ失敗していた問題を修正
- 原因: `liveWt` / `staleWt` を Node の `mkdtempSync(tmpdir())` の生パス（macOS では `/var/folders/...` というシンボリックリンク側）のまま `baselineWorktrees()`（`git worktree list --porcelain` の出力）と比較していたため、git が worktree 登録時に内部で realpath 解決した結果（`/private/var/folders/...`）と文字列が一致せず assertion が失敗
- 本体の `pruneStaleWorktrees`（`src/baseline.ts`）は既に `realpathSync` で両者を正規化しており、**product 側のバグではない**（テストの比較ロジックのみの問題）
- `liveWt` / `staleWt` の生成時に `realpathSync` でラップして解消

## Background
`main-protection` ruleset が `macos-latest` job を必須チェックにしているため、この修正がマージされるまで他の PR（#205, #206）も含めて一切マージできない状態でした。

## Test plan
- [x] ローカル (Linux) で `tests/baseline.test.ts` 全 21 tests pass 確認済み
- [x] `pnpm typecheck` green
- [ ] macOS CI job が green になることを確認