### PR TITLE
fix(impact): contains 辺を順方向限定にし同一 spec 兄弟 REQ の巻き込みを解消 (#215)

### DIFF
--- a/.agents/skills/_shared/output-schema.md
+++ b/.agents/skills/_shared/output-schema.md
@@ -79,10 +79,11 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```json
 {
   "affectedFiles": ["src/foo.ts"],                     // source file paths transitively impacted
-  "affectedDocs": ["doc:012-skills-expansion/spec.md"],// doc node IDs (prefixed "doc:")
-  "affectedReqs": ["FR-001", "012-skills-expansion/FR-002"],
+  "affectedDocs": ["doc:012-skills-expansion/spec.md"],// parent spec doc(s) of reached REQs/tasks — attribution context, not BFS reach (spec 019)
+  "impactReqs": ["FR-001", "012-skills-expansion/FR-002"], // REQ ids reached by the forward BFS
+  "originReqs": ["FR-001"],                            // REQ ids the start ids @impl-claim directly (1-hop reverse implements)
   "affectedTasks": ["012-skills-expansion/T001"],      // task node IDs (may be empty)
-  "drifted": [                                         // same DriftEntry shape as check
+  "drifted": [                                         // same DriftEntry shape as check; attributed affectedDocs entries participate too
     {
       "nodeId": "FR-001",
       "kind": "req",
@@ -90,7 +91,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
       "currentHash": "def456…"
     }
   ],
-  "summary": {                                         // optional — present when impact() returns one
+  "summary": {                                         // always present
     "docs": 12,
     "reqs": 39,
     "files": 0,
@@ -98,6 +99,8 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
   }
 }
 ```
+
+Array order is not part of the contract — treat every array as an unordered set. Same-spec sibling REQs with no code or dependency link of their own never appear in `impactReqs` (spec 019); when you need whole-feature context, open the spec file listed in `affectedDocs` instead.
 
 ## artgraph rename
 

--- a/.agents/skills/artgraph-impact/SKILL.md
+++ b/.agents/skills/artgraph-impact/SKILL.md
@@ -78,10 +78,13 @@ The result carries the **dual-axis impact view** plus drift:
 | --- | --- |
 | `impactReqs` | REQs reached by forward BFS from the start ids (file or symbol nodes) |
 | `originReqs` | REQs the start ids `@impl`-claim directly (1-hop reverse `implements` edge) |
-| `affectedFiles` / `affectedDocs` / `affectedTasks` | other node kinds reached by the same BFS |
-| `drifted` | lockfile drift on any of the above |
+| `affectedFiles` / `affectedTasks` | other node kinds reached by the same BFS |
+| `affectedDocs` | parent spec doc(s) of every reached REQ/task, attached as **context**, not BFS reach (see below) |
+| `drifted` | lockfile drift on any of the above (`affectedDocs` entries included) |
 
 See [output schema](../_shared/output-schema.md) for the full field shapes.
+
+**Same-spec siblings are not blast radius.** `impactReqs` only contains REQs the edit actually reaches — through code (`@impl`, `imports`) or explicit spec relations (`depends_on` / `derives_from`). A REQ that merely lives in the same `spec.md` as a reached REQ, with no code or dependency link of its own, does **not** appear in `impactReqs` / `affectedFiles` / `drifted`, even under the common Spec Kit / Kiro layout of "one spec.md, many REQs". Its parent spec doc still shows up in `affectedDocs` so you can open that file for full feature context, but don't treat every REQ inside it as touched by this edit — cite only the REQs actually listed in `impactReqs`.
 
 ### 4. Inject into the response
 

--- a/.agents/skills/artgraph-plan-coverage/SKILL.md
+++ b/.agents/skills/artgraph-plan-coverage/SKILL.md
@@ -66,6 +66,8 @@ Compare per-entry `impactReqs` against `originReqs`:
 - **Sets equal → no drift.** Claim and reach match.
 - **`originReqs \ impactReqs` non-empty → orphan claim.** Out of scope for this Skill — `artgraph check --gate` (Stop hook) will report it.
 
+**Same-spec siblings are not implicit impacts.** `impactReqs` only lists REQs the `Files:` entry actually reaches — via code (`@impl`, `imports`) or explicit spec relations (`depends_on` / `derives_from`). A REQ that merely lives in the same `spec.md` as a reached REQ does **not** appear here just because they're co-located, even under the common "one spec.md, many REQs" layout. If you need the full feature context (not just this entry's blast radius), run `artgraph impact` on the same file/symbol and read its `affectedDocs` — that points at the spec file(s) worth opening directly.
+
 #### Diagnostics
 
 - `unresolvedSymbol` (`{ sourceFile, symbol, line }`): the file exists but no exported symbol of that name was found in the symbol-mode graph. The entry is excluded from `implicitImpacts`. Ask the user whether to (a) fix the typo, (b) drop the `:symbol` suffix to fall back to file unit, or (c) re-run `<PM-exec> scan` if the symbol was just added.

--- a/.claude/skills/_shared/output-schema.md
+++ b/.claude/skills/_shared/output-schema.md
@@ -79,10 +79,11 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```json
 {
   "affectedFiles": ["src/foo.ts"],                     // source file paths transitively impacted
-  "affectedDocs": ["doc:012-skills-expansion/spec.md"],// doc node IDs (prefixed "doc:")
-  "affectedReqs": ["FR-001", "012-skills-expansion/FR-002"],
+  "affectedDocs": ["doc:012-skills-expansion/spec.md"],// parent spec doc(s) of reached REQs/tasks — attribution context, not BFS reach (spec 019)
+  "impactReqs": ["FR-001", "012-skills-expansion/FR-002"], // REQ ids reached by the forward BFS
+  "originReqs": ["FR-001"],                            // REQ ids the start ids @impl-claim directly (1-hop reverse implements)
   "affectedTasks": ["012-skills-expansion/T001"],      // task node IDs (may be empty)
-  "drifted": [                                         // same DriftEntry shape as check
+  "drifted": [                                         // same DriftEntry shape as check; attributed affectedDocs entries participate too
     {
       "nodeId": "FR-001",
       "kind": "req",
@@ -90,7 +91,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
       "currentHash": "def456…"
     }
   ],
-  "summary": {                                         // optional — present when impact() returns one
+  "summary": {                                         // always present
     "docs": 12,
     "reqs": 39,
     "files": 0,
@@ -98,6 +99,8 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
   }
 }
 ```
+
+Array order is not part of the contract — treat every array as an unordered set. Same-spec sibling REQs with no code or dependency link of their own never appear in `impactReqs` (spec 019); when you need whole-feature context, open the spec file listed in `affectedDocs` instead.
 
 ## artgraph rename
 

--- a/.claude/skills/artgraph-impact/SKILL.md
+++ b/.claude/skills/artgraph-impact/SKILL.md
@@ -78,10 +78,13 @@ The result carries the **dual-axis impact view** plus drift:
 | --- | --- |
 | `impactReqs` | REQs reached by forward BFS from the start ids (file or symbol nodes) |
 | `originReqs` | REQs the start ids `@impl`-claim directly (1-hop reverse `implements` edge) |
-| `affectedFiles` / `affectedDocs` / `affectedTasks` | other node kinds reached by the same BFS |
-| `drifted` | lockfile drift on any of the above |
+| `affectedFiles` / `affectedTasks` | other node kinds reached by the same BFS |
+| `affectedDocs` | parent spec doc(s) of every reached REQ/task, attached as **context**, not BFS reach (see below) |
+| `drifted` | lockfile drift on any of the above (`affectedDocs` entries included) |
 
 See [output schema](../_shared/output-schema.md) for the full field shapes.
+
+**Same-spec siblings are not blast radius.** `impactReqs` only contains REQs the edit actually reaches — through code (`@impl`, `imports`) or explicit spec relations (`depends_on` / `derives_from`). A REQ that merely lives in the same `spec.md` as a reached REQ, with no code or dependency link of its own, does **not** appear in `impactReqs` / `affectedFiles` / `drifted`, even under the common Spec Kit / Kiro layout of "one spec.md, many REQs". Its parent spec doc still shows up in `affectedDocs` so you can open that file for full feature context, but don't treat every REQ inside it as touched by this edit — cite only the REQs actually listed in `impactReqs`.
 
 ### 4. Inject into the response
 

--- a/.claude/skills/artgraph-plan-coverage/SKILL.md
+++ b/.claude/skills/artgraph-plan-coverage/SKILL.md
@@ -66,6 +66,8 @@ Compare per-entry `impactReqs` against `originReqs`:
 - **Sets equal → no drift.** Claim and reach match.
 - **`originReqs \ impactReqs` non-empty → orphan claim.** Out of scope for this Skill — `artgraph check --gate` (Stop hook) will report it.
 
+**Same-spec siblings are not implicit impacts.** `impactReqs` only lists REQs the `Files:` entry actually reaches — via code (`@impl`, `imports`) or explicit spec relations (`depends_on` / `derives_from`). A REQ that merely lives in the same `spec.md` as a reached REQ does **not** appear here just because they're co-located, even under the common "one spec.md, many REQs" layout. If you need the full feature context (not just this entry's blast radius), run `artgraph impact` on the same file/symbol and read its `affectedDocs` — that points at the spec file(s) worth opening directly.
+
 #### Diagnostics
 
 - `unresolvedSymbol` (`{ sourceFile, symbol, line }`): the file exists but no exported symbol of that name was found in the symbol-mode graph. The entry is excluded from `implicitImpacts`. Ask the user whether to (a) fix the typo, (b) drop the `:symbol` suffix to fall back to file unit, or (c) re-run `<PM-exec> scan` if the symbol was just added.

--- a/.cursor/skills/_shared/output-schema.md
+++ b/.cursor/skills/_shared/output-schema.md
@@ -79,10 +79,11 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```json
 {
   "affectedFiles": ["src/foo.ts"],                     // source file paths transitively impacted
-  "affectedDocs": ["doc:012-skills-expansion/spec.md"],// doc node IDs (prefixed "doc:")
-  "affectedReqs": ["FR-001", "012-skills-expansion/FR-002"],
+  "affectedDocs": ["doc:012-skills-expansion/spec.md"],// parent spec doc(s) of reached REQs/tasks — attribution context, not BFS reach (spec 019)
+  "impactReqs": ["FR-001", "012-skills-expansion/FR-002"], // REQ ids reached by the forward BFS
+  "originReqs": ["FR-001"],                            // REQ ids the start ids @impl-claim directly (1-hop reverse implements)
   "affectedTasks": ["012-skills-expansion/T001"],      // task node IDs (may be empty)
-  "drifted": [                                         // same DriftEntry shape as check
+  "drifted": [                                         // same DriftEntry shape as check; attributed affectedDocs entries participate too
     {
       "nodeId": "FR-001",
       "kind": "req",
@@ -90,7 +91,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
       "currentHash": "def456…"
     }
   ],
-  "summary": {                                         // optional — present when impact() returns one
+  "summary": {                                         // always present
     "docs": 12,
     "reqs": 39,
     "files": 0,
@@ -98,6 +99,8 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
   }
 }
 ```
+
+Array order is not part of the contract — treat every array as an unordered set. Same-spec sibling REQs with no code or dependency link of their own never appear in `impactReqs` (spec 019); when you need whole-feature context, open the spec file listed in `affectedDocs` instead.
 
 ## artgraph rename
 

--- a/.cursor/skills/artgraph-impact/SKILL.md
+++ b/.cursor/skills/artgraph-impact/SKILL.md
@@ -78,10 +78,13 @@ The result carries the **dual-axis impact view** plus drift:
 | --- | --- |
 | `impactReqs` | REQs reached by forward BFS from the start ids (file or symbol nodes) |
 | `originReqs` | REQs the start ids `@impl`-claim directly (1-hop reverse `implements` edge) |
-| `affectedFiles` / `affectedDocs` / `affectedTasks` | other node kinds reached by the same BFS |
-| `drifted` | lockfile drift on any of the above |
+| `affectedFiles` / `affectedTasks` | other node kinds reached by the same BFS |
+| `affectedDocs` | parent spec doc(s) of every reached REQ/task, attached as **context**, not BFS reach (see below) |
+| `drifted` | lockfile drift on any of the above (`affectedDocs` entries included) |
 
 See [output schema](../_shared/output-schema.md) for the full field shapes.
+
+**Same-spec siblings are not blast radius.** `impactReqs` only contains REQs the edit actually reaches — through code (`@impl`, `imports`) or explicit spec relations (`depends_on` / `derives_from`). A REQ that merely lives in the same `spec.md` as a reached REQ, with no code or dependency link of its own, does **not** appear in `impactReqs` / `affectedFiles` / `drifted`, even under the common Spec Kit / Kiro layout of "one spec.md, many REQs". Its parent spec doc still shows up in `affectedDocs` so you can open that file for full feature context, but don't treat every REQ inside it as touched by this edit — cite only the REQs actually listed in `impactReqs`.
 
 ### 4. Inject into the response
 

--- a/.cursor/skills/artgraph-plan-coverage/SKILL.md
+++ b/.cursor/skills/artgraph-plan-coverage/SKILL.md
@@ -66,6 +66,8 @@ Compare per-entry `impactReqs` against `originReqs`:
 - **Sets equal → no drift.** Claim and reach match.
 - **`originReqs \ impactReqs` non-empty → orphan claim.** Out of scope for this Skill — `artgraph check --gate` (Stop hook) will report it.
 
+**Same-spec siblings are not implicit impacts.** `impactReqs` only lists REQs the `Files:` entry actually reaches — via code (`@impl`, `imports`) or explicit spec relations (`depends_on` / `derives_from`). A REQ that merely lives in the same `spec.md` as a reached REQ does **not** appear here just because they're co-located, even under the common "one spec.md, many REQs" layout. If you need the full feature context (not just this entry's blast radius), run `artgraph impact` on the same file/symbol and read its `affectedDocs` — that points at the spec file(s) worth opening directly.
+
 #### Diagnostics
 
 - `unresolvedSymbol` (`{ sourceFile, symbol, line }`): the file exists but no exported symbol of that name was found in the symbol-mode graph. The entry is excluded from `implicitImpacts`. Ask the user whether to (a) fix the typo, (b) drop the `:symbol` suffix to fall back to file unit, or (c) re-run `<PM-exec> scan` if the symbol was just added.

--- a/.github/skills/_shared/output-schema.md
+++ b/.github/skills/_shared/output-schema.md
@@ -79,10 +79,11 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```json
 {
   "affectedFiles": ["src/foo.ts"],                     // source file paths transitively impacted
-  "affectedDocs": ["doc:012-skills-expansion/spec.md"],// doc node IDs (prefixed "doc:")
-  "affectedReqs": ["FR-001", "012-skills-expansion/FR-002"],
+  "affectedDocs": ["doc:012-skills-expansion/spec.md"],// parent spec doc(s) of reached REQs/tasks — attribution context, not BFS reach (spec 019)
+  "impactReqs": ["FR-001", "012-skills-expansion/FR-002"], // REQ ids reached by the forward BFS
+  "originReqs": ["FR-001"],                            // REQ ids the start ids @impl-claim directly (1-hop reverse implements)
   "affectedTasks": ["012-skills-expansion/T001"],      // task node IDs (may be empty)
-  "drifted": [                                         // same DriftEntry shape as check
+  "drifted": [                                         // same DriftEntry shape as check; attributed affectedDocs entries participate too
     {
       "nodeId": "FR-001",
       "kind": "req",
@@ -90,7 +91,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
       "currentHash": "def456…"
     }
   ],
-  "summary": {                                         // optional — present when impact() returns one
+  "summary": {                                         // always present
     "docs": 12,
     "reqs": 39,
     "files": 0,
@@ -98,6 +99,8 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
   }
 }
 ```
+
+Array order is not part of the contract — treat every array as an unordered set. Same-spec sibling REQs with no code or dependency link of their own never appear in `impactReqs` (spec 019); when you need whole-feature context, open the spec file listed in `affectedDocs` instead.
 
 ## artgraph rename
 

--- a/.github/skills/artgraph-impact/SKILL.md
+++ b/.github/skills/artgraph-impact/SKILL.md
@@ -78,10 +78,13 @@ The result carries the **dual-axis impact view** plus drift:
 | --- | --- |
 | `impactReqs` | REQs reached by forward BFS from the start ids (file or symbol nodes) |
 | `originReqs` | REQs the start ids `@impl`-claim directly (1-hop reverse `implements` edge) |
-| `affectedFiles` / `affectedDocs` / `affectedTasks` | other node kinds reached by the same BFS |
-| `drifted` | lockfile drift on any of the above |
+| `affectedFiles` / `affectedTasks` | other node kinds reached by the same BFS |
+| `affectedDocs` | parent spec doc(s) of every reached REQ/task, attached as **context**, not BFS reach (see below) |
+| `drifted` | lockfile drift on any of the above (`affectedDocs` entries included) |
 
 See [output schema](../_shared/output-schema.md) for the full field shapes.
+
+**Same-spec siblings are not blast radius.** `impactReqs` only contains REQs the edit actually reaches — through code (`@impl`, `imports`) or explicit spec relations (`depends_on` / `derives_from`). A REQ that merely lives in the same `spec.md` as a reached REQ, with no code or dependency link of its own, does **not** appear in `impactReqs` / `affectedFiles` / `drifted`, even under the common Spec Kit / Kiro layout of "one spec.md, many REQs". Its parent spec doc still shows up in `affectedDocs` so you can open that file for full feature context, but don't treat every REQ inside it as touched by this edit — cite only the REQs actually listed in `impactReqs`.
 
 ### 4. Inject into the response
 

--- a/.github/skills/artgraph-plan-coverage/SKILL.md
+++ b/.github/skills/artgraph-plan-coverage/SKILL.md
@@ -66,6 +66,8 @@ Compare per-entry `impactReqs` against `originReqs`:
 - **Sets equal → no drift.** Claim and reach match.
 - **`originReqs \ impactReqs` non-empty → orphan claim.** Out of scope for this Skill — `artgraph check --gate` (Stop hook) will report it.
 
+**Same-spec siblings are not implicit impacts.** `impactReqs` only lists REQs the `Files:` entry actually reaches — via code (`@impl`, `imports`) or explicit spec relations (`depends_on` / `derives_from`). A REQ that merely lives in the same `spec.md` as a reached REQ does **not** appear here just because they're co-located, even under the common "one spec.md, many REQs" layout. If you need the full feature context (not just this entry's blast radius), run `artgraph impact` on the same file/symbol and read its `affectedDocs` — that points at the spec file(s) worth opening directly.
+
 #### Diagnostics
 
 - `unresolvedSymbol` (`{ sourceFile, symbol, line }`): the file exists but no exported symbol of that name was found in the symbol-mode graph. The entry is excluded from `implicitImpacts`. Ask the user whether to (a) fix the typo, (b) drop the `:symbol` suffix to fall back to file unit, or (c) re-run `<PM-exec> scan` if the symbol was just added.

--- a/.kiro/skills/_shared/output-schema.md
+++ b/.kiro/skills/_shared/output-schema.md
@@ -79,10 +79,11 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```json
 {
   "affectedFiles": ["src/foo.ts"],                     // source file paths transitively impacted
-  "affectedDocs": ["doc:012-skills-expansion/spec.md"],// doc node IDs (prefixed "doc:")
-  "affectedReqs": ["FR-001", "012-skills-expansion/FR-002"],
+  "affectedDocs": ["doc:012-skills-expansion/spec.md"],// parent spec doc(s) of reached REQs/tasks — attribution context, not BFS reach (spec 019)
+  "impactReqs": ["FR-001", "012-skills-expansion/FR-002"], // REQ ids reached by the forward BFS
+  "originReqs": ["FR-001"],                            // REQ ids the start ids @impl-claim directly (1-hop reverse implements)
   "affectedTasks": ["012-skills-expansion/T001"],      // task node IDs (may be empty)
-  "drifted": [                                         // same DriftEntry shape as check
+  "drifted": [                                         // same DriftEntry shape as check; attributed affectedDocs entries participate too
     {
       "nodeId": "FR-001",
       "kind": "req",
@@ -90,7 +91,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
       "currentHash": "def456…"
     }
   ],
-  "summary": {                                         // optional — present when impact() returns one
+  "summary": {                                         // always present
     "docs": 12,
     "reqs": 39,
     "files": 0,
@@ -98,6 +99,8 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
   }
 }
 ```
+
+Array order is not part of the contract — treat every array as an unordered set. Same-spec sibling REQs with no code or dependency link of their own never appear in `impactReqs` (spec 019); when you need whole-feature context, open the spec file listed in `affectedDocs` instead.
 
 ## artgraph rename
 

--- a/.kiro/skills/artgraph-impact/SKILL.md
+++ b/.kiro/skills/artgraph-impact/SKILL.md
@@ -78,10 +78,13 @@ The result carries the **dual-axis impact view** plus drift:
 | --- | --- |
 | `impactReqs` | REQs reached by forward BFS from the start ids (file or symbol nodes) |
 | `originReqs` | REQs the start ids `@impl`-claim directly (1-hop reverse `implements` edge) |
-| `affectedFiles` / `affectedDocs` / `affectedTasks` | other node kinds reached by the same BFS |
-| `drifted` | lockfile drift on any of the above |
+| `affectedFiles` / `affectedTasks` | other node kinds reached by the same BFS |
+| `affectedDocs` | parent spec doc(s) of every reached REQ/task, attached as **context**, not BFS reach (see below) |
+| `drifted` | lockfile drift on any of the above (`affectedDocs` entries included) |
 
 See [output schema](../_shared/output-schema.md) for the full field shapes.
+
+**Same-spec siblings are not blast radius.** `impactReqs` only contains REQs the edit actually reaches — through code (`@impl`, `imports`) or explicit spec relations (`depends_on` / `derives_from`). A REQ that merely lives in the same `spec.md` as a reached REQ, with no code or dependency link of its own, does **not** appear in `impactReqs` / `affectedFiles` / `drifted`, even under the common Spec Kit / Kiro layout of "one spec.md, many REQs". Its parent spec doc still shows up in `affectedDocs` so you can open that file for full feature context, but don't treat every REQ inside it as touched by this edit — cite only the REQs actually listed in `impactReqs`.
 
 ### 4. Inject into the response
 

--- a/.kiro/skills/artgraph-plan-coverage/SKILL.md
+++ b/.kiro/skills/artgraph-plan-coverage/SKILL.md
@@ -66,6 +66,8 @@ Compare per-entry `impactReqs` against `originReqs`:
 - **Sets equal → no drift.** Claim and reach match.
 - **`originReqs \ impactReqs` non-empty → orphan claim.** Out of scope for this Skill — `artgraph check --gate` (Stop hook) will report it.
 
+**Same-spec siblings are not implicit impacts.** `impactReqs` only lists REQs the `Files:` entry actually reaches — via code (`@impl`, `imports`) or explicit spec relations (`depends_on` / `derives_from`). A REQ that merely lives in the same `spec.md` as a reached REQ does **not** appear here just because they're co-located, even under the common "one spec.md, many REQs" layout. If you need the full feature context (not just this entry's blast radius), run `artgraph impact` on the same file/symbol and read its `affectedDocs` — that points at the spec file(s) worth opening directly.
+
 #### Diagnostics
 
 - `unresolvedSymbol` (`{ sourceFile, symbol, line }`): the file exists but no exported symbol of that name was found in the symbol-mode graph. The entry is excluded from `implicitImpacts`. Ask the user whether to (a) fix the typo, (b) drop the `:symbol` suffix to fall back to file unit, or (c) re-run `<PM-exec> scan` if the symbol was just added.

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/017-check-gate-baseline-diff"
+  "feature_directory": "specs/019-impact-doc-containment"
 }

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ artgraph adds the layer *above* the code:
   TypeScript imports. No LLM in the graph, no embedding retrieval, no RAG.
 - **Per-change context routing** — `artgraph impact --diff` returns only the
   specs, docs, and tests a given change touches. Feed *that* to the agent
-  instead of the whole context file.
+  instead of the whole context file. This holds even when one `spec.md`
+  defines several requirements (the Spec Kit / Kiro default): a sibling
+  requirement with no code dependency of its own doesn't ride along just
+  because it's declared in the same file.
 - **Drift as a CI gate** — `artgraph check --gate` fails the build when a
   spec changed but the code/tests didn't. Byte-identical output on every run.
 - **Requirement IDs are the primary key** — the same `REQ-001` string is what

--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -210,6 +210,12 @@ artgraph impact src/auth.ts:validateToken --format json |
 
 典型ワークフロー例 — `Files: src/auth.ts:validateToken` を tasks.md に書いた後、spec.md で `REQ-001 depends_on REQ-007` を追加すると、次の `artgraph plan-coverage` 実行で `impactReqs = ["REQ-001", "REQ-007"]` / `originReqs = ["REQ-001"]` となり、`REQ-007` がドリフト候補として可視化されます。
 
+### 同一 spec.md 内の兄弟 REQ は blast radius に入らない (spec 019)
+
+Spec Kit / Kiro の標準構成は「1 feature = 1 spec.md に複数 REQ」です。`artgraph impact` / `artgraph plan-coverage` の `impactReqs` は、対象の file / symbol が実際にコードで到達する REQ (`@impl` / `imports` 経由) と、spec 側で明示された依存 (`depends_on` / `derives_from`) の到達先だけを含みます。**同じ spec.md に定義されているだけの兄弟 REQ は、コード上の依存が無ければ `impactReqs` / `affectedFiles` / `drifted` に混入しません。**
+
+一方、到達した REQ の親 spec doc は帰属情報として `affectedDocs` に残り続けます(`plan-coverage` にはこの帰属フィールドはありません)。その feature 全体の文脈が必要な場合は、`affectedDocs` に載っている spec ファイルを開いて読んでください — 兄弟 REQ を `impactReqs` に混ぜて渡すのではなく、必要な時に agent 自身が spec を読みに行く設計です。
+
 ### `Files:` syntax 例(symbol 含む)
 
 ```markdown

--- a/docs/skills-guide.md
+++ b/docs/skills-guide.md
@@ -214,7 +214,7 @@ artgraph impact src/auth.ts:validateToken --format json |
 
 Spec Kit / Kiro の標準構成は「1 feature = 1 spec.md に複数 REQ」です。`artgraph impact` / `artgraph plan-coverage` の `impactReqs` は、対象の file / symbol が実際にコードで到達する REQ (`@impl` / `imports` 経由) と、spec 側で明示された依存 (`depends_on` / `derives_from`) の到達先だけを含みます。**同じ spec.md に定義されているだけの兄弟 REQ は、コード上の依存が無ければ `impactReqs` / `affectedFiles` / `drifted` に混入しません。**
 
-一方、到達した REQ の親 spec doc は帰属情報として `affectedDocs` に残り続けます(`plan-coverage` にはこの帰属フィールドはありません)。その feature 全体の文脈が必要な場合は、`affectedDocs` に載っている spec ファイルを開いて読んでください — 兄弟 REQ を `impactReqs` に混ぜて渡すのではなく、必要な時に agent 自身が spec を読みに行く設計です。
+一方、到達した REQ の親 spec doc は帰属情報として `affectedDocs` に残り続け、**doc 自体は drift 判定の対象のまま**です — spec ファイルの contentHash が lock とずれていれば `drifted` に doc エントリとして現れます(`plan-coverage` にはこの帰属フィールドはありません)。その feature 全体の文脈が必要な場合は、`affectedDocs` に載っている spec ファイルを開いて読んでください — 兄弟 REQ を `impactReqs` に混ぜて渡すのではなく、必要な時に agent 自身が spec を読みに行く設計です。
 
 ### `Files:` syntax 例(symbol 含む)
 

--- a/specs/019-impact-doc-containment/plan.md
+++ b/specs/019-impact-doc-containment/plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan: impact BFS の contains 辺方向制約
+
+**Branch**: `feat/impact-doc-containment` | **Date**: 2026-07-10 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Issue [#215](https://github.com/mori-shin-x/artgraph/issues/215) / spec 019
+
+## Summary
+
+`impact()` の BFS で `contains` 辺を順方向 (doc → req|task) 限定にし、逆方向 (req|task → 親 doc) 経由の同一 spec 兄弟 REQ 巻き込みを根絶する。親 doc は BFS 完了後の帰属アトリビューション (到達 req/task → 親 doc の 1-hop 解決) で `affectedDocs` と drift 判定に温存する。US4 (`sameSpecReqs`) の deferral により **`ImpactResult` の型・JSON スキーマは完全に不変** — 変わるのは到達集合の中身だけで、変更は `src/graph/traverse.ts` の `impact()` 1 関数に閉じる。呼び出し元 3 箇所 (impact CLI / check --diff / plan-coverage) はコード変更なしで自動的に浄化され、その波及をテストで固定する。
+
+## Technical Context
+
+- **Language/Runtime**: TypeScript strict / Node.js。pnpm。テストは vitest (unit: `tests/*.test.ts`、e2e: `tests/e2e/`)。lint は oxlint / oxfmt (lefthook pre-commit)、未使用検出は knip。
+- **変更の中心**: `src/graph/traverse.ts` の `impact()`:
+  - BFS のエッジ展開ループ (現行 51-58 行): `edge.target === id` 側 (逆方向) の展開に `edge.kind !== "contains"` 条件を追加。順方向 (`edge.source === id`) は全辺種そのまま。
+  - BFS 完了後: visited 中の req / task ノードを target とする `contains` 辺の source doc を収集し、`affectedDocs` へ union (dedup)。attributed doc も lock との contentHash 比較で `drifted` 判定に含める。attributed doc からの再展開はしない。
+  - 冒頭の設計コメント (spec 014/016 由来の「bidirectional は意図」宣言、maxDepth 回避策) を spec 019 準拠に全面書き換え。
+- **呼び出し元は不変**: `src/commands/impact.ts` / `src/commands/check.ts` / `src/plan-coverage/index.ts` はコード変更不要。check のスコープ集合は `impactResult.affectedDocs` を既に取り込んでいるため、attribution 経由の doc もそのままスコープに入る。
+- **既存テストの書き換え**: 兄弟 REQ / 兄弟 task 到達を expect している既存テスト (`tests/traverse.test.ts` / check 系 / plan-coverage 系) は新セマンティクスへ期待値を反転し、PR 上で列挙する (spec 前提)。
+
+### 解決した設計判断 (詳細は spec.md の Alternatives Considered / US4 裁定注記)
+
+1. **方向制約 + 事後アトリビューション** — 経路依存 BFS (reverse contains で到達した doc を非展開マーク) は決定性の検証コストが上がるため不採用。BFS は辺種で一律に判定し、帰属は到達集合への決定的な後処理とする。
+2. **`sameSpecReqs` は Deferred** — 出力スキーマ不変という大きな単純化を得る。feature 文脈が必要な consumer は `affectedDocs` の spec を読む。
+3. **doc→task にも一律適用** — tasks.md が第 2 の(より強力な)兄弟増幅ハブであるため、修正の成立条件 (spec FR-003)。
+4. **`@impl` タグ削除境界は #229 に切り出し** — 現行でも確実には検出されておらず、本 spec の退行ではない。
+
+## Constitution Check
+
+### 原則との整合
+
+- **I. 決定的グラフ第一 (NON-NEGOTIABLE)**: ✅ BFS の決定性は維持 (visited set / queue 順序不変)。方向制約は辺種による静的条件で、訪問順に依存しない。帰属アトリビューションは到達集合に対する決定的後処理。出力順序契約 (INV-S2) 不変。
+- **II. 単一型付き4層グラフ**: ✅ ノード / エッジ型・グラフ生成 (builder) は一切変更しない。消費側 (traverse) のセマンティクスのみ。
+- **III. Spec が ID を所有、コードが claim (NON-NEGOTIABLE)**: ✅ 影響なし。
+- **IV. SDD ツール ID 直接利用**: ✅ 影響なし。
+- **V. 構造整合のみ保証 (NON-NEGOTIABLE)**: ✅ 影響なし。むしろ「blast radius = 構造的到達」の近似精度が上がる。
+
+### Engineering Hygiene Gates
+
+- `pnpm typecheck` / `pnpm test:unit` / `pnpm test:e2e` / `pnpm knip` green。
+- CHANGELOG / version は触らない (release-please 管理)。
+- dogfood テンプレート 5 agent path の byte-identical 同期テスト green (FR-013 の Skill 更新時)。
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/019-impact-doc-containment/
+├── spec.md      # 設計判断の SSOT (レビュー済み)
+├── plan.md      # 本ファイル
+└── tasks.md     # TDD タスク分解
+```
+
+### Source Code (repository root)
+
+```
+src/graph/traverse.ts            # 唯一のロジック変更点 (FR-001〜006, FR-012)
+tests/traverse.test.ts           # 単体: 方向制約・帰属・US1 シナリオ (追加 + 期待値反転)
+tests/impact-cli.test.ts         # CLI E2E: issue #215 最小再現 fixture (SC-001)
+tests/plan-coverage*.test.ts     # US2: 同一 spec 複数 REQ の二軸浄化 (FR-010)
+tests/check*.test.ts             # US3: スコープ浄化 + spec 変更経路維持 (FR-011)
+README.md / docs/skills-guide.md # FR-013 (impact セマンティクス説明の更新)
+templates/**(skills)             # FR-013 (該当記述がある場合のみ、5 path 同期)
+```
+
+## Complexity Tracking
+
+なし。単一関数の局所変更で、新規モジュール・新規依存・スキーマ変更を伴わない。
+
+## Follow-up
+
+- [#229](https://github.com/mori-shin-x/artgraph/issues/229) — `@impl` タグ削除の検出 (baseline 側グラフ辺のスコープ計算併用)。
+- [#218](https://github.com/mori-shin-x/artgraph/issues/218) — クラスメソッド粒度。本 spec 解決後に効果が観測可能になる次の支配的過剰検知源。
+- `sameSpecReqs` (spec 019 US4 スケッチ) — ドッグフーディングで実需が観測されたら再起票。
+- 「1 task に大量 REQ 列挙」パターン (Spec Kit convergence phase) のノイズ観測 (spec Edge Cases の watch item)。

--- a/specs/019-impact-doc-containment/spec.md
+++ b/specs/019-impact-doc-containment/spec.md
@@ -115,6 +115,7 @@ traversal セマンティクスの SSOT が変わるため、(a) `src/graph/trav
 - **`autoContains: false` 構成**: contains 辺が存在しないため帰属アトリビューションは空集合。従来との差分なし。
 - **lock に親 doc が存在しない場合**: 既存の drift 判定と同じく skip(`lock[id]` が無ければ判定しない)。
 - **起点自体が doc / spec パスの場合** (`artgraph impact specs/auth.md`): `resolveStartIds` の filePath fallback が doc ノードと全 req ノードを直接 seed するため、方向制約後も spec→code 方向の全展開が維持される。加えて doc ノードからの順方向 contains 展開も従来どおり機能する。
+- **seed された doc からの doc↔doc 辺経由の到達**: 起点 / diff に spec ファイルが入った場合、その doc から `depends_on` / `derives_from` (inline link / frontmatter / convention) で繋がる別 doc とその配下 REQ には従来どおり到達する (旧実装と同一挙動 — doc↔doc 辺セマンティクスは FR-014(d) でスコープ外)。US3 / FR-011 の「当該 spec の全 REQ がスコープに入る」は、この既存の doc 間到達を制限する意図ではない (PR #232 レビューで確認した列挙ギャップの補記)。
 - **req↔doc の往復による無限ループ**: 方向制約により構造的に発生しなくなる(従来は visited set で抑止していた)。
 - **1 つの task が複数 REQ を参照する場合** (`T010 ... [REQ-901, REQ-902]`): `REQ-901 → (逆implements) T010 → (順implements) REQ-902` のブリッジは**残る(意図)**。doc 同居と異なり「作者が明示的に 1 つの作業単位に束ねた」という task-tag 由来の宣言であり、因果的に意味がある。ただし Spec Kit convergence phase のような「1 task に大量の REQ 列挙」パターンがノイズ源になるかはドッグフーディングで観測する (watch item)。
 - **コードのみ diff での `@impl` タグ削除**: 削除で `implements` 辺ごと消えるため、新たに uncovered になった REQ へ到達できずスコープ外に落ちる。現行実装でも最小構成では素通りしており (doc 経由で偶然捕まる場合があるだけ)、本 spec の退行ではなく既存の境界問題。[#229](https://github.com/mori-shin-x/artgraph/issues/229) で独立に扱う (FR-014g)。

--- a/specs/019-impact-doc-containment/spec.md
+++ b/specs/019-impact-doc-containment/spec.md
@@ -18,8 +18,9 @@
 - [#122](https://github.com/mori-shin-x/artgraph/issues/122) (closed) — tag-zero impact UX。`ts-import` エッジのみの経路で req / doc ノードを経由しないため、本 spec の変更の影響を受けない。既存 brownfield E2E が回帰ガードになる。
 - spec 008 (document-graph) — doc↔doc の `derives_from` / `depends_on` 辺。本 spec は `contains` 辺のみを対象とし、doc 間辺のセマンティクスは変更しない。
 - spec 017 (check-gate-baseline-diff) — `check --diff` の scoped arrays は impact() の到達集合から計算されるため、本 spec により縮小する(US3)。
+- [#229](https://github.com/mori-shin-x/artgraph/issues/229) — コードのみ diff での `@impl` タグ削除がスコープ外に落ちる境界問題。現行でも確実には検出されておらず(doc 経由の偶然の検出のみ)、本 spec の設計レビューで切り出したフォローアップ。本 spec のスコープ外 (FR-014)。
 
-**前提**: artgraph は pre-1.0 につき、本 spec は後方互換を考慮せず traversal セマンティクスを clean に変更する。兄弟 REQ 到達を assert している既存テスト・fixture は新セマンティクスに書き直す(削除ではなく期待値の反転として明示的にレビュー可能にする)。
+**前提**: artgraph は公開済みだが 0.1 であり実利用者はいない想定。作者判断 (2026-07-10 設計レビュー) により**破壊的変更を許容**する — 後方互換・移行導線・非推奨期間は一切考慮せず、traversal セマンティクスを clean に変更する。兄弟 REQ 到達を assert している既存テスト・fixture は新セマンティクスに書き直す(削除ではなく期待値の反転として明示的にレビュー可能にする)。
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -73,7 +74,9 @@
 
 ---
 
-### User Story 4 — 兄弟 REQ の情報専用軸 `sameSpecReqs` (Priority: P2)
+### User Story 4 — 兄弟 REQ の情報専用軸 `sameSpecReqs` (Priority: Deferred — 本 spec では実装しない)
+
+> **設計レビュー裁定 (2026-07-10)**: 実装見送り。理由: (a) FR-004 の帰属アトリビューションにより「文脈が欲しければ `affectedDocs` の spec を読む」という迂回路が常に存在し、agent ワークフローはそれで足りる (Skill に 1 行書けば済む)。(b) 出力フィールドは後から足すのは非破壊だが消すのは破壊的で、非対称性は延期に有利。(c) ドッグフーディング 4 ループで文脈不足の実需は観測されておらず、困っていたのは常に文脈過多だった。絞った出力をドッグフーディングした上で、具体的なワークフローが要求したら足す。以下の記述は将来の設計スケッチとして残置する。
 
 「同じ spec の兄弟 REQ も参考情報としては見たい」ユーザー(例: agent が変更前に feature 全体の文脈を掴みたいケース)のために、`artgraph impact` の出力に `sameSpecReqs` — affected docs に含まれる REQ のうち `impactReqs` に入らなかったもの — を**情報専用の別軸**として載せる。この軸は Drift candidates に一切寄与せず、text 出力でも「Same-spec REQs (informational)」として明確に区別される。
 
@@ -93,7 +96,7 @@
 
 ### User Story 5 — ドキュメント / Skill / dogfood テンプレートの追随 (Priority: P2)
 
-traversal セマンティクスの SSOT が変わるため、(a) `src/graph/traverse.ts` 冒頭の設計コメント(旧「意図された設計」宣言)を本 spec 準拠に書き換え、(b) README / docs/skills-guide.md の impact 説明、(c) `artgraph-impact` / `artgraph-plan-coverage` Skill の出力解説(`sameSpecReqs` の読み方を含む)、(d) 5 agent path に配布される dogfood テンプレート(byte-identical 同期テストあり)を更新する。
+traversal セマンティクスの SSOT が変わるため、(a) `src/graph/traverse.ts` 冒頭の設計コメント(旧「意図された設計」宣言)を本 spec 準拠に書き換え、(b) README / docs/skills-guide.md の impact 説明、(c) `artgraph-impact` / `artgraph-plan-coverage` Skill の出力解説、(d) 5 agent path に配布される dogfood テンプレート(byte-identical 同期テストあり)を更新する。
 
 **Why this priority**: コメント・ドキュメントが旧設計を「意図」と主張したまま実装だけ変わると、次の開発者(або agent)が回帰させるリスクが高い。#215 の調査でも traverse.ts のコメントが「これはバグではなく設計」という誤誘導の起点になった。
 
@@ -113,6 +116,8 @@ traversal セマンティクスの SSOT が変わるため、(a) `src/graph/trav
 - **lock に親 doc が存在しない場合**: 既存の drift 判定と同じく skip(`lock[id]` が無ければ判定しない)。
 - **起点自体が doc / spec パスの場合** (`artgraph impact specs/auth.md`): `resolveStartIds` の filePath fallback が doc ノードと全 req ノードを直接 seed するため、方向制約後も spec→code 方向の全展開が維持される。加えて doc ノードからの順方向 contains 展開も従来どおり機能する。
 - **req↔doc の往復による無限ループ**: 方向制約により構造的に発生しなくなる(従来は visited set で抑止していた)。
+- **1 つの task が複数 REQ を参照する場合** (`T010 ... [REQ-901, REQ-902]`): `REQ-901 → (逆implements) T010 → (順implements) REQ-902` のブリッジは**残る(意図)**。doc 同居と異なり「作者が明示的に 1 つの作業単位に束ねた」という task-tag 由来の宣言であり、因果的に意味がある。ただし Spec Kit convergence phase のような「1 task に大量の REQ 列挙」パターンがノイズ源になるかはドッグフーディングで観測する (watch item)。
+- **コードのみ diff での `@impl` タグ削除**: 削除で `implements` 辺ごと消えるため、新たに uncovered になった REQ へ到達できずスコープ外に落ちる。現行実装でも最小構成では素通りしており (doc 経由で偶然捕まる場合があるだけ)、本 spec の退行ではなく既存の境界問題。[#229](https://github.com/mori-shin-x/artgraph/issues/229) で独立に扱う (FR-014g)。
 
 ## Requirements *(mandatory)*
 
@@ -122,7 +127,7 @@ traversal セマンティクスの SSOT が変わるため、(a) `src/graph/trav
 
 - **FR-001**: `impact()` の BFS は `contains` 辺を**順方向のみ** (edge.source = doc → edge.target = req|task) 辿る。逆方向 (req|task → 親 doc) はトラバースしない。
 - **FR-002**: `contains` 以外の 5 辺種 (`depends_on` / `derives_from` / `implements` / `verifies` / `imports`) の双方向トラバース、および file→symbol 展開 (spec 016 R-006 の挙動) は一切変更しない。
-- **FR-003**: 方向制約は `contains` 辺の target 種別 (req / task) を問わず一律に適用する。
+- **FR-003**: 方向制約は `contains` 辺の target 種別 (req / task) を問わず一律に適用する。**これは一貫性のためではなく修正の成立条件である**: task preset が有効なプロジェクト (Spec Kit の `T\d{3}` 等) では tasks.md の各 task が参照 REQ への `implements` 辺 (task-tag provenance) を持ち、feature の tasks.md は集合としてその feature のほぼ全 REQ を参照する。req のみ制約して task を除外すると、`REQ → (逆implements) task → (逆contains) doc:tasks.md → (順contains) 兄弟 task → (順implements) feature 全 REQ` の経路で #215 の症状がほぼ完全に復活する。
 
 #### 親 doc の帰属アトリビューション
 
@@ -130,7 +135,7 @@ traversal セマンティクスの SSOT が変わるため、(a) `src/graph/trav
 - **FR-005**: 帰属アトリビューションで追加された doc も、BFS で直接到達した doc と同様に drift 判定 (lock との contentHash 比較) の対象とする。
 - **FR-006**: 帰属アトリビューションで追加された doc から先へのグラフ展開は行わない (その doc の子 req が `impactReqs` / `affectedFiles` / `drifted` に寄与しない)。
 
-#### `sameSpecReqs` 情報軸 (P2)
+#### `sameSpecReqs` 情報軸 (Deferred — 実装対象外、将来の設計スケッチ)
 
 - **FR-007**: `sameSpecReqs` は「`affectedDocs` (BFS 到達 + 帰属アトリビューション) の contains 子 req のうち `impactReqs` に含まれないもの」と定義し、dedup + reqId 昇順で返す。
 - **FR-008**: `sameSpecReqs` は `artgraph impact` の JSON / text 出力にのみ載せる。text 出力では Impact reqs / Drift candidates と明確に区別された informational セクションとする。`sameSpecReqs` の要素は `drifted` の対象にならない。
@@ -144,16 +149,16 @@ traversal セマンティクスの SSOT が変わるため、(a) `src/graph/trav
 #### ドキュメント / Skill
 
 - **FR-012**: `src/graph/traverse.ts` 冒頭の設計コメント (spec 014/016 由来の「bidirectional は意図」宣言) を本 spec 準拠に書き換え、spec 019 を参照させる。maxDepth による回避策の記述を削除する。
-- **FR-013**: README / docs/skills-guide.md / `artgraph-impact` / `artgraph-plan-coverage` Skill テンプレートの impact 出力説明を更新し (`sameSpecReqs` の読み方を含む)、dogfood テンプレート 5 agent path の byte-identical 同期を維持する。
+- **FR-013**: README / docs/skills-guide.md / `artgraph-impact` / `artgraph-plan-coverage` Skill テンプレートの impact 出力説明を新セマンティクス (同一 spec 同居は blast radius に入らない・feature 文脈は `affectedDocs` の spec を読む) に更新し、dogfood テンプレート 5 agent path の byte-identical 同期を維持する。
 
 #### Scope exclusion (明示)
 
-- **FR-014**: 以下は本 spec のスコープ外: (a) #218 クラスメソッド粒度、(b) REQ-ID 直接入力の受理 (spec 016 FR-012 の rejection を維持)、(c) `maxDepth` のデフォルト値変更、(d) doc↔doc 辺 (`derives_from` / `depends_on`) のセマンティクス変更、(e) `contains` 辺の**生成側** (builder.ts) の変更、(f) `plan-coverage` / `check` 出力スキーマへの `sameSpecReqs` 追加。
+- **FR-014**: 以下は本 spec のスコープ外: (a) #218 クラスメソッド粒度、(b) REQ-ID 直接入力の受理 (spec 016 FR-012 の rejection を維持)、(c) `maxDepth` のデフォルト値変更、(d) doc↔doc 辺 (`derives_from` / `depends_on`) のセマンティクス変更、(e) `contains` 辺の**生成側** (builder.ts) の変更、(f) `sameSpecReqs` の実装 (Deferred — US4)、(g) コードのみ diff での `@impl` タグ削除による新規 uncovered の検出 (baseline 側グラフ辺のスコープ計算への併用 — [#229](https://github.com/mori-shin-x/artgraph/issues/229) として切り出し済み。現行でも確実には検出されていないため本 spec の退行ではない)。
 
 ### Key Entities
 
 - **`contains` 辺**: 生成 (builder.ts、provenance `structural`、doc→req|task) は不変。**消費側 (traverse) のセマンティクスのみ変更**。
-- **`ImpactResult`**: 既存フィールドの型は不変。`affectedDocs` の算出方法が「BFS 到達」から「BFS 到達 ∪ 帰属アトリビューション」に変わる。`sameSpecReqs` は CLI 層で合成する出力フィールドであり、`resolveOriginReqs` / `originReqs` と同じ責務分担に従う。
+- **`ImpactResult`**: US4 の deferral により**型・JSON フィールド構成は完全に不変**。変わるのは各フィールドの値(到達集合の中身)のみで、`affectedDocs` の算出方法が「BFS 到達」から「BFS 到達 ∪ 帰属アトリビューション」に変わる。(将来 `sameSpecReqs` を実装する場合は `resolveOriginReqs` / `originReqs` と同じ責務分担 — traverse 層ヘルパー + CLI 層合成 — に従う。)
 - **`DriftEntry`**: 型・判定ロジック不変。母集合 (visited + attributed docs) の変化のみ。
 
 ## Success Criteria *(mandatory)*
@@ -171,13 +176,13 @@ traversal セマンティクスの SSOT が変わるため、(a) `src/graph/trav
 | 案 | 内容 | 裁定 |
 |----|------|------|
 | 案 1: contains 方向制約 | BFS で doc contains を双方向に辿らない。req→doc は帰属メタデータとしてのみ扱う | **採用 (core)**。根本原因の除去。帰属は事後アトリビューション (FR-004) で温存 |
-| 案 2: `sameSpecReqs` 分離 | 兄弟 REQ を別カテゴリに分離し Drift candidates に混ぜない | **部分採用 (P2)**。案 1 の上に情報専用軸として載せる。案 1 なしの案 2 単独 (BFS は今のまま出力だけ分類) は、affectedFiles / check スコープ / plan-coverage の汚染が残るため不採用 |
+| 案 2: `sameSpecReqs` 分離 | 兄弟 REQ を別カテゴリに分離し Drift candidates に混ぜない | **採用見送り (Deferred)**。設計レビュー (2026-07-10) で実装対象外と裁定 — 理由は US4 冒頭の裁定注記を参照。案 1 なしの案 2 単独 (BFS は今のまま出力だけ分類) は、affectedFiles / check スコープ / plan-coverage の汚染が残るため元より不採用 |
 | 案 3: docs 明記のみ | 「1 spec.md 複数 REQ で impact は spec 単位」と制約を明記 | **不採用**。最も一般的な構成で中核価値提案が壊れたままになる。#177/#179/#188/spec 016 の投資も回収不能 |
 | 変形案: 経路依存 BFS | reverse contains で到達した doc を「非展開ノード」としてマークし BFS 内で処理 | **不採用**。訪問順で結果が変わりうる経路依存性を BFS に持ち込み、決定性の検証コストが上がる。事後アトリビューションが同じ出力をより単純に達成する |
 
 ## Assumptions
 
-- pre-1.0 の挙動変更として許容する (リリースノートで traversal セマンティクス変更を明示する。既存ユーザーの `impact` / `check --diff` / `plan-coverage` の出力は狭くなる方向にのみ変わる)。
+- 公開済みだが 0.1 で実利用者はいない想定。作者判断 (2026-07-10 設計レビュー) により破壊的変更を許容し、移行導線・非推奨期間は設けない。出力は狭くなる方向にのみ変わる。
 - `contains` 辺の生成は builder.ts の 1 箇所 (provenance `structural`) のみであり、方向制約の適用点は traverse 層に閉じる。
 - traverse.ts 冒頭コメントおよび spec 014/016 の「bidirectional は意図」という記述は、同一 doc 内の狭い fixture では妥当に見えたが、Spec Kit / Kiro の標準構成 (1 spec.md = 1 feature = 複数 REQ) に対する検証を欠いていた。#215 の 3 段階切り分け (dogfooding で実証) を優先し、本 spec で設計判断を更新する。
 - `visited` 集合ベースの現行 BFS 実装は方向制約後も決定的であり、出力順序の契約 (INV-S2 等) に影響しない。

--- a/specs/019-impact-doc-containment/spec.md
+++ b/specs/019-impact-doc-containment/spec.md
@@ -1,0 +1,183 @@
+# Feature Specification: impact BFS の contains 辺方向制約 — 同一 spec 兄弟 REQ の巻き込み解消
+
+**Feature Branch**: `feat/impact-doc-containment`
+
+**Created**: 2026-07-10
+
+**Status**: Draft
+
+**Input**: Issue [#215](https://github.com/mori-shin-x/artgraph/issues/215) — 「`artgraph impact <file>:<symbol>` が、コード上の依存 (import / 呼び出し) がゼロでも、対象 REQ と同じ spec ドキュメントファイルに同居している他の全 REQ を Impact reqs / Drift candidates に巻き込む。Spec Kit / Kiro の標準は『1 feature = 1 spec.md に複数 REQ』なので、この構成では symbol 単位で impact を引いても実質その feature の全 REQ が毎回返ってくることになり、"per-change context" という中核の価値提案が最も一般的なプロジェクト構成で機能しない。」
+
+**Parent issue**: [#215](https://github.com/mori-shin-x/artgraph/issues/215)
+
+**Related**:
+
+- spec 014 / spec 016 ([#104](https://github.com/mori-shin-x/artgraph/issues/104), [#107](https://github.com/mori-shin-x/artgraph/issues/107)) — 現行 BFS セマンティクス(全辺無条件双方向)の出自。`src/graph/traverse.ts` 冒頭コメントは「req → 親 doc → 兄弟 reqs への到達は意図された設計」と明記しており、**本 spec はその設計判断を上書きする**。本 spec マージ後は本 spec が traversal セマンティクスの SSOT。
+- [#177](https://github.com/mori-shin-x/artgraph/issues/177) / [#179](https://github.com/mori-shin-x/artgraph/issues/179) / [#188](https://github.com/mori-shin-x/artgraph/issues/188) — symbol-level 精度改善の系譜。doc 経由の巻き込みが支配的な現状ではこれらの効果が観測できず、本 spec が解決して初めてフルに効く。
+- [#218](https://github.com/mori-shin-x/artgraph/issues/218) — クラスメソッド粒度。本 spec 解決後に次の支配的な過剰検知源となる後続課題。本 spec のスコープ外。
+- [#122](https://github.com/mori-shin-x/artgraph/issues/122) (closed) — tag-zero impact UX。`ts-import` エッジのみの経路で req / doc ノードを経由しないため、本 spec の変更の影響を受けない。既存 brownfield E2E が回帰ガードになる。
+- spec 008 (document-graph) — doc↔doc の `derives_from` / `depends_on` 辺。本 spec は `contains` 辺のみを対象とし、doc 間辺のセマンティクスは変更しない。
+- spec 017 (check-gate-baseline-diff) — `check --diff` の scoped arrays は impact() の到達集合から計算されるため、本 spec により縮小する(US3)。
+
+**前提**: artgraph は pre-1.0 につき、本 spec は後方互換を考慮せず traversal セマンティクスを clean に変更する。兄弟 REQ 到達を assert している既存テスト・fixture は新セマンティクスに書き直す(削除ではなく期待値の反転として明示的にレビュー可能にする)。
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — symbol 起点 impact から同一 spec 兄弟 REQ を排除 (Priority: P1)
+
+ユーザーが Spec Kit 標準構成(1 つの spec.md に REQ-901 / REQ-902 を記述)で、`fnA` (`@impl REQ-901`) と `fnB` (`@impl REQ-902`) を実装している。`fnA` は `fnB` を一切呼んでいない。`artgraph impact src/sample.ts:fnA` を実行すると、Impact reqs は `REQ-901` のみ、Drift candidates にも Affected files にも `REQ-902` / `fnB` 側のファイルは現れない。一方、REQ-901 が属する spec ドキュメントは「この変更がどの spec の話か」の帰属情報として Affected docs に残り続ける。
+
+**Why this priority**: Issue #215 の存在理由そのもの。「変更に関連する REQ だけを agent に渡す」という per-change context の中核価値が、最も一般的なプロジェクト構成(1 feature = 1 spec.md に複数 REQ)で機能しない状態を解消する。spec 016 で積んだ symbol 粒度・二軸出力の投資は、doc 経由の巻き込みが支配的な現状では回収できていない。
+
+**Independent Test**: `fnA` (`@impl REQ-901`) / `fnB` (`@impl REQ-902`) が同一ファイルにあり、REQ-901 / REQ-902 が同一 spec.md にある fixture を symbol mode で scan する。`artgraph impact src/sample.ts:fnA --format json` の `impactReqs` が `["REQ-901"]` であることを assert する。
+
+**Acceptance Scenarios**:
+
+1. **Given** 同一ファイルの `fnA` (`@impl REQ-901`) / `fnB` (`@impl REQ-902`)、REQ-901/902 が同一 spec.md、fnA→fnB のコード依存なし、 **When** `artgraph impact src/sample.ts:fnA --format json`、 **Then** `impactReqs = ["REQ-901"]`。`REQ-902` は `impactReqs` / `drifted` に含まれない (issue #215 再現手順 1 の非再現)。
+2. **Given** `fnA` / `fnB` を別ファイル (`src/sample.ts` / `src/other.ts`) に分けた同構成、 **When** 同コマンド、 **Then** `impactReqs = ["REQ-901"]` かつ `affectedFiles` に `src/other.ts` が含まれない (issue #215 再現手順 2 の非再現)。
+3. **Given** 同構成で `fnA` が `fnB` を import して呼んでいる、 **When** 同コマンド、 **Then** `imports` 辺経由の到達により `REQ-902` / `src/other.ts` は**含まれる** (コード依存由来の巻き込みは正当な blast radius として維持)。
+4. **Given** シナリオ 1 の構成、 **When** 同コマンド、 **Then** `affectedDocs` に REQ-901 の親 spec doc が含まれる(帰属メタデータ)。親 doc の contentHash が lock と異なる場合は `drifted` に doc entry として現れる。
+5. **Given** REQ-901 / REQ-902 を別々の spec ファイルに分けた構成、 **When** 同コマンド、 **Then** 従来 (issue #215 再現手順 3) と同一の結果 — 挙動不変。
+6. **Given** シナリオ 1 の構成に spec 側で `REQ-901 depends_on REQ-903` (REQ-903 は別 spec) を追加、 **When** 同コマンド、 **Then** `impactReqs = ["REQ-901", "REQ-903"]` — req→req 辺経由の到達は維持され、spec 016 の二軸ドリフト検知 (`impactReqs \ originReqs`) が引き続き機能する。
+
+---
+
+### User Story 2 — plan-coverage のドリフト候補軸の浄化 (Priority: P1)
+
+ユーザーが spec 016 US1 の標準フロー(tasks.md に `Files: src/auth.ts:validateToken`)を、Spec Kit 標準構成(REQ-001 / REQ-005 / REQ-009 が**同一 spec.md** に同居)で回す。`artgraph plan-coverage --format json` の per-entry `impactReqs` にはコード依存由来の REQ のみが載り、同一 doc 同居だけを理由とする兄弟 REQ は載らない。これにより `impactReqs \ originReqs` のドリフト候補軸が「spec 側で増えた依存」だけを指すようになる。
+
+**Why this priority**: 同一 spec 内の兄弟 REQ は spec.md に定義されている時点で mention 済みとなるため `implicit` リストには出ないが、per-entry の `impactReqs` には現状混入し続け、ドリフト候補軸 (`impactReqs \ originReqs`) を常時汚染する。spec 016 が設計した二軸比較は同一 spec 複数 REQ 構成では実質使えない。US1 と同じ BFS 修正で自動的に直るが、plan-coverage 側の観測点として独立に固定する。
+
+**Independent Test**: spec 016 US1 の fixture (validateToken/issueToken/revokeToken、各 `@impl REQ-001/005/009`) の 3 REQ を**同一 spec.md** に配置し直し、tasks.md に `Files: src/auth.ts:validateToken` のみを書いて `artgraph plan-coverage --format json` を実行。`implicitImpacts[0].impactReqs` が `[{reqId: "REQ-001", ...}]` のみであることを assert する。
+
+**Acceptance Scenarios**:
+
+1. **Given** REQ-001 / REQ-005 / REQ-009 が同一 spec.md、`src/auth.ts` の 3 symbol が各々を `@impl`、tasks.md に `Files: src/auth.ts:validateToken`、 **When** `artgraph plan-coverage --format json`、 **Then** `implicitImpacts[0].impactReqs` は REQ-001 のみ。`originReqs = ["REQ-001"]` との二軸差分は空(ドリフトなしが正しく観測できる)。
+2. **Given** 同構成に spec 側で `REQ-001 depends_on REQ-007` を追加、 **When** 同コマンド、 **Then** `impactReqs = [REQ-001, REQ-007]` / `originReqs = [REQ-001]` — ドリフト候補は依存由来の REQ-007 のみで、REQ-005 / REQ-009 は混入しない (spec 016 US1 シナリオ 6 の同一 spec 版)。
+
+---
+
+### User Story 3 — `check --diff` スコープの浄化と spec 変更経路の維持 (Priority: P1)
+
+ユーザーがコードファイル 1 個だけを変更して `artgraph check --diff` を実行すると、scoped arrays (`drifted` / `orphans` / `uncovered` / `coverage`) の範囲はその変更が実際に到達する REQ 群に限定され、同一 spec に同居しているだけの兄弟 REQ の負債(uncovered 等)が「in range の pre-existing debt」としてカウントされない。一方、spec.md 自体を変更した場合は従来どおりその spec の全 REQ がスコープに入る(新 REQ 追加 → uncovered 検出のゲート経路は無退行)。
+
+**Why this priority**: `check --diff` は impact() の到達集合でスコープを計算するため、US1 の BFS 変更が自動的に波及する。波及自体は望ましい(スコープの意味が正しくなり `suppressedCount` のノイズが減る)が、**ゲートの挙動変更**なので受け入れシナリオとして明示的に固定し、特に「spec ファイル変更時は全 REQ がスコープに残る」ことを退行テストで担保する。
+
+**Independent Test**: 同一 spec.md に REQ-A (`@impl` あり) / REQ-B (`@impl` なし = uncovered) がある fixture で、REQ-A の実装ファイルのみを diff に含めて `check --diff --format json` を実行し、`uncovered` に REQ-B が含まれないことを assert する。次に spec.md 自体を diff に含めて再実行し、REQ-B が `uncovered` に含まれることを assert する。
+
+**Acceptance Scenarios**:
+
+1. **Given** 同一 spec.md の REQ-A (実装あり) / REQ-B (実装なし)、diff は REQ-A の実装ファイルのみ、 **When** `check --diff`、 **Then** scoped `uncovered` に REQ-B が含まれない。
+2. **Given** 同構成で diff に spec.md 自体が含まれる、 **When** `check --diff`、 **Then** REQ-B が `uncovered` としてスコープに入る(`resolveStartIds` の filePath fallback が doc / 全 req ノードを seed し、順方向 contains もこれを補強する)。
+3. **Given** spec.md に新 REQ を追記し実装を追加する通常の SDD ループ、 **When** `check --diff`、 **Then** 従来と同じ検出結果(spec 変更経路の無退行)。
+
+---
+
+### User Story 4 — 兄弟 REQ の情報専用軸 `sameSpecReqs` (Priority: P2)
+
+「同じ spec の兄弟 REQ も参考情報としては見たい」ユーザー(例: agent が変更前に feature 全体の文脈を掴みたいケース)のために、`artgraph impact` の出力に `sameSpecReqs` — affected docs に含まれる REQ のうち `impactReqs` に入らなかったもの — を**情報専用の別軸**として載せる。この軸は Drift candidates に一切寄与せず、text 出力でも「Same-spec REQs (informational)」として明確に区別される。
+
+**Why this priority**: Issue #215 の対応方向 2 の採用。巻き込みを止めた上でなお「同一 feature の文脈」が欲しい場面は agent workflow で現実にあるが、blast radius と混ざることが害だったのであり、分離されたチャネルなら価値になる。ただし P1 (巻き込み排除) が成立すれば `affectedDocs` から spec を読めば同じ情報に到達できるため、優先度は P2。
+
+**Independent Test**: US1 シナリオ 1 の fixture で `artgraph impact src/sample.ts:fnA --format json` を実行し、`sameSpecReqs = ["REQ-902"]` かつ `drifted` に REQ-902 が含まれないことを assert する。
+
+**Acceptance Scenarios**:
+
+1. **Given** US1 シナリオ 1 の構成、 **When** `impact --format json`、 **Then** 出力 JSON に `sameSpecReqs: ["REQ-902"]` が含まれ、`impactReqs` / `drifted` には含まれない。
+2. **Given** 同構成、 **When** text 出力 (`--format` なし)、 **Then** 「Same-spec REQs (informational)」等の独立セクションに REQ-902 が表示され、Impact reqs / Drift candidates セクションとは視覚的に区別される。
+3. **Given** REQ-902 の contentHash が lock と drift している、 **When** `impact --format json`、 **Then** REQ-902 は `sameSpecReqs` に載るが `drifted` には載らない(情報軸は drift 判定対象外)。
+4. **Given** すべての同 doc REQ が impactReqs に含まれる(依存で全到達)、 **When** 同コマンド、 **Then** `sameSpecReqs = []`。
+5. `plan-coverage` / `check` の出力スキーマには `sameSpecReqs` を**追加しない**(スコープ外宣言 — FR-014)。
+
+---
+
+### User Story 5 — ドキュメント / Skill / dogfood テンプレートの追随 (Priority: P2)
+
+traversal セマンティクスの SSOT が変わるため、(a) `src/graph/traverse.ts` 冒頭の設計コメント(旧「意図された設計」宣言)を本 spec 準拠に書き換え、(b) README / docs/skills-guide.md の impact 説明、(c) `artgraph-impact` / `artgraph-plan-coverage` Skill の出力解説(`sameSpecReqs` の読み方を含む)、(d) 5 agent path に配布される dogfood テンプレート(byte-identical 同期テストあり)を更新する。
+
+**Why this priority**: コメント・ドキュメントが旧設計を「意図」と主張したまま実装だけ変わると、次の開発者(або agent)が回帰させるリスクが高い。#215 の調査でも traverse.ts のコメントが「これはバグではなく設計」という誤誘導の起点になった。
+
+**Acceptance Scenarios**:
+
+1. **Given** 本 spec の実装マージ後、 **When** `src/graph/traverse.ts` を読む、 **Then** 冒頭コメントが「contains は順方向のみ・親 doc は帰属アトリビューション」という新セマンティクスを spec 019 参照付きで説明している。
+2. **Given** Skill テンプレート更新後、 **When** dogfood 同期テストを実行、 **Then** 5 agent path すべてで byte-identical に通る。
+
+---
+
+### Edge Cases
+
+- **同一 REQ ID が複数 doc に含まれる場合**: 帰属アトリビューションは該当するすべての親 doc を `affectedDocs` に列挙する。
+- **`maxDepth` 指定時**: 親 doc の帰属アトリビューションは BFS の到達集合に対する後処理であり、depth を消費しない。`maxDepth` の意味は「グラフ辺のトラバース段数」のまま変わらない(従来コメントの「contains の広がりすぎを maxDepth で抑える」という回避策は不要になり、記述を削除する)。
+- **`contains` は doc→task 辺にも存在する** (tasks.md 由来): 方向制約は req と task に等しく適用する。task 起点/経由の traversal が tasks.md の兄弟 task を巻き込む同型の問題も同時に解消され、親 doc (tasks.md) は帰属として `affectedDocs` に残る。
+- **`autoContains: false` 構成**: contains 辺が存在しないため帰属アトリビューションは空集合。従来との差分なし。
+- **lock に親 doc が存在しない場合**: 既存の drift 判定と同じく skip(`lock[id]` が無ければ判定しない)。
+- **起点自体が doc / spec パスの場合** (`artgraph impact specs/auth.md`): `resolveStartIds` の filePath fallback が doc ノードと全 req ノードを直接 seed するため、方向制約後も spec→code 方向の全展開が維持される。加えて doc ノードからの順方向 contains 展開も従来どおり機能する。
+- **req↔doc の往復による無限ループ**: 方向制約により構造的に発生しなくなる(従来は visited set で抑止していた)。
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### BFS 方向制約 (core)
+
+- **FR-001**: `impact()` の BFS は `contains` 辺を**順方向のみ** (edge.source = doc → edge.target = req|task) 辿る。逆方向 (req|task → 親 doc) はトラバースしない。
+- **FR-002**: `contains` 以外の 5 辺種 (`depends_on` / `derives_from` / `implements` / `verifies` / `imports`) の双方向トラバース、および file→symbol 展開 (spec 016 R-006 の挙動) は一切変更しない。
+- **FR-003**: 方向制約は `contains` 辺の target 種別 (req / task) を問わず一律に適用する。
+
+#### 親 doc の帰属アトリビューション
+
+- **FR-004**: BFS 完了後、到達した req / task ノードそれぞれについて、当該ノードを target とする `contains` 辺の source doc を解決し、`affectedDocs` に追加する (dedup、BFS で直接到達した doc との重複は集合として collapse)。
+- **FR-005**: 帰属アトリビューションで追加された doc も、BFS で直接到達した doc と同様に drift 判定 (lock との contentHash 比較) の対象とする。
+- **FR-006**: 帰属アトリビューションで追加された doc から先へのグラフ展開は行わない (その doc の子 req が `impactReqs` / `affectedFiles` / `drifted` に寄与しない)。
+
+#### `sameSpecReqs` 情報軸 (P2)
+
+- **FR-007**: `sameSpecReqs` は「`affectedDocs` (BFS 到達 + 帰属アトリビューション) の contains 子 req のうち `impactReqs` に含まれないもの」と定義し、dedup + reqId 昇順で返す。
+- **FR-008**: `sameSpecReqs` は `artgraph impact` の JSON / text 出力にのみ載せる。text 出力では Impact reqs / Drift candidates と明確に区別された informational セクションとする。`sameSpecReqs` の要素は `drifted` の対象にならない。
+- **FR-009**: `sameSpecReqs` の算出は `resolveOriginReqs` と同じパターン(traverse 層の独立ヘルパーを CLI 層が呼ぶ)とし、`impact()` 本体の戻り値契約への追加は最小限に留める。plan-coverage / check はこのヘルパーを呼ばない。
+
+#### 呼び出し元への波及の固定
+
+- **FR-010**: `plan-coverage` の per-entry `impactReqs` に、同一 doc 同居のみを理由とする兄弟 REQ が混入しないこと (US2 — BFS 変更の自動波及をテストで固定)。
+- **FR-011**: `check --diff` の scoped arrays に、コード側変更起点で兄弟 REQ 由来の項目が混入しないこと。spec ファイルが diff に含まれる場合は当該 spec の全 REQ がスコープに入ること (US3)。
+
+#### ドキュメント / Skill
+
+- **FR-012**: `src/graph/traverse.ts` 冒頭の設計コメント (spec 014/016 由来の「bidirectional は意図」宣言) を本 spec 準拠に書き換え、spec 019 を参照させる。maxDepth による回避策の記述を削除する。
+- **FR-013**: README / docs/skills-guide.md / `artgraph-impact` / `artgraph-plan-coverage` Skill テンプレートの impact 出力説明を更新し (`sameSpecReqs` の読み方を含む)、dogfood テンプレート 5 agent path の byte-identical 同期を維持する。
+
+#### Scope exclusion (明示)
+
+- **FR-014**: 以下は本 spec のスコープ外: (a) #218 クラスメソッド粒度、(b) REQ-ID 直接入力の受理 (spec 016 FR-012 の rejection を維持)、(c) `maxDepth` のデフォルト値変更、(d) doc↔doc 辺 (`derives_from` / `depends_on`) のセマンティクス変更、(e) `contains` 辺の**生成側** (builder.ts) の変更、(f) `plan-coverage` / `check` 出力スキーマへの `sameSpecReqs` 追加。
+
+### Key Entities
+
+- **`contains` 辺**: 生成 (builder.ts、provenance `structural`、doc→req|task) は不変。**消費側 (traverse) のセマンティクスのみ変更**。
+- **`ImpactResult`**: 既存フィールドの型は不変。`affectedDocs` の算出方法が「BFS 到達」から「BFS 到達 ∪ 帰属アトリビューション」に変わる。`sameSpecReqs` は CLI 層で合成する出力フィールドであり、`resolveOriginReqs` / `originReqs` と同じ責務分担に従う。
+- **`DriftEntry`**: 型・判定ロジック不変。母集合 (visited + attributed docs) の変化のみ。
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Issue #215 の再現手順 1 / 2 が非再現になり、手順 3 (別 spec 分割) の挙動が不変であることを、issue 記載の最小構成 fixture の E2E で確認できる。
+- **SC-002**: spec 016 の受け入れシナリオ (二軸出力・symbol 過剰検知抑制) がすべて green のまま維持される。
+- **SC-003**: tag-zero brownfield E2E (#122) が**無変更で** green (ts-import 経路への非干渉の証明)。
+- **SC-004**: 既存テストスイート (typecheck / unit / e2e / knip) が green。兄弟 REQ 到達を expect していた既存テストは新セマンティクスへの書き換えとして PR 上で列挙・レビュー可能にする。
+- **SC-005**: dogfooding 環境 (artgraph-dogfooding リポ、specs 001〜004 + src/todo.ts) で `artgraph impact src/todo.ts:<symbol>` を実行すると、当該 symbol の `@impl` claim とコード依存由来の REQ のみが返る (実プロジェクト構成での価値提案の回復確認)。
+
+## Alternatives Considered
+
+| 案 | 内容 | 裁定 |
+|----|------|------|
+| 案 1: contains 方向制約 | BFS で doc contains を双方向に辿らない。req→doc は帰属メタデータとしてのみ扱う | **採用 (core)**。根本原因の除去。帰属は事後アトリビューション (FR-004) で温存 |
+| 案 2: `sameSpecReqs` 分離 | 兄弟 REQ を別カテゴリに分離し Drift candidates に混ぜない | **部分採用 (P2)**。案 1 の上に情報専用軸として載せる。案 1 なしの案 2 単独 (BFS は今のまま出力だけ分類) は、affectedFiles / check スコープ / plan-coverage の汚染が残るため不採用 |
+| 案 3: docs 明記のみ | 「1 spec.md 複数 REQ で impact は spec 単位」と制約を明記 | **不採用**。最も一般的な構成で中核価値提案が壊れたままになる。#177/#179/#188/spec 016 の投資も回収不能 |
+| 変形案: 経路依存 BFS | reverse contains で到達した doc を「非展開ノード」としてマークし BFS 内で処理 | **不採用**。訪問順で結果が変わりうる経路依存性を BFS に持ち込み、決定性の検証コストが上がる。事後アトリビューションが同じ出力をより単純に達成する |
+
+## Assumptions
+
+- pre-1.0 の挙動変更として許容する (リリースノートで traversal セマンティクス変更を明示する。既存ユーザーの `impact` / `check --diff` / `plan-coverage` の出力は狭くなる方向にのみ変わる)。
+- `contains` 辺の生成は builder.ts の 1 箇所 (provenance `structural`) のみであり、方向制約の適用点は traverse 層に閉じる。
+- traverse.ts 冒頭コメントおよび spec 014/016 の「bidirectional は意図」という記述は、同一 doc 内の狭い fixture では妥当に見えたが、Spec Kit / Kiro の標準構成 (1 spec.md = 1 feature = 複数 REQ) に対する検証を欠いていた。#215 の 3 段階切り分け (dogfooding で実証) を優先し、本 spec で設計判断を更新する。
+- `visited` 集合ベースの現行 BFS 実装は方向制約後も決定的であり、出力順序の契約 (INV-S2 等) に影響しない。

--- a/specs/019-impact-doc-containment/tasks.md
+++ b/specs/019-impact-doc-containment/tasks.md
@@ -17,32 +17,32 @@
 
 ## Phase 1: Red — US1 の失敗テスト
 
-- [ ] T001 [US1] issue #215 最小再現 fixture の単体テストを `tests/traverse.test.ts` に追加: `fnA` (`@impl REQ-901`) / `fnB` (`@impl REQ-902`) 同居 spec.md 構成のグラフを組み、`impact()` が (a) 同一ファイル・依存なしで REQ-902 を含まない (AS1-1)、(b) 別ファイル・依存なしで REQ-902 / other.ts を含まない (AS1-2)、(c) 別 spec 分割時は従来どおり (AS1-5) を assert — 現行実装で **Red** になることを確認
-- [ ] T002 [P] [US1] 追加の Red テスト: (a) fnA→fnB の `imports` 辺があるときは REQ-902 が正しく含まれる (AS1-3)、(b) 親 doc が `affectedDocs` に帰属として残り drift 時は `drifted` に doc entry が出る (AS1-4)、(c) `REQ-901 depends_on REQ-903` (別 spec) の req→req 到達は維持 (AS1-6)、(d) doc→task: task 経由で tasks.md の兄弟 task を巻き込まない (FR-003)、(e) 起点が spec パス (`resolveStartIds` filePath fallback) のとき全子 REQ に到達 (Edge Case)
+- [X] T001 [US1] issue #215 最小再現 fixture の単体テストを `tests/traverse.test.ts` に追加: `fnA` (`@impl REQ-901`) / `fnB` (`@impl REQ-902`) 同居 spec.md 構成のグラフを組み、`impact()` が (a) 同一ファイル・依存なしで REQ-902 を含まない (AS1-1)、(b) 別ファイル・依存なしで REQ-902 / other.ts を含まない (AS1-2)、(c) 別 spec 分割時は従来どおり (AS1-5) を assert — 現行実装で **Red** になることを確認
+- [X] T002 [P] [US1] 追加の Red テスト: (a) fnA→fnB の `imports` 辺があるときは REQ-902 が正しく含まれる (AS1-3)、(b) 親 doc が `affectedDocs` に帰属として残り drift 時は `drifted` に doc entry が出る (AS1-4)、(c) `REQ-901 depends_on REQ-903` (別 spec) の req→req 到達は維持 (AS1-6)、(d) doc→task: task 経由で tasks.md の兄弟 task を巻き込まない (FR-003)、(e) 起点が spec パス (`resolveStartIds` filePath fallback) のとき全子 REQ に到達 (Edge Case)
 
 ## Phase 2: Green — traverse.ts コア変更
 
-- [ ] T003 [US1] `impact()` の BFS エッジ展開に contains 方向制約を実装 (FR-001〜003): 逆方向展開 (`edge.target === id`) を `edge.kind !== "contains"` のときのみ行う。順方向展開・file→symbol 展開・他 5 辺種の双方向性は不変
-- [ ] T004 [US1] 帰属アトリビューションを実装 (FR-004〜006): BFS 後、visited の req / task を target とする contains 辺の source doc を `affectedDocs` へ union (dedup)、attributed doc も lock 比較で `drifted` 判定。attributed doc からの再展開はしない。T001 / T002 が **Green** になることを確認
-- [ ] T005 [US1] `src/graph/traverse.ts` 冒頭の設計コメントを spec 019 準拠に書き換え (FR-012): 「bidirectional は意図」「maxDepth で contains の広がりを抑える」の記述を削除し、contains 順方向限定 + 帰属アトリビューションのセマンティクスを spec 019 参照付きで記述
+- [X] T003 [US1] `impact()` の BFS エッジ展開に contains 方向制約を実装 (FR-001〜003): 逆方向展開 (`edge.target === id`) を `edge.kind !== "contains"` のときのみ行う。順方向展開・file→symbol 展開・他 5 辺種の双方向性は不変
+- [X] T004 [US1] 帰属アトリビューションを実装 (FR-004〜006): BFS 後、visited の req / task を target とする contains 辺の source doc を `affectedDocs` へ union (dedup)、attributed doc も lock 比較で `drifted` 判定。attributed doc からの再展開はしない。T001 / T002 が **Green** になることを確認
+- [X] T005 [US1] `src/graph/traverse.ts` 冒頭の設計コメントを spec 019 準拠に書き換え (FR-012): 「bidirectional は意図」「maxDepth で contains の広がりを抑える」の記述を削除し、contains 順方向限定 + 帰属アトリビューションのセマンティクスを spec 019 参照付きで記述
 
 ## Phase 3: 波及の固定 — US2 / US3
 
-- [ ] T006 [P] [US2] plan-coverage の観測点テスト (FR-010): 同一 spec.md に REQ-001/005/009、`src/auth.ts` の 3 symbol が各々を claim する fixture で、`Files: src/auth.ts:validateToken` の per-entry `impactReqs` が REQ-001 のみ (AS2-1)、`depends_on REQ-007` 追加時は `[REQ-001, REQ-007]` (AS2-2) — `tests/plan-coverage*.test.ts` に追加
-- [ ] T007 [P] [US3] check --diff のスコープテスト (FR-011): 同一 spec.md の REQ-A (実装あり) / REQ-B (実装なし) fixture で、(a) コードのみ diff → scoped `uncovered` に REQ-B なし (AS3-1)、(b) spec.md が diff に入る → REQ-B が `uncovered` に入る (AS3-2)、(c) 新 REQ 追記+実装の SDD ループ無退行 (AS3-3) — `tests/check*.test.ts` に追加
-- [ ] T008 [US1] issue #215 再現手順の CLI E2E (SC-001): `tests/impact-cli.test.ts` に最小再現 fixture の `impact <file>:<symbol> --format json` を追加し、手順 1/2 非再現・手順 3 不変を assert
+- [X] T006 [P] [US2] plan-coverage の観測点テスト (FR-010): 同一 spec.md に REQ-001/005/009、`src/auth.ts` の 3 symbol が各々を claim する fixture で、`Files: src/auth.ts:validateToken` の per-entry `impactReqs` が REQ-001 のみ (AS2-1)、`depends_on REQ-007` 追加時は `[REQ-001, REQ-007]` (AS2-2) — `tests/plan-coverage*.test.ts` に追加
+- [X] T007 [P] [US3] check --diff のスコープテスト (FR-011): 同一 spec.md の REQ-A (実装あり) / REQ-B (実装なし) fixture で、(a) コードのみ diff → scoped `uncovered` に REQ-B なし (AS3-1)、(b) spec.md が diff に入る → REQ-B が `uncovered` に入る (AS3-2)、(c) 新 REQ 追記+実装の SDD ループ無退行 (AS3-3) — `tests/check*.test.ts` に追加
+- [X] T008 [US1] issue #215 再現手順の CLI E2E (SC-001): `tests/impact-cli.test.ts` に最小再現 fixture の `impact <file>:<symbol> --format json` を追加し、手順 1/2 非再現・手順 3 不変を assert
 
 ## Phase 4: 既存テストの期待値反転
 
-- [ ] T009 既存テストスイートを実行し、兄弟 REQ / 兄弟 task / doc 経由到達を expect して落ちるテストを列挙 → 各々を新セマンティクスの期待値に書き換える。**書き換えた全テストを PR 本文に列挙する** (spec 前提: 削除ではなく期待値の反転としてレビュー可能にする)
-- [ ] T010 tag-zero brownfield E2E (#122 系) が**無変更で** green であることを確認 (SC-003)。spec 016 系の二軸テスト (originReqs) が green のまま維持されることを確認 (SC-002)
+- [X] T009 既存テストスイートを実行し、兄弟 REQ / 兄弟 task / doc 経由到達を expect して落ちるテストを列挙 → 各々を新セマンティクスの期待値に書き換える。**書き換えた全テストを PR 本文に列挙する** (spec 前提: 削除ではなく期待値の反転としてレビュー可能にする)
+- [X] T010 tag-zero brownfield E2E (#122 系) が**無変更で** green であることを確認 (SC-003)。spec 016 系の二軸テスト (originReqs) が green のまま維持されることを確認 (SC-002)
 
 ## Phase 5: Polish — ドキュメント・最終確認
 
-- [ ] T011 [P] [US5] README / docs/skills-guide.md の impact 説明を新セマンティクスに更新 (FR-013): 「同一 spec 同居は blast radius に入らない」「feature 文脈は affectedDocs の spec を読む」。旧挙動を前提にした記述 (1 spec 複数 REQ の制約回避策等) があれば削除
-- [ ] T012 [P] [US5] `artgraph-impact` / `artgraph-plan-coverage` Skill テンプレートに旧セマンティクス前提の記述があれば更新し、dogfood テンプレート 5 agent path の byte-identical 同期テスト green を維持 (該当記述がなければ「変更不要」と PR に明記)
-- [ ] T013 全 suite green 確認: `pnpm typecheck && pnpm test:unit && pnpm test:e2e && pnpm knip` (SC-004)
-- [ ] T014 dogfooding 確認 (SC-005): ビルド済み CLI (`node dist/cli.js`) を `~/artgraph-dogfooding` (specs 001〜004 + src/todo.ts) に対して read-only 実行し、`impact src/todo.ts:<symbol>` が当該 symbol の claim + コード依存由来の REQ のみ返すことを確認、結果を PR 本文に記載
+- [X] T011 [P] [US5] README / docs/skills-guide.md の impact 説明を新セマンティクスに更新 (FR-013): 「同一 spec 同居は blast radius に入らない」「feature 文脈は affectedDocs の spec を読む」。旧挙動を前提にした記述 (1 spec 複数 REQ の制約回避策等) があれば削除
+- [X] T012 [P] [US5] `artgraph-impact` / `artgraph-plan-coverage` Skill テンプレートに旧セマンティクス前提の記述があれば更新し、dogfood テンプレート 5 agent path の byte-identical 同期テスト green を維持 (該当記述がなければ「変更不要」と PR に明記)
+- [X] T013 全 suite green 確認: `pnpm typecheck && pnpm test:unit && pnpm test:e2e && pnpm knip` (SC-004)
+- [X] T014 dogfooding 確認 (SC-005): ビルド済み CLI (`node dist/cli.js`) を `~/artgraph-dogfooding` (specs 001〜004 + src/todo.ts) に対して read-only 実行し、`impact src/todo.ts:<symbol>` が当該 symbol の claim + コード依存由来の REQ のみ返すことを確認、結果を PR 本文に記載
 
 ## Dependencies (完了順)
 

--- a/specs/019-impact-doc-containment/tasks.md
+++ b/specs/019-impact-doc-containment/tasks.md
@@ -1,0 +1,61 @@
+# Tasks: impact BFS の contains 辺方向制約
+
+**Input**: [spec.md](./spec.md) / [plan.md](./plan.md)
+
+## 進め方 (TDD: Red ⇒ Green ⇒ 追随 ⇒ Polish)
+
+コア変更は `src/graph/traverse.ts` の 1 関数に閉じるため、まず US1 の失敗テストを書き (Red)、方向制約 + 帰属アトリビューションで Green にし、その後 US2 / US3 の波及を観測点として固定、最後に既存テストの期待値反転とドキュメント追随を行う。
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: 他タスクと並行実行可能 (異なるファイル・依存なし)
+- **[USn]**: 対応する spec.md の User Story
+
+## Path Conventions
+
+単一パッケージ。ソースは `src/`、単体テストは `tests/*.test.ts`、E2E は `tests/e2e/`。
+
+## Phase 1: Red — US1 の失敗テスト
+
+- [ ] T001 [US1] issue #215 最小再現 fixture の単体テストを `tests/traverse.test.ts` に追加: `fnA` (`@impl REQ-901`) / `fnB` (`@impl REQ-902`) 同居 spec.md 構成のグラフを組み、`impact()` が (a) 同一ファイル・依存なしで REQ-902 を含まない (AS1-1)、(b) 別ファイル・依存なしで REQ-902 / other.ts を含まない (AS1-2)、(c) 別 spec 分割時は従来どおり (AS1-5) を assert — 現行実装で **Red** になることを確認
+- [ ] T002 [P] [US1] 追加の Red テスト: (a) fnA→fnB の `imports` 辺があるときは REQ-902 が正しく含まれる (AS1-3)、(b) 親 doc が `affectedDocs` に帰属として残り drift 時は `drifted` に doc entry が出る (AS1-4)、(c) `REQ-901 depends_on REQ-903` (別 spec) の req→req 到達は維持 (AS1-6)、(d) doc→task: task 経由で tasks.md の兄弟 task を巻き込まない (FR-003)、(e) 起点が spec パス (`resolveStartIds` filePath fallback) のとき全子 REQ に到達 (Edge Case)
+
+## Phase 2: Green — traverse.ts コア変更
+
+- [ ] T003 [US1] `impact()` の BFS エッジ展開に contains 方向制約を実装 (FR-001〜003): 逆方向展開 (`edge.target === id`) を `edge.kind !== "contains"` のときのみ行う。順方向展開・file→symbol 展開・他 5 辺種の双方向性は不変
+- [ ] T004 [US1] 帰属アトリビューションを実装 (FR-004〜006): BFS 後、visited の req / task を target とする contains 辺の source doc を `affectedDocs` へ union (dedup)、attributed doc も lock 比較で `drifted` 判定。attributed doc からの再展開はしない。T001 / T002 が **Green** になることを確認
+- [ ] T005 [US1] `src/graph/traverse.ts` 冒頭の設計コメントを spec 019 準拠に書き換え (FR-012): 「bidirectional は意図」「maxDepth で contains の広がりを抑える」の記述を削除し、contains 順方向限定 + 帰属アトリビューションのセマンティクスを spec 019 参照付きで記述
+
+## Phase 3: 波及の固定 — US2 / US3
+
+- [ ] T006 [P] [US2] plan-coverage の観測点テスト (FR-010): 同一 spec.md に REQ-001/005/009、`src/auth.ts` の 3 symbol が各々を claim する fixture で、`Files: src/auth.ts:validateToken` の per-entry `impactReqs` が REQ-001 のみ (AS2-1)、`depends_on REQ-007` 追加時は `[REQ-001, REQ-007]` (AS2-2) — `tests/plan-coverage*.test.ts` に追加
+- [ ] T007 [P] [US3] check --diff のスコープテスト (FR-011): 同一 spec.md の REQ-A (実装あり) / REQ-B (実装なし) fixture で、(a) コードのみ diff → scoped `uncovered` に REQ-B なし (AS3-1)、(b) spec.md が diff に入る → REQ-B が `uncovered` に入る (AS3-2)、(c) 新 REQ 追記+実装の SDD ループ無退行 (AS3-3) — `tests/check*.test.ts` に追加
+- [ ] T008 [US1] issue #215 再現手順の CLI E2E (SC-001): `tests/impact-cli.test.ts` に最小再現 fixture の `impact <file>:<symbol> --format json` を追加し、手順 1/2 非再現・手順 3 不変を assert
+
+## Phase 4: 既存テストの期待値反転
+
+- [ ] T009 既存テストスイートを実行し、兄弟 REQ / 兄弟 task / doc 経由到達を expect して落ちるテストを列挙 → 各々を新セマンティクスの期待値に書き換える。**書き換えた全テストを PR 本文に列挙する** (spec 前提: 削除ではなく期待値の反転としてレビュー可能にする)
+- [ ] T010 tag-zero brownfield E2E (#122 系) が**無変更で** green であることを確認 (SC-003)。spec 016 系の二軸テスト (originReqs) が green のまま維持されることを確認 (SC-002)
+
+## Phase 5: Polish — ドキュメント・最終確認
+
+- [ ] T011 [P] [US5] README / docs/skills-guide.md の impact 説明を新セマンティクスに更新 (FR-013): 「同一 spec 同居は blast radius に入らない」「feature 文脈は affectedDocs の spec を読む」。旧挙動を前提にした記述 (1 spec 複数 REQ の制約回避策等) があれば削除
+- [ ] T012 [P] [US5] `artgraph-impact` / `artgraph-plan-coverage` Skill テンプレートに旧セマンティクス前提の記述があれば更新し、dogfood テンプレート 5 agent path の byte-identical 同期テスト green を維持 (該当記述がなければ「変更不要」と PR に明記)
+- [ ] T013 全 suite green 確認: `pnpm typecheck && pnpm test:unit && pnpm test:e2e && pnpm knip` (SC-004)
+- [ ] T014 dogfooding 確認 (SC-005): ビルド済み CLI (`node dist/cli.js`) を `~/artgraph-dogfooding` (specs 001〜004 + src/todo.ts) に対して read-only 実行し、`impact src/todo.ts:<symbol>` が当該 symbol の claim + コード依存由来の REQ のみ返すことを確認、結果を PR 本文に記載
+
+## Dependencies (完了順)
+
+```
+T001, T002 (Red)
+  └─> T003 → T004 (Green) → T005
+        └─> T006, T007, T008 (並行可)
+              └─> T009 → T010
+                    └─> T011, T012 (並行可) → T013 → T014
+```
+
+## Implementation Strategy
+
+- コア (T003/T004) は 10 行前後の差分に収まる見込み。大半の工数は fixture 作成と既存テストの期待値反転 (T009)。
+- `ImpactResult` の型・JSON スキーマは不変のため、スキーマ系スナップショット / contract テストは原則影響を受けない。落ちる場合は到達集合の値変化によるものなので、期待値のみ更新する。
+- コミットは論理単位の日本語 conventional commits: (1) Red テスト、(2) traverse コア + コメント、(3) 波及テスト、(4) 既存テスト反転、(5) docs。CHANGELOG / version は触らない (release-please)。

--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -2,23 +2,43 @@ import { isAbsolute, relative, resolve as resolvePath, sep } from "node:path";
 import type { ArtifactGraph, DriftEntry, ImpactResult, SymbolEntry } from "../types.js";
 import type { LockFile } from "../types.js";
 
-// spec 016 (R-006, data-model.md §2.3) — `impact()` BFS body is **unchanged
-// from spec 014**. The redesign reroutes the startId construction (now via
-// `resolveStartIds` taking `SymbolEntry[]`) and adds an out-of-band
-// `originReqs` axis (via `resolveOriginReqs`) computed at the CLI / plan-
-// coverage layer. The BFS traversal itself is BIDIRECTIONAL: edges are
-// followed in both directions regardless of their declared source/target.
-// This means:
-//   - From a req node, traversal reaches the parent doc (via reverse contains edge)
-//   - From a doc node, traversal reaches child reqs (via forward contains edge)
-//   - Starting from any req, the blast radius includes sibling reqs in the same doc
-//     (req -> parent doc -> sibling reqs -> their implementations)
-// Pass maxDepth to limit traversal when contains edges cause unexpectedly wide reach.
+// spec 019 (FR-001〜006, issue #215) — `contains` (doc -> req|task) is the
+// ONE edge kind the BFS below does not treat as bidirectional. Every other
+// edge kind (`depends_on` / `derives_from` / `implements` / `verifies` /
+// `imports`) and the file→symbol expansion (the `node.kind === "file"`
+// branch below) keep the spec 014/016 bidirectional semantics unchanged.
+//
+// Why: Spec Kit / Kiro's standard layout is "1 feature = 1 spec.md with
+// multiple REQs". Treating `contains` as bidirectional let a symbol-unit
+// BFS walk req -> (reverse contains) parent doc -> (forward contains)
+// sibling req -> sibling req's implementors, dragging the WHOLE feature's
+// REQ set into `impactReqs` / `affectedFiles` / `drifted` even when the
+// target symbol has zero code dependency on the sibling. That defeated the
+// per-change-context value proposition `artgraph impact` exists for (see
+// specs/019-impact-doc-containment/spec.md US1). The same amplification
+// happens one hub further for tasks: a task's `implements` edge to its REQ
+// plus tasks.md's `contains` edges to every sibling task reconstructs the
+// same blowup through the task layer, so the direction constraint applies
+// uniformly to `contains` edges regardless of whether the target is a req
+// or a task node (FR-003) — restricting only req targets leaves the task
+// path wide open and the symptom returns almost unchanged.
+//
+// The parent doc is not simply dropped: after the BFS below completes,
+// `impact()` re-attaches each visited req/task's parent doc(s) via a
+// one-hop, non-recursive post-processing pass (FR-004〜006, "attribution").
+// Attributed docs land in `affectedDocs` and participate in drift detection
+// exactly like BFS-reached docs, but nothing is expanded FROM an attributed
+// doc — so attribution restores "which spec is this REQ's home" context
+// without reopening the sibling-REQ leak. `maxDepth` no longer needs to
+// double as a `contains`-blast-radius mitigation (the old comment's
+// workaround is gone): attribution is a depth-independent post-BFS step,
+// so `maxDepth` keeps its one meaning — how many graph-edge hops the BFS
+// itself takes.
 //
 // File→symbol expansion (the `node.kind === "file"` branch below) is the
 // reason a file startId still drags in same-file symbols; for symbol startIds
 // `resolveStartIds` deliberately omits the parent file node so a symbol-unit
-// input doesn't sweep up its siblings (R-006 mitigation).
+// input doesn't sweep up its siblings (spec 016 R-006 mitigation).
 export function impact(
   graph: ArtifactGraph,
   startIds: string[],
@@ -52,14 +72,17 @@ export function impact(
       if (edge.source === id && !visited.has(edge.target)) {
         queue.push({ id: edge.target, depth: depth + 1 });
       }
-      if (edge.target === id && !visited.has(edge.source)) {
+      // spec 019 (FR-001〜003): reverse traversal (target -> source) skips
+      // `contains` edges so a req/task node cannot walk "backwards" into its
+      // parent doc during BFS. Every other edge kind keeps reverse traversal.
+      if (edge.target === id && edge.kind !== "contains" && !visited.has(edge.source)) {
         queue.push({ id: edge.source, depth: depth + 1 });
       }
     }
   }
 
   const affectedFileSet = new Set<string>();
-  const affectedDocs: string[] = [];
+  const affectedDocsSet = new Set<string>();
   const impactReqs: string[] = [];
   const affectedTasks: string[] = [];
   const drifted: DriftEntry[] = [];
@@ -75,7 +98,7 @@ export function impact(
         affectedFileSet.add(node.filePath);
         break;
       case "doc":
-        affectedDocs.push(id);
+        affectedDocsSet.add(id);
         break;
       case "req":
         impactReqs.push(id);
@@ -86,16 +109,43 @@ export function impact(
         affectedTasks.push(id);
         break;
     }
+  }
 
-    if ((node.kind === "req" || node.kind === "doc") && lock[id]) {
-      if (lock[id].contentHash !== node.contentHash) {
-        drifted.push({
-          nodeId: id,
-          kind: node.kind,
-          lockedHash: lock[id].contentHash,
-          currentHash: node.contentHash,
-        });
-      }
+  // spec 019 (FR-004〜006) — post-BFS attribution: resolve the parent doc(s)
+  // of every visited req/task node via `contains` edges and union them into
+  // `affectedDocs`. This is a one-hop, non-recursive lookup over `visited`
+  // (not a queue push), so an attributed doc never seeds further expansion —
+  // its OTHER children never enter `impactReqs` / `affectedFiles`.
+  for (const edge of graph.edges) {
+    if (edge.kind !== "contains") continue;
+    const target = graph.nodes.get(edge.target);
+    if (!target || (target.kind !== "req" && target.kind !== "task")) continue;
+    if (!visited.has(edge.target)) continue;
+    affectedDocsSet.add(edge.source);
+  }
+
+  const affectedDocs = [...affectedDocsSet];
+
+  // spec 019 (FR-005) — attributed docs are drift-checked exactly like any
+  // other visited node; docs unioned in above are added to `visited` here
+  // (`Set.add` on an already-visited req is a no-op) purely so the shared
+  // drift loop below covers both BFS-reached and attribution-reached docs
+  // without duplicating the lock-comparison logic.
+  for (const id of affectedDocs) {
+    visited.add(id);
+  }
+
+  for (const id of visited) {
+    const node = graph.nodes.get(id);
+    if (!node || (node.kind !== "req" && node.kind !== "doc")) continue;
+    if (!lock[id]) continue;
+    if (lock[id].contentHash !== node.contentHash) {
+      drifted.push({
+        nodeId: id,
+        kind: node.kind,
+        lockedHash: lock[id].contentHash,
+        currentHash: node.contentHash,
+      });
     }
   }
 

--- a/src/graph/traverse.ts
+++ b/src/graph/traverse.ts
@@ -121,6 +121,11 @@ export function impact(
     const target = graph.nodes.get(edge.target);
     if (!target || (target.kind !== "req" && target.kind !== "task")) continue;
     if (!visited.has(edge.target)) continue;
+    // Symmetric with the target guard above: builder.ts only ever emits
+    // `contains` from doc nodes, but impact() also receives hand-built
+    // graphs (tests, embedders) — a dangling or non-doc source must not
+    // leak into `affectedDocs`.
+    if (graph.nodes.get(edge.source)?.kind !== "doc") continue;
     affectedDocsSet.add(edge.source);
   }
 

--- a/templates/skills/_shared/output-schema.md
+++ b/templates/skills/_shared/output-schema.md
@@ -79,10 +79,11 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```json
 {
   "affectedFiles": ["src/foo.ts"],                     // source file paths transitively impacted
-  "affectedDocs": ["doc:012-skills-expansion/spec.md"],// doc node IDs (prefixed "doc:")
-  "affectedReqs": ["FR-001", "012-skills-expansion/FR-002"],
+  "affectedDocs": ["doc:012-skills-expansion/spec.md"],// parent spec doc(s) of reached REQs/tasks — attribution context, not BFS reach (spec 019)
+  "impactReqs": ["FR-001", "012-skills-expansion/FR-002"], // REQ ids reached by the forward BFS
+  "originReqs": ["FR-001"],                            // REQ ids the start ids @impl-claim directly (1-hop reverse implements)
   "affectedTasks": ["012-skills-expansion/T001"],      // task node IDs (may be empty)
-  "drifted": [                                         // same DriftEntry shape as check
+  "drifted": [                                         // same DriftEntry shape as check; attributed affectedDocs entries participate too
     {
       "nodeId": "FR-001",
       "kind": "req",
@@ -90,7 +91,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
       "currentHash": "def456…"
     }
   ],
-  "summary": {                                         // optional — present when impact() returns one
+  "summary": {                                         // always present
     "docs": 12,
     "reqs": 39,
     "files": 0,
@@ -98,6 +99,8 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
   }
 }
 ```
+
+Array order is not part of the contract — treat every array as an unordered set. Same-spec sibling REQs with no code or dependency link of their own never appear in `impactReqs` (spec 019); when you need whole-feature context, open the spec file listed in `affectedDocs` instead.
 
 ## artgraph rename
 

--- a/templates/skills/artgraph-impact/SKILL.md
+++ b/templates/skills/artgraph-impact/SKILL.md
@@ -78,10 +78,13 @@ The result carries the **dual-axis impact view** plus drift:
 | --- | --- |
 | `impactReqs` | REQs reached by forward BFS from the start ids (file or symbol nodes) |
 | `originReqs` | REQs the start ids `@impl`-claim directly (1-hop reverse `implements` edge) |
-| `affectedFiles` / `affectedDocs` / `affectedTasks` | other node kinds reached by the same BFS |
-| `drifted` | lockfile drift on any of the above |
+| `affectedFiles` / `affectedTasks` | other node kinds reached by the same BFS |
+| `affectedDocs` | parent spec doc(s) of every reached REQ/task, attached as **context**, not BFS reach (see below) |
+| `drifted` | lockfile drift on any of the above (`affectedDocs` entries included) |
 
 See [output schema](../_shared/output-schema.md) for the full field shapes.
+
+**Same-spec siblings are not blast radius.** `impactReqs` only contains REQs the edit actually reaches — through code (`@impl`, `imports`) or explicit spec relations (`depends_on` / `derives_from`). A REQ that merely lives in the same `spec.md` as a reached REQ, with no code or dependency link of its own, does **not** appear in `impactReqs` / `affectedFiles` / `drifted`, even under the common Spec Kit / Kiro layout of "one spec.md, many REQs". Its parent spec doc still shows up in `affectedDocs` so you can open that file for full feature context, but don't treat every REQ inside it as touched by this edit — cite only the REQs actually listed in `impactReqs`.
 
 ### 4. Inject into the response
 

--- a/templates/skills/artgraph-plan-coverage/SKILL.md
+++ b/templates/skills/artgraph-plan-coverage/SKILL.md
@@ -66,6 +66,8 @@ Compare per-entry `impactReqs` against `originReqs`:
 - **Sets equal → no drift.** Claim and reach match.
 - **`originReqs \ impactReqs` non-empty → orphan claim.** Out of scope for this Skill — `artgraph check --gate` (Stop hook) will report it.
 
+**Same-spec siblings are not implicit impacts.** `impactReqs` only lists REQs the `Files:` entry actually reaches — via code (`@impl`, `imports`) or explicit spec relations (`depends_on` / `derives_from`). A REQ that merely lives in the same `spec.md` as a reached REQ does **not** appear here just because they're co-located, even under the common "one spec.md, many REQs" layout. If you need the full feature context (not just this entry's blast radius), run `artgraph impact` on the same file/symbol and read its `affectedDocs` — that points at the spec file(s) worth opening directly.
+
 #### Diagnostics
 
 - `unresolvedSymbol` (`{ sourceFile, symbol, line }`): the file exists but no exported symbol of that name was found in the symbol-mode graph. The entry is excluded from `implicitImpacts`. Ask the user whether to (a) fix the typo, (b) drop the `:symbol` suffix to fall back to file unit, or (c) re-run `<PM-exec> scan` if the symbol was just added.

--- a/tests/check-baseline-diff.test.ts
+++ b/tests/check-baseline-diff.test.ts
@@ -50,21 +50,25 @@ describe("check --diff --gate baseline diff (US1)", () => {
     expect(json.baselineStatus).toBe("skipped");
   });
 
-  it("(b) harmless edit to a debt-connected file → exit 0, pre-existing REQ NOT new", async () => {
+  it("(b) harmless edit to the hub → exit 0, doc-sibling debt REQ excluded from scope entirely (spec 019 US3)", async () => {
     const dir = repo("artgraph-debt-us1b-");
-    // Touch the hub: its blast radius reaches the sibling pre-existing debt
-    // REQ-200 via the shared doc, but the edit introduces nothing new.
+    // spec 019 (issue #215): touching the hub reaches only its own `@impl`
+    // claim (REQ-100) — the `contains` reverse edge no longer bridges
+    // REQ-100 -> parent doc -> sibling REQ-200, so the pre-existing debt
+    // REQ never enters scope at all (previously it leaked in "for free" via
+    // the shared doc and had to be suppressed as pre-existing debt).
     appendFileSync(join(dir, "src", "hub.ts"), "\n// harmless comment\n");
 
     const { exitCode, json } = await checkJson(dir);
     expect(exitCode).toBe(0);
     expect(json.pass).toBe(true);
-    expect(json.baselineStatus).toBe("computed");
-    // REQ-200 is in scope (pre-existing) but must NOT be flagged as new.
-    expect(json.uncovered).toContain("REQ-200");
-    expect(json.newIssues.uncovered).not.toContain("REQ-200");
+    // Scope is now fully clean (REQ-100 alone, and it's covered) → the
+    // lazy-eval short-circuit fires; no baseline worktree is built.
+    expect(json.baselineStatus).toBe("skipped");
+    expect(json.uncovered).not.toContain("REQ-200");
+    expect(json.uncovered).toEqual([]);
     expect(json.newIssues.uncovered).toEqual([]);
-    expect(json.suppressedCount).toBeGreaterThanOrEqual(1);
+    expect(json.suppressedCount).toBe(0);
   });
 
   it("(c) editing an untracked file outside the graph → exit 0 (FR-013)", async () => {
@@ -112,16 +116,21 @@ describe("check --diff --gate baseline diff (US1)", () => {
     expect(json.baselineStatus).toBe("skipped");
   });
 
-  it("(e) scope with pre-existing debt only → baseline computed and subtracted → exit 0", async () => {
+  it("(e) hub-only edit → scope carries no pre-existing debt anymore → baseline skipped → exit 0 (spec 019 US3)", async () => {
     const dir = repo("artgraph-debt-us1e-");
+    // spec 019 (issue #215): this used to be the "pre-existing debt only"
+    // scenario (REQ-200 dragged in via the shared doc, then suppressed as
+    // pre-existing). With the doc-sibling leak fixed, hub.ts's blast radius
+    // is just REQ-100 (covered) — there is no debt in scope to suppress, so
+    // this now takes the exact same "skipped" lazy-eval path as (b)/(d).
     appendFileSync(join(dir, "src", "hub.ts"), "\n// another harmless comment\n");
 
     const { exitCode, json } = await checkJson(dir);
     expect(exitCode).toBe(0);
-    expect(json.baselineStatus).toBe("computed");
-    // Every scoped issue was pre-existing → nothing new → gate passes.
+    expect(json.baselineStatus).toBe("skipped");
+    // Nothing was ever in scope → nothing new, nothing suppressed.
     expect(json.newIssues).toEqual({ drifted: [], orphans: [], uncovered: [], testFailures: [] });
-    expect(json.suppressedCount).toBeGreaterThanOrEqual(1);
+    expect(json.suppressedCount).toBe(0);
   });
 });
 
@@ -334,25 +343,71 @@ describe("check --diff --gate rename-aware baseline normalization (C2)", () => {
 });
 
 // spec 017 US4 (T027) — the gate narrowing must NOT shrink the `impact --diff`
-// blast radius (FR-007 / SC-006). `impact` still reports the pre-existing debt
-// REQ that `check --gate` suppresses.
+// blast radius (FR-007 / SC-006): `check --diff`'s scope must always agree
+// with plain `impact --diff`'s reach — the gate only decides new-vs-pre-
+// existing, it never computes a narrower reachable set of its own.
+//
+// spec 019 (issue #215) update: this fixture's original demonstration relied
+// on REQ-200 being reachable from hub.ts ONLY via the doc-sibling containment
+// leak that spec 019 removes — REQ-100 and REQ-200 share `specs/debt.md` but
+// hub.ts has zero code dependency on REQ-200. That reachability was itself
+// the bug #215 reports, so "impact still reports the debt REQ the gate
+// suppresses" no longer has a debt REQ to report: hub.ts's blast radius is
+// now exactly REQ-100. The invariant this test protects (impact's view and
+// check's scope never diverge) still holds — just with a narrower shared
+// scope, which is the fix working as intended.
 describe("impact --diff blast radius is preserved (US4)", () => {
-  it("impact still reports the debt REQ that the gate suppresses", async () => {
+  it("impact and check --diff agree: hub.ts's blast radius is REQ-100 only, doc-sibling debt is out of scope (spec 019 US3)", async () => {
     const dir = repo("artgraph-us4-impact-");
     appendFileSync(join(dir, "src", "hub.ts"), "\n// harmless\n");
 
     const impact = await runAt(dir, ["impact", "--diff", "--format", "json"]);
     const ij = JSON.parse(impact.stdout);
-    // Blast radius reaches BOTH reqs via the shared doc — unchanged by spec 017.
-    expect(ij.impactReqs).toContain("REQ-100");
-    expect(ij.impactReqs).toContain("REQ-200");
-    expect(ij.summary.reqs).toBe(2);
+    expect(ij.impactReqs).toEqual(["REQ-100"]);
+    expect(ij.impactReqs).not.toContain("REQ-200");
+    expect(ij.summary.reqs).toBe(1);
 
-    // …yet the same change's gate treats the pre-existing REQ-200 as suppressed.
+    // check --diff's scope agrees: nothing pre-existing is in scope, so the
+    // lazy-eval short-circuit fires (baselineStatus "skipped") rather than
+    // computing a baseline to suppress a debt REQ that was never reached.
     const gate = await checkJson(dir);
     expect(gate.exitCode).toBe(0);
+    expect(gate.json.baselineStatus).toBe("skipped");
     expect(gate.json.newIssues.uncovered).not.toContain("REQ-200");
-    expect(gate.json.uncovered).toContain("REQ-200"); // still visible in scoped output
+    expect(gate.json.uncovered).not.toContain("REQ-200");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spec 019 (US3, T007) — dedicated pin for the spec's Independent Test:
+// same-doc REQ-A (REQ-100, implemented) / REQ-B (REQ-200, uncovered) via
+// `tests/helpers.ts`'s `makeRepoWithDebt` fixture. A code-only diff must NOT
+// pull REQ-B into the scoped `uncovered` array; diffing the spec file itself
+// must (spec-change path stays unretouched — FR-011 / Edge Case).
+// ---------------------------------------------------------------------------
+describe("check --diff scope purification — same-spec REQ-A/REQ-B (spec 019 US3, T007)", () => {
+  it("AS3-1: code-only diff (hub.ts) → scoped uncovered excludes the sibling debt REQ-B", async () => {
+    const dir = repo("artgraph-019-us3-code-");
+    appendFileSync(join(dir, "src", "hub.ts"), "\n// spec 019 US3 pin — code-only diff\n");
+    const { exitCode, json } = await checkJson(dir);
+    expect(exitCode).toBe(0);
+    expect(json.pass).toBe(true);
+    expect(json.uncovered).not.toContain("REQ-200");
+  });
+
+  it("AS3-2: spec-file diff (specs/debt.md) → REQ-B enters scope as (pre-existing) uncovered", async () => {
+    const dir = repo("artgraph-019-us3-spec-");
+    appendFileSync(join(dir, "specs", "debt.md"), "\n<!-- spec 019 US3 pin — spec-file diff -->\n");
+    const { exitCode, json } = await checkJson(dir);
+    expect(exitCode).toBe(0);
+    expect(json.pass).toBe(true);
+    // resolveStartIds' filePath fallback seeds the doc + every req parsed
+    // from it directly (no `contains` traversal needed) — unaffected by the
+    // direction constraint, per spec 019 Edge Cases.
+    expect(json.uncovered).toContain("REQ-200");
+    // Still pre-existing (REQ-100/REQ-200 content unchanged) → suppressed,
+    // not new.
+    expect(json.newIssues.uncovered).not.toContain("REQ-200");
   });
 });
 

--- a/tests/check-gate-output.test.ts
+++ b/tests/check-gate-output.test.ts
@@ -35,7 +35,7 @@ afterEach(() => {
 });
 
 describe("check --diff text output (US3, FR-008)", () => {
-  it("(a) new issues → summary + new detail + suppressed count + impact pointer (§4.1)", async () => {
+  it("(a) new issues → summary + new detail; no pre-existing debt left in scope (§4.1, spec 019 US3)", async () => {
     const dir = track(makeRepoWithDebt("artgraph-out-newa-"));
     introduceNewOrphan(dir);
     const { stdout, exitCode } = await runAt(dir, ["check", "--diff", "--gate"]);
@@ -46,27 +46,29 @@ describe("check --diff text output (US3, FR-008)", () => {
     // New-issue detail, grouped with a per-category count.
     expect(stdout).toMatch(/ORPHANS \(1\):/);
     expect(stdout).toContain("REQ-999 (implements)");
-    // Pre-existing debt is collapsed to a suppressed count + a pointer.
-    expect(stdout).toMatch(/pre-existing issue(s)? in blast radius (was|were) suppressed\./);
-    expect(stdout).toContain("artgraph impact --diff");
-    // SC-004: the pre-existing uncovered REQ is NOT enumerated in the output.
+    // spec 019 (issue #215): hub.ts's blast radius no longer reaches the
+    // doc-sibling debt REQ-200 (no code dependency between them) — there is
+    // nothing pre-existing left in scope, so neither the suppressed-count
+    // line nor the impact pointer print anymore.
+    expect(stdout).not.toMatch(/pre-existing issue/);
+    expect(stdout).not.toContain("artgraph impact --diff");
+    // SC-004 (unchanged): the pre-existing uncovered REQ is NOT enumerated.
     expect(stdout).not.toContain("REQ-200");
   });
 
-  it("(b) no new issues but pre-existing debt → concise + parenthetical suppressed count (§4.2)", async () => {
+  it("(b) hub.ts edit → doc-sibling debt no longer in scope → bare concise line (was §4.2, spec 019 US3)", async () => {
     const dir = track(makeRepoWithDebt("artgraph-out-preb-"));
     appendFileSync(join(dir, "src", "hub.ts"), "\n// harmless comment\n");
     const { stdout, exitCode } = await runAt(dir, ["check", "--diff", "--gate"]);
 
     expect(exitCode).toBe(0);
     expect(stdout).toContain("No new issues introduced by this change.");
-    // Parenthetical suppressed count (§4.2 shape).
-    expect(stdout).toMatch(
-      /\(\d+ pre-existing issue(s)? in blast radius (was|were) suppressed\.\)/,
-    );
-    // SC-004: pre-existing debt list is NOT dumped.
+    // spec 019 (issue #215): REQ-200 is no longer part of hub.ts's blast
+    // radius at all (no code dependency, only same-doc siblinghood) — there
+    // is nothing pre-existing left in scope to suppress, so this scenario
+    // now matches the bare §4.3 shape (no parenthetical suppressed line).
+    expect(stdout).not.toContain("suppressed");
     expect(stdout).not.toContain("REQ-200");
-    // No impact pointer when there are zero new issues.
     expect(stdout).not.toContain("artgraph impact --diff");
   });
 
@@ -83,7 +85,7 @@ describe("check --diff text output (US3, FR-008)", () => {
 });
 
 describe("check --diff json output (US3, FR-009, contract §3)", () => {
-  it("(C7) keeps existing fields and adds newIssues/suppressedCount/baselineStatus", async () => {
+  it("(C7) keeps existing fields and adds newIssues/suppressedCount/baselineStatus (spec 019 US3)", async () => {
     const dir = track(makeRepoWithDebt("artgraph-json-c7-"));
     introduceNewOrphan(dir);
     const { stdout, exitCode } = await runAt(dir, [
@@ -103,15 +105,19 @@ describe("check --diff json output (US3, FR-009, contract §3)", () => {
     expect(Array.isArray(j.coverage)).toBe(true);
     expect(Array.isArray(j.testFailures)).toBe(true);
     expect(Array.isArray(j.warnings)).toBe(true);
-    // scoped orphans include BOTH the new one and (in-scope) content.
+    // scoped orphans include the new one.
     expect(j.orphans).toContain("file:src/hub.ts -> REQ-999 (implements)");
-    // pre-existing uncovered is present in the scoped list…
-    expect(j.uncovered).toContain("REQ-200");
-    // …but suppressed from newIssues.
+    // spec 019 (issue #215): REQ-200 no longer enters scope via doc-sibling
+    // containment — hub.ts's blast radius is exactly REQ-100 (covered), so
+    // there is no pre-existing uncovered REQ left in the scoped list either.
+    expect(j.uncovered).not.toContain("REQ-200");
     expect(j.newIssues.uncovered).not.toContain("REQ-200");
     // Added fields.
     expect(j.newIssues.orphans).toEqual(["file:src/hub.ts -> REQ-999 (implements)"]);
-    expect(j.suppressedCount).toBeGreaterThanOrEqual(1);
+    // Nothing pre-existing is in scope to suppress — the new orphan is the
+    // only scoped issue, and it's new (not suppressed).
+    expect(j.suppressedCount).toBe(0);
+    // The orphan alone is still a scoped issue → baseline is still computed.
     expect(j.baselineStatus).toBe("computed");
     expect(j.pass).toBe(false);
   });
@@ -146,10 +152,15 @@ describe("check --diff matrix: gate × format × baselineStatus", () => {
 
   const cases: Case[] = [
     {
-      name: "computed + no new (pre-existing only)",
+      // spec 019 (issue #215): hub.ts's blast radius no longer reaches the
+      // doc-sibling debt REQ-200 (no code dependency) — the scope is fully
+      // clean (REQ-100 alone, covered), so the lazy-eval short-circuit fires
+      // and baselineStatus is "skipped", not "computed" (was "computed +
+      // no new (pre-existing only)" pre-spec-019).
+      name: "skipped (hub edit — doc-sibling debt out of scope, spec 019)",
       make: () => makeRepoWithDebt("artgraph-mx-comp-clean-"),
       edit: (d) => appendFileSync(join(d, "src", "hub.ts"), "\n// noop\n"),
-      status: "computed",
+      status: "skipped",
       hasNew: false,
     },
     {

--- a/tests/impact-cli.test.ts
+++ b/tests/impact-cli.test.ts
@@ -16,7 +16,7 @@
 //     fixture (FIXTURE_DIR) so we don't pay the symbol-mode scan cost.
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, rmSync, cpSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, cpSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { runAt, FIXTURE_DIR } from "./helpers.js";
@@ -473,5 +473,184 @@ describe("CLI: impact — input validation (spec 016 keeps spec 014 behavior)", 
     const { exitCode, stderr } = await runAt(FIXTURE_DIR, ["impact"]);
     expect(exitCode).toBe(1);
     expect(stderr).toMatch(/no.*target|no start source/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spec 019 (T008, SC-001) — issue #215 minimal repro, CLI E2E. `mode: symbol`
+// with `docGraph.autoContains` at its DEFAULT (true) — unlike
+// `setupSymbolModeFixture` above (which sets `autoContains: false` and so
+// never exercises the doc-sibling containment leak). fnA (`@impl REQ-901`) /
+// fnB (`@impl REQ-902`) co-located in one spec.md; fnA has zero code
+// dependency on fnB.
+// ---------------------------------------------------------------------------
+
+function writeContainsReproSpec(root: string, extraReqLine?: string): void {
+  mkdirSync(join(root, "specs"), { recursive: true });
+  writeFileSync(
+    join(root, "specs", "901-demo.md"),
+    [
+      "# 901 Demo Spec (issue #215 minimal repro)",
+      "",
+      "## Requirements",
+      "",
+      "- REQ-901: fnA does X",
+      "- REQ-902: fnB does Y",
+      ...(extraReqLine ? [extraReqLine] : []),
+      "",
+    ].join("\n"),
+  );
+}
+
+function writeArtgraphConfig(root: string): void {
+  writeFileSync(
+    join(root, ".artgraph.json"),
+    JSON.stringify({
+      include: ["src/**/*.ts"],
+      specDirs: ["specs"],
+      testPatterns: ["tests/**/*.test.ts"],
+      lockFile: ".trace.lock",
+      mode: "symbol",
+      // Deliberately NO `docGraph.autoContains` override — defaults to true.
+    }),
+  );
+}
+
+describe("CLI: impact — issue #215 minimal repro (spec 019 contains direction, T008/SC-001)", () => {
+  let root: string;
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+  });
+
+  it("repro step 1 (AS1-1): fnA/fnB same file, no code dependency → impactReqs=[REQ-901] only", async () => {
+    root = mkdtempSync(join(tmpdir(), "artgraph-215-repro1-"));
+    writeContainsReproSpec(root);
+    writeArtgraphConfig(root);
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(
+      join(root, "src", "sample.ts"),
+      [
+        "export function fnA(): void {",
+        "  // @impl REQ-901",
+        "}",
+        "",
+        "export function fnB(): void {",
+        "  // @impl REQ-902",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    const { stdout, exitCode } = await runAt(root, [
+      "impact",
+      "src/sample.ts:fnA",
+      "--format",
+      "json",
+    ]);
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.impactReqs).toEqual(["REQ-901"]);
+    expect(result.impactReqs).not.toContain("REQ-902");
+    expect(result.drifted.some((d: { nodeId: string }) => d.nodeId === "REQ-902")).toBe(false);
+    // Attribution: the parent spec doc still surfaces as context.
+    expect(result.affectedDocs.length).toBeGreaterThan(0);
+  });
+
+  it("repro step 2 (AS1-2): fnB in a separate file, no code dependency → impactReqs=[REQ-901], other.ts excluded", async () => {
+    root = mkdtempSync(join(tmpdir(), "artgraph-215-repro2-"));
+    writeContainsReproSpec(root);
+    writeArtgraphConfig(root);
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(
+      join(root, "src", "sample.ts"),
+      ["export function fnA(): void {", "  // @impl REQ-901", "}", ""].join("\n"),
+    );
+    writeFileSync(
+      join(root, "src", "other.ts"),
+      ["export function fnB(): void {", "  // @impl REQ-902", "}", ""].join("\n"),
+    );
+
+    const { stdout, exitCode } = await runAt(root, [
+      "impact",
+      "src/sample.ts:fnA",
+      "--format",
+      "json",
+    ]);
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.impactReqs).toEqual(["REQ-901"]);
+    expect(result.affectedFiles).not.toContain("src/other.ts");
+  });
+
+  it("repro step 3 (AS1-5): REQ-901/902 split across separate spec docs → behavior unchanged (still excluded)", async () => {
+    root = mkdtempSync(join(tmpdir(), "artgraph-215-repro3-"));
+    mkdirSync(join(root, "specs"), { recursive: true });
+    writeFileSync(
+      join(root, "specs", "901.md"),
+      ["# 901 Spec", "", "## Requirements", "", "- REQ-901: fnA does X", ""].join("\n"),
+    );
+    writeFileSync(
+      join(root, "specs", "902.md"),
+      ["# 902 Spec", "", "## Requirements", "", "- REQ-902: fnB does Y", ""].join("\n"),
+    );
+    writeArtgraphConfig(root);
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(
+      join(root, "src", "sample.ts"),
+      ["export function fnA(): void {", "  // @impl REQ-901", "}", ""].join("\n"),
+    );
+    writeFileSync(
+      join(root, "src", "other.ts"),
+      ["export function fnB(): void {", "  // @impl REQ-902", "}", ""].join("\n"),
+    );
+
+    const { stdout, exitCode } = await runAt(root, [
+      "impact",
+      "src/sample.ts:fnA",
+      "--format",
+      "json",
+    ]);
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.impactReqs).toEqual(["REQ-901"]);
+    expect(result.affectedFiles).not.toContain("src/other.ts");
+  });
+
+  it("AS1-3: sample.ts imports fnB → REQ-902 IS included (legit code-dependency blast radius)", async () => {
+    // NOTE: the TS parser attributes cross-file `imports` edges at FILE
+    // grain even in symbol mode (`src/parsers/typescript.ts` `sourceId =
+    // file:${relPath}`, unrelated to spec 019 — barrel/re-export chains are
+    // the one exception, see issue #191). A symbol-unit start (`fnA`,
+    // deliberately excluding its parent file per R-006) would never see
+    // that edge regardless of this fix, so this regression pin uses a
+    // file-unit entry (`src/sample.ts`), which resolveStartIds seeds
+    // together with the file node itself — exactly where the real
+    // `imports` edge is anchored.
+    root = mkdtempSync(join(tmpdir(), "artgraph-215-repro-imports-"));
+    writeContainsReproSpec(root);
+    writeArtgraphConfig(root);
+    mkdirSync(join(root, "src"), { recursive: true });
+    writeFileSync(
+      join(root, "src", "other.ts"),
+      ["export function fnB(): void {", "  // @impl REQ-902", "}", ""].join("\n"),
+    );
+    writeFileSync(
+      join(root, "src", "sample.ts"),
+      [
+        'import { fnB } from "./other.js";',
+        "",
+        "export function fnA(): void {",
+        "  // @impl REQ-901",
+        "  fnB();",
+        "}",
+        "",
+      ].join("\n"),
+    );
+
+    const { stdout, exitCode } = await runAt(root, ["impact", "src/sample.ts", "--format", "json"]);
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.impactReqs).toEqual(expect.arrayContaining(["REQ-901", "REQ-902"]));
+    expect(result.affectedFiles).toContain("src/other.ts");
   });
 });

--- a/tests/plan-coverage.test.ts
+++ b/tests/plan-coverage.test.ts
@@ -37,8 +37,14 @@ interface FixtureRoot {
 // implemented by src/auth/login.ts AND src/auth/session.ts; AUTH-002 by
 // src/auth/session.ts only; AUTH-003 by src/auth/logout.ts. tasks.md
 // declares `Files: src/auth/login.ts` only — so the implicit blast from
-// that file should be AUTH-001 (mentioned only if the user wrote it in
-// tasks/plan/spec) and via the doc → other-req hops, AUTH-002 and AUTH-003.
+// that file is AUTH-001 alone (mentioned only if the user wrote it in
+// tasks/plan/spec). Since spec 019 (issue #215), same-spec-doc siblings
+// (AUTH-002 / AUTH-003) are NOT swept in merely because they share
+// doc:auth-design with AUTH-001 — `contains` reverse traversal no longer
+// bridges req -> parent doc -> sibling req. Tests below that need AUTH-002 /
+// AUTH-003 to be reachable explicitly list `session.ts` / `logout.ts` in
+// `Files:` (real code-dependency origin) instead of relying on doc
+// containment.
 function setupFixture(opts?: {
   tasksBody?: string;
   planBody?: string;
@@ -152,15 +158,21 @@ describe("runPlanCoverage — by-sourceFile + by-FR dual axis", () => {
     expect(result.json.implicitImpacts).toBeDefined();
     expect(result.json.implicitImpactsByReq).toBeDefined();
 
-    // Login.ts brings AUTH-001 + (via doc:auth-design containment) AUTH-002
-    // and AUTH-003. None are mentioned in tasks/plan/spec text → all implicit.
+    // spec 019 (FR-010, issue #215): login.ts `@impl`s AUTH-001 only.
+    // AUTH-002 is still legitimately reached — session.ts implements BOTH
+    // AUTH-001 and AUTH-002, so `implements` (unaffected by this spec, still
+    // bidirectional) bridges login.ts -> AUTH-001 -> session.ts -> AUTH-002
+    // via a real shared-implementer file, not doc co-location. AUTH-003
+    // (logout.ts's lone claim, no shared-file bridge to login.ts) must NOT
+    // leak in anymore merely because it shares doc:auth-design with
+    // AUTH-001/002 — that pure same-spec-doc containment amplification is
+    // exactly what issue #215 reported and this spec removes (US1/US2).
     const reqIds = new Set<string>();
     for (const group of result.json.implicitImpacts) {
       for (const req of group.impactReqs) reqIds.add(req.reqId);
     }
-    expect(reqIds.has("AUTH-001")).toBe(true);
-    expect(reqIds.has("AUTH-002")).toBe(true);
-    expect(reqIds.has("AUTH-003")).toBe(true);
+    expect(reqIds).toEqual(new Set(["AUTH-001", "AUTH-002"]));
+    expect(reqIds.has("AUTH-003")).toBe(false);
 
     // by-FR axis is the inversion of the by-sourceFile axis.
     const byReqIds = result.json.implicitImpactsByReq.map((r) => r.reqId);
@@ -1310,5 +1322,167 @@ describe("runPlanCoverage — symbol-mode US1 (Phase 3)", () => {
     });
     expect(result.text).toContain("Drift candidates");
     expect(result.text).toContain("REQ-007");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spec 019 (US2, T006) — dedicated pin for the spec's Independent Test:
+// REQ-001/005/009 declared together in ONE spec.md (Spec Kit standard
+// layout), `docGraph.autoContains` left at its default (true) so `contains`
+// edges actually exist — unlike `setupSymbolFixture` above, which disables
+// autoContains and therefore never exercised the doc-sibling leak issue
+// #215 reports. A symbol-unit `Files:` entry for validateToken must NOT pull
+// its same-spec-doc siblings (REQ-005 / REQ-009) into `impactReqs`.
+// ---------------------------------------------------------------------------
+
+interface SameSpecFixture {
+  root: string;
+  specDir: string;
+  tasksPath: string;
+  planPath: string;
+}
+
+function setupSameSpecFixture(opts?: {
+  tasksBody?: string;
+  /** REQ-001 depends_on REQ-007 (same spec.md) — spec 019 AS2-2. */
+  addReq007DependsOnReq001?: boolean;
+}): SameSpecFixture {
+  const root = mkdtempSync(join(tmpdir(), "artgraph-pc-samespec-"));
+  const specDir = join(root, "specs/001-symbol-demo");
+  mkdirSync(specDir, { recursive: true });
+
+  // Analysis target spec.md — intentionally REQ-ID-free (mirrors
+  // `setupSymbolFixture`) so the mention detector doesn't eclipse implicit
+  // impacts. The REQ-001/005/009 (+ REQ-007) definitions all live TOGETHER
+  // in one external spec.md below — that co-location is the whole point of
+  // this fixture (spec 019 US2 / issue #215's "1 feature = 1 spec.md with
+  // multiple REQs" scenario).
+  writeFileSync(
+    join(specDir, "spec.md"),
+    [
+      "# Symbol Demo Spec (spec 019 US2 fixture)",
+      "",
+      "Intentionally REQ-ID-free body — REQ definitions live in the external",
+      "same-spec-doc catalogue below.",
+      "",
+    ].join("\n"),
+  );
+
+  const reqLines = [
+    "- REQ-001: validateToken must reject empty bearer tokens.",
+    "- REQ-005: issueToken must mint a fresh bearer token tied to a user id.",
+    "- REQ-009: revokeToken must mark a token as revoked.",
+  ];
+  if (opts?.addReq007DependsOnReq001) {
+    reqLines.push("- REQ-007: audit hook. (depends_on: REQ-001)");
+  }
+  const externalSpecDir = join(root, "specs/auth-design");
+  mkdirSync(externalSpecDir, { recursive: true });
+  writeFileSync(
+    join(externalSpecDir, "requirements.md"),
+    [
+      "# Auth Requirements (same spec.md, spec 019 US2 fixture)",
+      "",
+      "## Requirements",
+      "",
+      ...reqLines,
+      "",
+    ].join("\n"),
+  );
+
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(
+    join(root, "src/auth.ts"),
+    [
+      "export function validateToken(token: string): boolean {",
+      "  // @impl REQ-001",
+      "  return token.length > 0;",
+      "}",
+      "export function issueToken(userId: string): string {",
+      "  // @impl REQ-005",
+      "  return `token:${userId}`;",
+      "}",
+      "export function revokeToken(token: string): void {",
+      "  // @impl REQ-009",
+      "  void token;",
+      "}",
+      "",
+    ].join("\n"),
+  );
+
+  writeFileSync(
+    join(root, ".artgraph.json"),
+    JSON.stringify({
+      include: ["src/**/*.ts"],
+      specDirs: ["specs"],
+      testPatterns: ["tests/**/*.test.ts"],
+      lockFile: ".trace.lock",
+      mode: "symbol",
+      // Deliberately NO `docGraph.autoContains` override — defaults to true,
+      // so `contains` edges exist and this fixture actually exercises the
+      // direction constraint (unlike `setupSymbolFixture`'s autoContains:false).
+    }),
+  );
+
+  const tasksBody =
+    opts?.tasksBody ??
+    ["# Tasks", "", "### T001", "", "Files: src/auth.ts:validateToken", ""].join("\n");
+  const tasksPath = join(specDir, "tasks.md");
+  writeFileSync(tasksPath, tasksBody);
+
+  const planPath = join(specDir, "plan.md");
+  writeFileSync(planPath, "# Plan\n\nNo REQ references.\n");
+  return { root, specDir, tasksPath, planPath };
+}
+
+describe("runPlanCoverage — same-spec REQ siblings excluded from impactReqs (spec 019 US2, T006)", () => {
+  let fx: SameSpecFixture;
+  afterEach(() => {
+    if (fx) rmSync(fx.root, { recursive: true, force: true });
+  });
+
+  it("AS2-1: Files: src/auth.ts:validateToken → impactReqs is REQ-001 only (siblings REQ-005/009 excluded)", () => {
+    fx = setupSameSpecFixture();
+    const result = runPlanCoverage({
+      repoRoot: fx.root,
+      specDir: fx.specDir,
+      tasksPath: fx.tasksPath,
+      planPath: fx.planPath,
+      format: "json",
+      gate: false,
+      ignore: [],
+      requireFilesSection: false,
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.json.implicitImpacts).toHaveLength(1);
+    const g = result.json.implicitImpacts[0];
+    expect(g.impactReqs.map((r: { reqId: string }) => r.reqId)).toEqual(["REQ-001"]);
+    // Two-axis comparison (impactReqs \ originReqs) is empty — no drift.
+    const impactIds = g.impactReqs.map((r: { reqId: string }) => r.reqId);
+    const originIds = g.originReqs.map((r: { reqId: string }) => r.reqId);
+    expect(impactIds.filter((id: string) => !originIds.includes(id))).toEqual([]);
+  });
+
+  it("AS2-2: `REQ-001 depends_on REQ-007` (same spec) → impactReqs = [REQ-001, REQ-007]; siblings still excluded", () => {
+    fx = setupSameSpecFixture({ addReq007DependsOnReq001: true });
+    const result = runPlanCoverage({
+      repoRoot: fx.root,
+      specDir: fx.specDir,
+      tasksPath: fx.tasksPath,
+      planPath: fx.planPath,
+      format: "json",
+      gate: false,
+      ignore: [],
+      requireFilesSection: false,
+    });
+    expect(result.json.implicitImpacts).toHaveLength(1);
+    const g = result.json.implicitImpacts[0];
+    const impactIds = g.impactReqs.map((r: { reqId: string }) => r.reqId).sort();
+    const originIds = g.originReqs.map((r: { reqId: string }) => r.reqId);
+    expect(impactIds).toEqual(["REQ-001", "REQ-007"]);
+    expect(originIds).toEqual(["REQ-001"]);
+    // Drift candidate axis surfaces REQ-007 only — REQ-005/009 never appear.
+    const drift = impactIds.filter((id) => !originIds.includes(id));
+    expect(drift).toEqual(["REQ-007"]);
   });
 });

--- a/tests/traverse.test.ts
+++ b/tests/traverse.test.ts
@@ -9,7 +9,13 @@ import {
   formatOrphan,
   findUncovered,
 } from "../src/graph/traverse.js";
-import type { ArtgraphConfig, ArtifactGraph, GraphNode, LockFile } from "../src/types.js";
+import type {
+  ArtgraphConfig,
+  ArtifactGraph,
+  GraphEdge,
+  GraphNode,
+  LockFile,
+} from "../src/types.js";
 
 // spec 016 — `resolveFileStartIds` was removed in favor of `resolveStartIds`.
 // Provide a local compat shim so spec 014 test bodies still compile/import
@@ -557,5 +563,226 @@ describe("resolveOriginReqs (spec 016)", () => {
     const reqs = resolveOriginReqs(graph, ["symbol:src/auth.ts#validateToken"]);
     // REQ-009 must NOT appear — `depends_on` is not the `implements` axis.
     expect(reqs).toEqual(["REQ-001"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spec 019 (issue #215) — `contains` 辺の方向制約 + 親 doc 帰属アトリビューション
+//
+// T001/T002: hand-rolled fixtures mirroring the issue #215 minimal repro
+// (fnA `@impl REQ-901` / fnB `@impl REQ-902` co-located in one spec.md, no
+// code dependency between fnA/fnB). Under the CURRENT (pre-fix) bidirectional
+// BFS these are RED: REQ-902 leaks into `impactReqs` via
+// fnA -> REQ-901 -> (reverse contains) doc -> (forward contains) REQ-902.
+// Phase 2 (T003/T004) makes them GREEN by restricting `contains` reverse
+// traversal and re-adding the parent doc via post-BFS attribution.
+// ---------------------------------------------------------------------------
+
+function makeContainsFixture(
+  opts: { sameFile?: boolean; splitSpec?: boolean } = {},
+): ArtifactGraph {
+  const { sameFile = true, splitSpec = false } = opts;
+  const fileA = "src/sample.ts";
+  const fileB = sameFile ? "src/sample.ts" : "src/other.ts";
+
+  const nodes = new Map<string, GraphNode>();
+  nodes.set("doc:d1", {
+    id: "doc:d1",
+    kind: "doc",
+    filePath: "specs/901.md",
+    contentHash: "doc1-hash",
+  });
+  if (splitSpec) {
+    nodes.set("doc:d2", {
+      id: "doc:d2",
+      kind: "doc",
+      filePath: "specs/902.md",
+      contentHash: "doc2-hash",
+    });
+  }
+  nodes.set("REQ-901", {
+    id: "REQ-901",
+    kind: "req",
+    filePath: "specs/901.md",
+    contentHash: "req901-hash",
+  });
+  nodes.set("REQ-902", {
+    id: "REQ-902",
+    kind: "req",
+    filePath: splitSpec ? "specs/902.md" : "specs/901.md",
+    contentHash: "req902-hash",
+  });
+  nodes.set(`file:${fileA}`, {
+    id: `file:${fileA}`,
+    kind: "file",
+    filePath: fileA,
+    contentHash: "fa",
+  });
+  if (fileB !== fileA) {
+    nodes.set(`file:${fileB}`, {
+      id: `file:${fileB}`,
+      kind: "file",
+      filePath: fileB,
+      contentHash: "fb",
+    });
+  }
+  nodes.set(`symbol:${fileA}#fnA`, {
+    id: `symbol:${fileA}#fnA`,
+    kind: "symbol",
+    filePath: fileA,
+    contentHash: "fna",
+    label: "fnA",
+  });
+  nodes.set(`symbol:${fileB}#fnB`, {
+    id: `symbol:${fileB}#fnB`,
+    kind: "symbol",
+    filePath: fileB,
+    contentHash: "fnb",
+    label: "fnB",
+  });
+
+  const edges: GraphEdge[] = [
+    { source: "doc:d1", target: "REQ-901", kind: "contains", provenances: ["structural"] },
+    {
+      source: splitSpec ? "doc:d2" : "doc:d1",
+      target: "REQ-902",
+      kind: "contains",
+      provenances: ["structural"],
+    },
+    {
+      source: `symbol:${fileA}#fnA`,
+      target: "REQ-901",
+      kind: "implements",
+      provenances: ["code-tag"],
+    },
+    {
+      source: `symbol:${fileB}#fnB`,
+      target: "REQ-902",
+      kind: "implements",
+      provenances: ["code-tag"],
+    },
+  ];
+
+  return { nodes, edges };
+}
+
+describe("impact: contains 辺方向制約 — US1 (issue #215 repro, spec 019)", () => {
+  it("AS1-1: same-file fnA/fnB, no code dependency — REQ-902 excluded from impactReqs", () => {
+    const graph = makeContainsFixture({ sameFile: true });
+    const result = impact(graph, ["symbol:src/sample.ts#fnA"], {});
+    expect(result.impactReqs).toEqual(["REQ-901"]);
+    expect(result.impactReqs).not.toContain("REQ-902");
+    expect(result.drifted.some((d) => d.nodeId === "REQ-902")).toBe(false);
+  });
+
+  it("AS1-2: fnB in a separate file, no code dependency — REQ-902 / other.ts excluded", () => {
+    const graph = makeContainsFixture({ sameFile: false });
+    const result = impact(graph, ["symbol:src/sample.ts#fnA"], {});
+    expect(result.impactReqs).toEqual(["REQ-901"]);
+    expect(result.affectedFiles).not.toContain("src/other.ts");
+  });
+
+  it("AS1-5: REQ-901/REQ-902 split across separate spec docs — behavior unchanged (still excluded)", () => {
+    const graph = makeContainsFixture({ sameFile: false, splitSpec: true });
+    const result = impact(graph, ["symbol:src/sample.ts#fnA"], {});
+    expect(result.impactReqs).toEqual(["REQ-901"]);
+    expect(result.affectedFiles).not.toContain("src/other.ts");
+  });
+
+  it("AS1-3: fnA imports fnB — REQ-902 IS reached via `imports` (code-dependency blast radius is legit)", () => {
+    const graph = makeContainsFixture({ sameFile: false });
+    graph.edges.push({
+      source: "symbol:src/sample.ts#fnA",
+      target: "symbol:src/other.ts#fnB",
+      kind: "imports",
+      provenances: ["ts-import"],
+    });
+    const result = impact(graph, ["symbol:src/sample.ts#fnA"], {});
+    expect(result.impactReqs).toEqual(expect.arrayContaining(["REQ-901", "REQ-902"]));
+    expect(result.affectedFiles).toContain("src/other.ts");
+  });
+
+  it("AS1-4: parent doc is attributed to affectedDocs and participates in drift detection", () => {
+    const graph = makeContainsFixture({ sameFile: true });
+    const result = impact(graph, ["symbol:src/sample.ts#fnA"], {});
+    expect(result.affectedDocs).toContain("doc:d1");
+
+    const staleLock: LockFile = {
+      "doc:d1": { contentHash: "stale", lastReconciled: "2025-01-01T00:00:00Z" },
+    };
+    const withDrift = impact(graph, ["symbol:src/sample.ts#fnA"], staleLock);
+    expect(withDrift.drifted.some((d) => d.nodeId === "doc:d1" && d.kind === "doc")).toBe(true);
+  });
+
+  it("AS1-6: `REQ-901 depends_on REQ-903` (separate spec) — req→req reach is maintained", () => {
+    const graph = makeContainsFixture({ sameFile: true });
+    graph.nodes.set("doc:d3", {
+      id: "doc:d3",
+      kind: "doc",
+      filePath: "specs/903.md",
+      contentHash: "d3",
+    });
+    graph.nodes.set("REQ-903", {
+      id: "REQ-903",
+      kind: "req",
+      filePath: "specs/903.md",
+      contentHash: "r903",
+    });
+    graph.edges.push(
+      { source: "doc:d3", target: "REQ-903", kind: "contains", provenances: ["structural"] },
+      { source: "REQ-901", target: "REQ-903", kind: "depends_on", provenances: ["annotation"] },
+    );
+    const result = impact(graph, ["symbol:src/sample.ts#fnA"], {});
+    expect(result.impactReqs).toEqual(expect.arrayContaining(["REQ-901", "REQ-903"]));
+    expect(result.impactReqs).not.toContain("REQ-902");
+  });
+
+  it("FR-003: doc→task contains direction constraint — sibling task not swept via req→task→doc→task", () => {
+    const nodes = new Map<string, GraphNode>();
+    nodes.set("REQ-901", {
+      id: "REQ-901",
+      kind: "req",
+      filePath: "specs/901.md",
+      contentHash: "r",
+    });
+    nodes.set("REQ-902", {
+      id: "REQ-902",
+      kind: "req",
+      filePath: "specs/901.md",
+      contentHash: "r2",
+    });
+    nodes.set("doc:tasks", {
+      id: "doc:tasks",
+      kind: "doc",
+      filePath: "specs/tasks.md",
+      contentHash: "dt",
+    });
+    nodes.set("T001", { id: "T001", kind: "task", filePath: "specs/tasks.md", contentHash: "t1" });
+    nodes.set("T002", { id: "T002", kind: "task", filePath: "specs/tasks.md", contentHash: "t2" });
+    const edges: GraphEdge[] = [
+      { source: "T001", target: "REQ-901", kind: "implements", provenances: ["task-tag"] },
+      { source: "T002", target: "REQ-902", kind: "implements", provenances: ["task-tag"] },
+      { source: "doc:tasks", target: "T001", kind: "contains", provenances: ["structural"] },
+      { source: "doc:tasks", target: "T002", kind: "contains", provenances: ["structural"] },
+    ];
+    const graph: ArtifactGraph = { nodes, edges };
+
+    const result = impact(graph, ["REQ-901"], {});
+    expect(result.affectedTasks).toContain("T001");
+    expect(result.affectedTasks).not.toContain("T002");
+    expect(result.impactReqs).not.toContain("REQ-902");
+    // Attribution: doc:tasks still surfaces as T001's parent doc.
+    expect(result.affectedDocs).toContain("doc:tasks");
+  });
+
+  it("Edge Case: spec-path start (resolveStartIds filePath fallback) still reaches all child REQs", () => {
+    const graph = makeContainsFixture({ sameFile: true });
+    const { startIds } = resolveStartIds(graph, [{ path: "specs/901.md", line: 1 }]);
+    expect(startIds).toContain("doc:d1");
+    expect(startIds).toContain("REQ-901");
+    expect(startIds).toContain("REQ-902");
+
+    const result = impact(graph, startIds, {});
+    expect(result.impactReqs).toEqual(expect.arrayContaining(["REQ-901", "REQ-902"]));
   });
 });

--- a/tests/traverse.test.ts
+++ b/tests/traverse.test.ts
@@ -786,3 +786,89 @@ describe("impact: contains 辺方向制約 — US1 (issue #215 repro, spec 019)"
     expect(result.impactReqs).toEqual(expect.arrayContaining(["REQ-901", "REQ-902"]));
   });
 });
+
+describe("impact: spec 019 review follow-up — attribution guard & intentional task bridge", () => {
+  it("attribution ignores contains edges whose source is dangling or not a doc node", () => {
+    const nodes = new Map<string, GraphNode>();
+    nodes.set("REQ-1", { id: "REQ-1", kind: "req", filePath: "specs/a.md", contentHash: "r1" });
+    nodes.set("file:src/a.ts", {
+      id: "file:src/a.ts",
+      kind: "file",
+      filePath: "src/a.ts",
+      contentHash: "fa",
+    });
+    nodes.set("symbol:src/a.ts#f", {
+      id: "symbol:src/a.ts#f",
+      kind: "symbol",
+      filePath: "src/a.ts",
+      contentHash: "sf",
+    });
+    const edges: GraphEdge[] = [
+      {
+        source: "symbol:src/a.ts#f",
+        target: "REQ-1",
+        kind: "implements",
+        provenances: ["code-tag"],
+      },
+      // Malformed by construction — builder.ts never emits these, but
+      // impact() also receives hand-built graphs: a dangling doc id and a
+      // non-doc source must not leak into affectedDocs.
+      { source: "doc:ghost", target: "REQ-1", kind: "contains", provenances: ["structural"] },
+      { source: "file:src/a.ts", target: "REQ-1", kind: "contains", provenances: ["structural"] },
+    ];
+    const graph: ArtifactGraph = { nodes, edges };
+
+    const result = impact(graph, ["symbol:src/a.ts#f"], {});
+    expect(result.impactReqs).toEqual(["REQ-1"]);
+    expect(result.affectedDocs).toEqual([]);
+  });
+
+  it("pins the INTENTIONAL multi-REQ task bridge (spec 019 Edge Cases watch item)", () => {
+    // T020 bundles REQ-901 + REQ-902 into one declared unit of work
+    // (task-tag `implements`). Reaching REQ-901 from code legitimately pulls
+    // in T020 and, through it, REQ-902 — unlike doc co-residency this is an
+    // author-declared causal link and must keep working. Sibling task T021
+    // (connected only via doc:tasks `contains`) must stay unreachable.
+    const nodes = new Map<string, GraphNode>();
+    nodes.set("doc:tasks", {
+      id: "doc:tasks",
+      kind: "doc",
+      filePath: "specs/tasks.md",
+      contentHash: "dt",
+    });
+    nodes.set("T020", { id: "T020", kind: "task", filePath: "specs/tasks.md", contentHash: "t20" });
+    nodes.set("T021", { id: "T021", kind: "task", filePath: "specs/tasks.md", contentHash: "t21" });
+    nodes.set("REQ-901", { id: "REQ-901", kind: "req", filePath: "specs/f.md", contentHash: "h1" });
+    nodes.set("REQ-902", { id: "REQ-902", kind: "req", filePath: "specs/f.md", contentHash: "h2" });
+    nodes.set("REQ-903", { id: "REQ-903", kind: "req", filePath: "specs/f.md", contentHash: "h3" });
+    nodes.set("symbol:src/a.ts#fnA", {
+      id: "symbol:src/a.ts#fnA",
+      kind: "symbol",
+      filePath: "src/a.ts",
+      contentHash: "fna",
+    });
+    const edges: GraphEdge[] = [
+      {
+        source: "symbol:src/a.ts#fnA",
+        target: "REQ-901",
+        kind: "implements",
+        provenances: ["code-tag"],
+      },
+      { source: "T020", target: "REQ-901", kind: "implements", provenances: ["task-tag"] },
+      { source: "T020", target: "REQ-902", kind: "implements", provenances: ["task-tag"] },
+      { source: "T021", target: "REQ-903", kind: "implements", provenances: ["task-tag"] },
+      { source: "doc:tasks", target: "T020", kind: "contains", provenances: ["structural"] },
+      { source: "doc:tasks", target: "T021", kind: "contains", provenances: ["structural"] },
+    ];
+    const graph: ArtifactGraph = { nodes, edges };
+
+    const result = impact(graph, ["symbol:src/a.ts#fnA"], {});
+    expect(result.impactReqs).toEqual(expect.arrayContaining(["REQ-901", "REQ-902"]));
+    expect(result.affectedTasks).toContain("T020");
+    // The sibling-task path stays closed: T021 / REQ-903 merely co-reside.
+    expect(result.affectedTasks).not.toContain("T021");
+    expect(result.impactReqs).not.toContain("REQ-903");
+    // tasks.md is attributed as T020's home for context.
+    expect(result.affectedDocs).toContain("doc:tasks");
+  });
+});


### PR DESCRIPTION
## 変更概要 (spec 019 参照)

`specs/019-impact-doc-containment/` (spec.md / plan.md / tasks.md) で確定した設計どおり、`src/graph/traverse.ts` の `impact()` に2つの変更のみを加えた:

1. **BFS の contains 辺を順方向限定に**: エッジ展開ループの逆方向展開 (`edge.target === id`) を `edge.kind !== "contains"` のときのみ行うよう変更。順方向展開・file→symbol 展開・`contains` 以外の5辺種 (`depends_on` / `derives_from` / `implements` / `verifies` / `imports`) の双方向性は無変更 (FR-001〜003)。
2. **親 doc の帰属アトリビューション**: BFS 完了後、visited の req/task ノードを target とする `contains` 辺の source doc を `affectedDocs` へ union する事後処理を追加。attributed doc も lock との contentHash 比較で `drifted` 判定に含めるが、attributed doc から先への再展開はしない (FR-004〜006)。

冒頭の設計コメント (「bidirectional は意図」宣言、maxDepth による contains 広がり抑制の回避策) を spec 019 準拠に書き換え (FR-012)。

呼び出し元 (`commands/impact.ts` / `commands/check.ts` / `plan-coverage/index.ts`) はコード変更なし — `impact()` の戻り値の中身が縮小するだけで自動的に浄化される。

## 受け入れシナリオとテストの対応

| Acceptance Scenario | テスト |
| --- | --- |
| AS1-1/AS1-2 (同一/別ファイル、依存なし → REQ-902 除外) | `tests/traverse.test.ts` (T001), `tests/impact-cli.test.ts` (T008 repro step 1/2) |
| AS1-3 (imports 経由の正当な巻き込みは維持) | `tests/traverse.test.ts`, `tests/impact-cli.test.ts` |
| AS1-4 (親 doc の帰属 + drift 判定) | `tests/traverse.test.ts` |
| AS1-5 (別 spec 分割時は不変) | `tests/traverse.test.ts`, `tests/impact-cli.test.ts` (T008 repro step 3) |
| AS1-6 (req→req depends_on 到達は維持) | `tests/traverse.test.ts` |
| FR-003 (doc→task にも同じ方向制約) | `tests/traverse.test.ts` |
| AS2-1/AS2-2 (plan-coverage の兄弟 REQ 浄化) | `tests/plan-coverage.test.ts` (T006 dedicated fixture) |
| AS3-1/AS3-2 (check --diff のスコープ浄化 / spec 変更経路維持) | `tests/check-baseline-diff.test.ts` (T007 dedicated fixture) |
| SC-001 (issue #215 再現手順の非再現) | `tests/impact-cli.test.ts` |
| SC-002 (spec 016 二軸出力 green 維持) | 全 unit suite green (無変更) |
| SC-003 (tag-zero brownfield E2E 無変更 green) | `tests/e2e/tag-zero.e2e.test.ts` (無変更で green) |
| SC-004 (既存スイート green) | 下記「全 suite 実行結果」参照 |
| SC-005 (dogfooding 確認) | 下記参照 |

## T009 で書き換えた既存テスト (削除ではなく期待値の反転)

既存テストスイート実行で、同一 spec.md の兄弟 REQ / 兄弟 task への到達を expect していた以下のテストが Red になったため、新セマンティクスの期待値に書き換えました:

- `tests/plan-coverage.test.ts`
  - `emits implicitImpacts (by-sourceFile) and implicitImpactsByReq (by-FR) together` — AUTH-003 (logout.ts 単独 claim) が doc 同居のみで混入しなくなったことを反映。AUTH-002 は `session.ts` が AUTH-001/002 を両方 implement する実コード接続 (`implements` は本 spec で無変更) で維持されることを明記。
- `tests/check-baseline-diff.test.ts`
  - `(b) harmless edit to a debt-connected file → exit 0, pre-existing REQ NOT new` → `(b) harmless edit to the hub → exit 0, doc-sibling debt REQ excluded from scope entirely` — REQ-200 がスコープ外になり `baselineStatus` が `computed` → `skipped` に反転。
  - `(e) scope with pre-existing debt only → baseline computed and subtracted → exit 0` → `(e) hub-only edit → scope carries no pre-existing debt anymore → baseline skipped → exit 0` — 同上。
  - `impact still reports the debt REQ that the gate suppresses` → `impact and check --diff agree: hub.ts's blast radius is REQ-100 only, doc-sibling debt is out of scope` — REQ-200 が `impact --diff` 自体からも消えるため、REQ-100 のみの blast radius であることに反転。
- `tests/check-gate-output.test.ts`
  - `(a) new issues → summary + new detail + suppressed count + impact pointer` — suppressed count 行 / impact pointer が消えることに反転。
  - `(b) no new issues but pre-existing debt → concise + parenthetical suppressed count` — bare な §4.3 形状 (suppressed 行なし) に反転。
  - `(C7) keeps existing fields and adds newIssues/suppressedCount/baselineStatus` — `suppressedCount` が `0`、`uncovered` から REQ-200 消失に反転。
  - `check --diff matrix` の `computed + no new (pre-existing only)` ケース — `status: "computed"` → `status: "skipped"` に反転。

落ちた原因はいずれも到達集合の縮小 (spec 019 の意図どおり) であり、それ以外の要因 (実装の逸脱等) は確認されませんでした。

## 全 suite 実行結果 (SC-004)

```
$ pnpm typecheck
$ tsc --noEmit
(no errors)

$ pnpm test:unit
 Test Files  71 passed (71)
      Tests  1627 passed (1627)

$ pnpm test:e2e
 Test Files  7 passed | 1 skipped (8)
      Tests  41 passed | 2 skipped (43)
(tag-zero.e2e.test.ts — #122 系 — 無変更で green)

$ pnpm knip
Configuration hints (6)  ← 本 PR と無関係の pre-existing hints のみ、exit 0
```

`git push` 時の pre-push hook (typecheck / test-unit / test-e2e / knip) も全て green で通過済みです。

## SC-005 dogfooding 実行結果

`pnpm build` 後、`artgraph-dogfooding` リポ (specs 001〜004 + `src/todo.ts`) に対して read-only 実行:

```
$ node dist/cli.js impact src/todo.ts:addTodo --format json
{"affectedFiles":["src/todo.ts","src/cli.ts","tests/todo.test.ts"],
 "affectedDocs":["doc:001-core-todo-crud/spec.md","doc:002-priority-and-due-dates/spec.md","doc:003-tags-and-filtering/spec.md","doc:004-storage-schema-versioning/spec.md"],
 "impactReqs":["REQ-001","REQ-002","REQ-003","REQ-013","REQ-014","REQ-015","REQ-017","REQ-018","REQ-020","REQ-021","REQ-006","REQ-007","REQ-022","REQ-023","REQ-004","REQ-005","REQ-016","REQ-019","REQ-011","REQ-012","REQ-025","REQ-026","REQ-008","REQ-009","REQ-010","REQ-024"],
 "originReqs":["REQ-001","REQ-002","REQ-003","REQ-013","REQ-014","REQ-015","REQ-017","REQ-018","REQ-020","REQ-021"],
 "drifted":[], ...}
```

`git status --porcelain` はコマンド実行後も空 — scan / reconcile / init は実行せず、dogfooding リポには何もコミットしていません。

`impactReqs` の26件は、`addTodo` 自身の `@impl` claim (10件 = `originReqs`) に加え、`src/cli.ts` が `addTodo` を含む `todo.ts` の全公開関数 (`loadTodos` / `saveTodos` / `addTodo` / `filterByTag` / `listTodos` / `completeTodo` / `removeTodo`) を import している実コード依存で完全に説明できることを手計算で確認済みです (7関数の `@impl` REQ の和集合 = 26件と厳密一致)。`contains` 辺経由 (同一 spec.md 同居のみ) で混入した REQ はゼロでした — `affectedDocs` の4 spec は帰属メタデータとして残るのみで、そこから REQ が追加で漏れ出すことはありません。

## スコープ外の明記

- `sameSpecReqs` フィールドの追加 — US4 として **Deferred** (spec 019 設計レビュー裁定、2026-07-10)。将来ドッグフーディングで実需が観測されたら再起票。
- `builder.ts` の変更 — `contains` 辺の生成側は不変 (消費側 `traverse.ts` のみ変更)。
- `ImpactResult` の型変更 — 型・JSON スキーマは完全に不変。
- 呼び出し元 (`commands/impact.ts` / `commands/check.ts` / `plan-coverage/index.ts`) のコード変更 — 不要 (自動的に浄化される)。
- CHANGELOG / version — release-please 管理のため未変更。
- [#218](https://github.com/mori-shin-x/artgraph/issues/218) (クラスメソッド粒度) — 本 spec 解決後に効果が観測可能になる次の支配的過剰検知源。後続課題。
- [#229](https://github.com/mori-shin-x/artgraph/issues/229) (コードのみ diff での `@impl` タグ削除の検出) — 設計レビューで切り出し済みのフォローアップ issue。

## 想定外だったこと

SC-005 のdogfooding実行で、`src/cli.ts` が `todo.ts` の全公開関数を import している構成のため、`addTodo` 起点の `impactReqs` が26件 (ほぼ全REQ) になりました。これは `contains` 辺 (spec 019 の対象) ではなく、`imports` 辺がファイル粒度 (`file:${relPath}`) でアトリビュートされる既存の (spec 019 スコープ外の) 挙動によるもので、`src/parsers/typescript.ts` の設計です。手計算で全26件が実コード依存 (7つの import された関数の `@impl` の和集合) で説明できることを確認しており、`contains` 経由の巻き込みはゼロでした。小さな dogfooding リポ (3ファイルのみ) では CLI エントリポイントが全関数を import するため、このリポ単体では新旧セマンティクスの差が `addTodo` では観測しにくい点を申し添えます (`tests/plan-coverage.test.ts` / `tests/check-baseline-diff.test.ts` の同一 spec 内 fixture では差分を明確に観測・pin 済みです)。

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## レビュー反映 (7観点敵対的レビュー、マージ前実施)

クリーンなレビューエージェントによる7観点 (境界条件 / 条件分岐の組み合わせ / 不正な状態遷移 / 例外系 / 実運用事故パターン / エッジケース / 変更外ファイルへの影響) の敵対的レビューを実施。**CRITICAL / HIGH は 0 件**、LOW〜LOW-MEDIUM 5 件を検証の上、以下を本 PR に反映した (1cb90b5, f1f5e40):

- 帰属アトリビューションの `contains` 辺 source に doc 検証ガードを追加 (target 側と対称。dangling / 非 doc source が手組みグラフから `affectedDocs` へ漏れないように) + pin テスト
- 意図的な複数 REQ task ブリッジ (spec 019 Edge Cases の watch item) を pin するテストを追加 — 将来この経路が誤って塞がれたら検知される
- `_shared/output-schema.md` (6 系統同期): `affectedReqs` → `impactReqs` (spec 016 改名の追随漏れ・pre-existing)、`originReqs` 追加、帰属セマンティクスと配列順序非保証の注記 — 本 PR の SKILL.md が参照するドキュメントとの矛盾を解消
- docs/skills-guide.md に「帰属 doc 自体は drift 判定対象のまま (FR-005)」を明記
- spec 019 Edge Cases に「seed された doc からの doc↔doc 辺経由の到達は既存挙動でスコープ外 (FR-014d)」の補記

**ゲート不変の正確な論拠 (レビューで実証、記録として)**: `check --diff` の `pass` / `newIssues` が本変更で変わらないのは「doc 到達集合が不変」だからではない (兄弟 REQ 経由で多段先の doc に到達するケースでは affectedDocs は縮小する)。正しい理由は (a) baseline (`src/baseline.ts`) が**スコープ非依存にグラフ全体**から issue キーを算出すること、(b) diff 対象ファイル自身は `resolveStartIds` の filePath fallback で直接 seed されること、の 2 点。新旧スコープで `pass` / `newIssues` の完全一致を fixture 実行で確認済み。

**レビュー起点のフォローアップ (本 PR スコープ外、main 5c42940 で再現確認の上で起票済み)**: #234 (specDirs 親子重複の無警告 doc 分裂)、#235 (doc contentHash のファイル全体粒度による checkbox drift ノイズ)。いずれも pre-existing で本 PR の退行ではない。
