### PR TITLE
ci(pack-smoke): release-please PR で pack + install テストを検証する workflow を追加

### DIFF
--- a/.github/workflows/pack-smoke.yml
+++ b/.github/workflows/pack-smoke.yml
@@ -34,8 +34,12 @@ jobs:
   pack-smoke:
     name: pack-smoke
     # All non-release-please PRs get an instant no-op skip here.
-    if: startsWith(github.head_ref, 'release-please--branches--')
+    # PR-author gate hardens against branch-name spoofing from forks/misuse.
+    if: >-
+      startsWith(github.head_ref, 'release-please--branches--')
+      && github.event.pull_request.user.login == 'github-actions[bot]'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/pack-smoke.yml
+++ b/.github/workflows/pack-smoke.yml
@@ -1,0 +1,55 @@
+name: pack-smoke
+
+# Mirrors publish.yml's `prepublishOnly` pack path: `npm publish` runs
+# `pnpm pack` + a real `npm install` of the packed tarball (gated behind
+# ARTGRAPH_E2E_PACK=1, see #211 / #228) as part of its `prepublishOnly`
+# lifecycle hook. That path had never once run in CI before #228 shipped —
+# its first execution was during an actual `npm publish` attempt (#230).
+#
+# This job re-runs test:e2e with ARTGRAPH_E2E_PACK=1 directly, but only on
+# the release-please Release PR (branch `release-please--branches--*`), so
+# pack breakage is caught before the Release PR is merged and published,
+# not during the publish itself.
+#
+# Not wired into ci.yml: running the pack+install path on every PR would add
+# cost for no signal on ordinary PRs (per ci.yml's own design-policy comment
+# on keeping matrix/step cost proportional to what changed). Scoping to the
+# release-please branch keeps the extra cost to once per release.
+#
+# Closes #230.
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: pack-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pack-smoke:
+    name: pack-smoke
+    # All non-release-please PRs get an instant no-op skip here.
+    if: startsWith(github.head_ref, 'release-please--branches--')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - run: pnpm test:e2e
+        env:
+          ARTGRAPH_E2E_PACK: "1"

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
     include: ["tests/e2e/**/*.test.ts"],
     exclude: ["**/node_modules/**", "**/dist/**", "**/.claude/**"],
     testTimeout: 60000,
+    // beforeAll in tests/e2e/bin.e2e.test.ts pack path may take up to 5 min
+    // (pnpm pack spawnSync timeout 120s + npm install spawnSync timeout 180s).
+    // Vitest default hookTimeout (10s) is far too short and would kill the
+    // hook before its own internal timeouts fire. See PR #231 review.
+    hookTimeout: 300000,
     pool: "forks",
     forks: { singleFork: true },
     fileParallelism: false,


### PR DESCRIPTION
## Summary

PR #228 (issue #211) で `publish.yml` の Publish step に `ARTGRAPH_E2E_PACK=1` を配線し、`npm publish` の `prepublishOnly` lifecycle で pack + install テストが release 直前に走るようになった。しかしこの経路は **CI で一度も実行されたことがない状態** で release-blocking な `prepublishOnly` に組み込まれており、初回実行が real release 中というリスクが残っていた (#230 の起票理由)。

`.github/workflows/pack-smoke.yml` を新規追加し、**release-please Release PR (`release-please--branches--*`) 限定** で `pnpm test:e2e` + `ARTGRAPH_E2E_PACK=1` を実行する。これで Release PR merge 前に pack 経路が validate 済みの状態になる。

Closes #230

## Change type

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [x] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] `pnpm build && pnpm test:unit` passed (71 files, 1606 tests / 5 skipped)
- [x] Pre-push hook: knip / `test:e2e` (41 passed / 2 skipped) / `tsc --noEmit` 全 green
- [x] YAML syntax validation: `python3 -c "import yaml; yaml.safe_load(...)"` → OK
- [x] `pnpm test:e2e` with `ARTGRAPH_E2E_PACK=1` の pack + install 経路は #228 レビューで実測 3/3 pass (~6.5s)
- [ ] Added tests where needed — 該当なし (workflow のみ)

**この PR そのものは release-please PR ではないので `pack-smoke` job は `if:` gate によって skip される**。次に release-please PR が open されたときが本 workflow の実地初回実行になる。

## Breaking change

- [ ] Yes (described below)
- [x] No

## Notes

**設計判断**:
- **release-please PR 限定**: `if: startsWith(github.head_ref, 'release-please--branches--') && github.event.pull_request.user.login == 'github-actions[bot]'` の 2 段 gate。ci.yml (毎 PR job) に混ぜず独立 workflow file とすることで責務分離
- **`startsWith`**: 現在の release-please 設定 (`separate-pull-requests: false`) では `release-please--branches--main` 固定だが、将来 monorepo 化しても catch できるよう prefix match
- **PR author gate**: branch prefix だけだと fork ユーザーが `release-please--branches--*` を作れば runner 時間を浪費できる。PR author が `github-actions[bot]` であることも要求
- **`pnpm test:e2e` そのまま実行**: pack test のみ targeted 実行ではなく `prepublishOnly` と同じコマンドで release codepath を厳密再現
- **CI (`ci.yml`) 側には配線しない**: 毎 PR で ~30s は頻度過剰 (`ci.yml` の設計方針コメントとも整合)

## レビュー指摘対応 (commit `0a7e834`)

敵対的レビューで検出された 3 件の対応済み:

1. **[MAJOR] vitest hookTimeout 不足**: `vitest.e2e.config.ts` の `hookTimeout` が未設定で vitest default (10s) にフォールバックしていた。`bin.e2e.test.ts:65` の `beforeAll` は `pnpm pack` (spawnSync 120s) + `npm install` (spawnSync 180s) を回すため、CI cold cache 時に vitest が hook を kill する flake 余地があった。`hookTimeout: 300000` を追加。
2. **[MINOR] actor gate 追加**: 上記の PR author 制約を追加。
3. **[MINOR] `timeout-minutes: 15` 追加**: job の GH Actions default (360 min) stall を防止。

## ⚠️ Follow-up: branch protection の必須 check 追加要

**maintainer 権限で GitHub 上の main branch protection ruleset に `pack-smoke` を必須 status check として追加してください** (repo settings → Rules → main → Require status checks to pass → `pack-smoke`)。これを行わないと job は走るものの結果が無視され Release PR を merge 可能になり、本 PR の目的 (#230 解消) が silently 達成されない状態になります。

コード変更範囲外のため本 PR には含めていません。

## 副作用

release-please Release PR がひとつ open されるたびに ~30s の pack-smoke job が走る。頻度は月〜週レベルなので影響は無視できる。

## Related

- #211 (元 issue), #228 (release workflow への env 配線)
