### PR TITLE
test(e2e): release workflow で ARTGRAPH_E2E_PACK=1 を有効化

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,3 +51,5 @@ jobs:
       # lifecycle hook — no separate step needed here.
       - name: Publish
         run: npm publish --access public --provenance
+        env:
+          ARTGRAPH_E2E_PACK: "1"


### PR DESCRIPTION
## Summary

`tests/e2e/bin.e2e.test.ts` の `describe.skipIf(!RUN_PACK)("e2e: npm pack + install", ...)` は「`ARTGRAPH_E2E_PACK=1` (used by the release workflow before npm publish)」とコメントしているが、実際にはどの workflow / `package.json` script にも配線されておらず、v0.1.0 直前の release でも silent skip されていた。

`publish.yml` の Publish step に env として `ARTGRAPH_E2E_PACK=1` を追加。`npm publish` の lifecycle で `prepublishOnly → pnpm test:e2e` に env が伝播し、npm publish 直前で pack + install テストが走るようになる。

Closes #211

## Change type

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [x] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm test:unit` — 71 files, 1606 tests passed, 5 skipped)
- [x] Ran `pnpm build`
- [x] **pack + install テストを local で dry-run 検証**: `ARTGRAPH_E2E_PACK=1 pnpm exec vitest run --config vitest.e2e.config.ts tests/e2e/bin.e2e.test.ts` → 3/3 passed (~6.5s)
- [ ] Added tests where needed — 該当なし (workflow env の追加のみ)
- [ ] Ran `pnpm -r knip` — pre-push hook で通過

pack+install テスト自体は `pnpm test:e2e` を `ARTGRAPH_E2E_PACK=1` 付きで local 実行することで検証可能だが、~10–30s + `pnpm pack` の副作用が発生するため CI (`ci.yml`) には配線せず、release workflow 限定とした。

## Breaking change

- [ ] Yes (described below)
- [x] No

## Notes

**選択したアプローチ**: workflow 側で env を追加する方針を採用 (issue の choice A)。
- コメントの記述と実装を一致させ、release 前の pack 破損を早期検出できる
- CI に配線しない理由: 毎 PR で ~30s 追加は頻度過剰
- `package.json` の script に埋め込まない理由: env の scope は workflow レイヤーが自然

**副作用**: publish workflow の実行時間が pack + install ぶん延びる (~10–30s)。pack が壊れていた場合は `npm publish` 手前で止まるため、これは望ましい挙動 (`prepublishOnly` は npm registry 接触前の hook のため partial-publish 状態にはならない)。

**残存リスク (Minor)**: GH Actions ランナー + Trusted Publishing (OIDC) 環境固有の組合せは実 release まで検証不能。ただし失敗時は publish 手前で cleanly abort するため、最初の release で問題が出た場合は再試行で復旧可能。
