### PR TITLE
fix(release): release-please のタグ形式を release-tags ruleset と一致させる

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "package-name": "artgraph",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
       "bootstrap-sha": "ffe249b7d25f070ad8becf119e40147675c69e38",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },


### PR DESCRIPTION
## Summary
- `release-please-config.json` に `"include-component-in-tag": false` を追加
- デフォルト設定だと release-please は `artgraph-v0.1.0` のようなタグを作るが、`release-tags` ruleset は `refs/tags/v*` しか保護対象にしていないため保護漏れになっていた
- `v0.1.0` のような bare 形式に変更し、既存 ruleset と一致させる

## Background
PR #208（release-please の自動生成 Release PR）の compare リンクで `artgraph-v0.1.0...artgraph-v0.2.0` という形式を確認し発覚。#208 は bootstrap-sha の別問題もあり close 済み。

## Test plan
- [ ] 次回 release-please が生成する Release PR の compare リンクが `v0.1.0...v0.x.x` 形式になることを確認