### PR TITLE
feat(config): .artgraph.json に agents field を追加して doctor cross-check を有効化

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ import {
   type ReqPatternConfig,
   type TaskConventionPreset,
 } from "./types.js";
+import { AGENT_IDS, type AgentId } from "./agents/descriptors.js";
 
 const CONFIG_FILE = ".artgraph.json";
 
@@ -351,6 +352,35 @@ function validateIgnoreIdPrefixes(value: unknown): string[] | undefined {
   return out;
 }
 
+// spec 013 follow-up (#158) — `.artgraph.json` `agents` field validation.
+// Mirrors `validateIgnoreIdPrefixes`: `undefined` round-trips as `undefined`
+// (legacy configs pre-dating this field), everything else must be a
+// deduped array of Tier 1 `AgentId` strings. Returned alpha-sorted so the
+// persisted array (and every downstream cross-check) has a stable order
+// regardless of how `init --agents=<csv>` was invoked.
+function validateAgents(value: unknown): AgentId[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw new Error("Invalid agents: must be an array of strings");
+  }
+  const seen = new Set<string>();
+  for (const entry of value) {
+    if (typeof entry !== "string" || entry === "") {
+      throw new Error("Invalid agents: every entry must be a non-empty string");
+    }
+    if (!(AGENT_IDS as readonly string[]).includes(entry)) {
+      throw new Error(
+        `Invalid agents: "${entry}" is not a supported agent id (allowed: ${AGENT_IDS.join(", ")})`,
+      );
+    }
+    if (seen.has(entry)) {
+      throw new Error(`Invalid agents: duplicate entry "${entry}"`);
+    }
+    seen.add(entry);
+  }
+  return [...seen].sort() as AgentId[];
+}
+
 // spec 014 — `.artgraph.json` `planCoverage` section validation. Currently
 // only `requireFilesSection: boolean` is recognised; unknown fields are
 // silently dropped (no warning) so the schema can grow without breaking
@@ -441,6 +471,8 @@ export function loadConfig(rootDir: string): ArtgraphConfig {
 
   const planCoverage = validatePlanCoverage(raw.planCoverage);
 
+  const agents = validateAgents(raw.agents);
+
   const lockFile = raw.lockFile ?? DEFAULT_CONFIG.lockFile;
   const resolvedLock = resolve(rootDir, lockFile);
   const relFromRoot = relative(rootDir, resolvedLock);
@@ -462,5 +494,6 @@ export function loadConfig(rootDir: string): ArtgraphConfig {
     taskConventions: raw.taskConventions,
     disableBuiltinTaskConventions: disabledBuiltins,
     planCoverage,
+    agents,
   };
 }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -28,6 +28,7 @@ import {
 import { buildAgentsMdBody, inspectMarkerBlock } from "./agents/agent-context.js";
 import { detectPackageManager } from "./package-manager.js";
 import { readSkillSource, type SkillSource } from "./agents/source.js";
+import { loadConfig } from "./config.js";
 
 /** Skip files larger than this when hashing / walking (C-adj-1). Prevents an
  * accidentally-planted multi-GB file inside a Skills dir from OOM-ing the
@@ -60,7 +61,29 @@ export type DoctorFindingKind =
   | "wrapper-broken-marker"
   | "extraneous-file"
   | "walk-error"
-  | "distribution-absent";
+  | "distribution-absent"
+  /**
+   * spec 013 follow-up (#158) — `.artgraph.json` has no `agents` field
+   * (legacy config predating this feature) while at least one Tier 1 agent
+   * distribution is present on disk. Advisory only (severity `pass`) — never
+   * flips the doctor exit code.
+   */
+  | "config-missing-agents-field"
+  /**
+   * spec 013 follow-up (#158) — `.artgraph.json`'s `agents` field lists an
+   * id whose distribution directory is missing on disk. Actionable drift
+   * (severity `fail`) — replaces `distribution-absent` when the absent set
+   * was derived from config.agents rather than an explicit `opts.agents`
+   * override.
+   */
+  | "agent-recorded-but-missing"
+  /**
+   * spec 013 follow-up (#158) — a Tier 1 agent has a distribution directory
+   * on disk that isn't listed in `.artgraph.json`'s `agents` field. Advisory
+   * only (severity `pass`) — the on-disk state itself isn't broken, just
+   * unrecorded.
+   */
+  | "agent-installed-not-recorded";
 
 export interface DoctorFinding {
   severity: DoctorFindingSeverity;
@@ -125,18 +148,36 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
   // Quiet mode — doctor never prints its own PM detection warning.
   const detectedPm = detectPackageManager(rootAbs, { quiet: true });
 
+  // spec 013 follow-up (#158) — load `.artgraph.json` so the default
+  // (no `opts.agents`) detection path can trust `config.agents` as SSOT
+  // instead of blind on-disk observation, when the field is present.
+  const config = loadConfig(rootAbs);
+
   // Step 1 — detect agents.
   //   - explicit `opts.agents`: trust the caller; the CLI parser has already
   //     enforced lowercase + Tier 1 membership. If an id has no distribution
   //     directory on disk, we record it in `absentDescriptors` and emit a
   //     single `distribution-absent` finding (D1) instead of flooding with
-  //     N `skill-file-missing` entries.
-  //   - default: every descriptor whose `<rootDir>/<skillsPath>` directory
-  //     exists on disk AND contains at least one canonical top-level (D5),
-  //     using `lstatSync` so a symlink-to-/dev-null does not crash the
-  //     doctor (C-adj-2). Zero detected → return an empty report.
+  //     N `skill-file-missing` entries. Explicit override — the config.agents
+  //     cross-check below is skipped entirely.
+  //   - `config.agents` defined (persisted state, #158): trust the config,
+  //     cross-checking each recorded id against disk. Ids present on disk go
+  //     to `detectedDescriptors`; ids missing on disk go to
+  //     `absentDescriptors` and get an `agent-recorded-but-missing` finding
+  //     (not `distribution-absent`) below. A separate pass then flags any
+  //     on-disk agent NOT recorded in config.agents as
+  //     `agent-installed-not-recorded`.
+  //   - legacy fallback (config.agents undefined): every descriptor whose
+  //     `<rootDir>/<skillsPath>` directory exists on disk AND contains at
+  //     least one canonical top-level (D5), using `lstatSync` so a
+  //     symlink-to-/dev-null does not crash the doctor (C-adj-2). An
+  //     advisory `config-missing-agents-field` finding is emitted once when
+  //     at least one agent was detected this way.
+  //   Zero detected (and no config cross-check findings) → return an empty
+  //   report.
   const detectedDescriptors: AgentDescriptor[] = [];
   const absentDescriptors: AgentDescriptor[] = [];
+  const usingConfigAgents = !(opts.agents && opts.agents.length > 0) && config.agents !== undefined;
   if (opts.agents && opts.agents.length > 0) {
     for (const id of opts.agents) {
       const d = findDescriptor(id);
@@ -148,6 +189,27 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
           `Unknown agent id: "${id}". Supported values: ${AGENT_DESCRIPTORS.map((x) => x.id).join(", ")}`,
         );
       }
+      const dist = resolve(rootAbs, d.skillsPath);
+      let stat;
+      try {
+        stat = lstatSync(dist);
+      } catch {
+        stat = undefined;
+      }
+      if (stat && stat.isDirectory()) {
+        detectedDescriptors.push(d);
+      } else {
+        absentDescriptors.push(d);
+      }
+    }
+  } else if (usingConfigAgents) {
+    for (const id of config.agents as AgentId[]) {
+      const d = findDescriptor(id);
+      // Defensive: `validateAgents` already restricts `config.agents` to
+      // `AGENT_IDS`, so this only fires for a hand-edited/pre-validation
+      // config. Skip rather than throw — unlike the `opts.agents` path this
+      // isn't direct per-call caller input.
+      if (!d) continue;
       const dist = resolve(rootAbs, d.skillsPath);
       let stat;
       try {
@@ -186,7 +248,67 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
     }
   }
 
-  if (detectedDescriptors.length === 0 && absentDescriptors.length === 0) {
+  // spec 013 follow-up (#158) — config ↔ disk cross-check findings. Computed
+  // before the empty-report short-circuit so a config-only signal (e.g. an
+  // agent recorded but never distributed, or an on-disk agent recorded
+  // nowhere) still produces output even when both `detectedDescriptors` and
+  // `absentDescriptors` are otherwise empty (e.g. `config.agents: []`).
+  // Skipped entirely for the explicit `opts.agents` override path.
+  const configFindings: DoctorFinding[] = [];
+  if (!(opts.agents && opts.agents.length > 0)) {
+    if (config.agents === undefined) {
+      if (detectedDescriptors.length > 0) {
+        configFindings.push({
+          severity: "pass",
+          agent: null,
+          kind: "config-missing-agents-field",
+          path: ".artgraph.json",
+          expected: "agents field present",
+          actual: "agents field absent",
+          message:
+            '.artgraph.json has no "agents" field — run `artgraph init --force --agents=<csv>` to persist the current install for reliable doctor / rename / uninstall cross-checks.',
+        });
+      }
+    } else {
+      const recordedSet = new Set<AgentId>(config.agents);
+      for (const d of absentDescriptors) {
+        configFindings.push({
+          severity: "fail",
+          agent: d.id,
+          kind: "agent-recorded-but-missing",
+          path: d.skillsPath,
+          expected: "distribution present",
+          actual: "no distribution directory",
+          message: `Agent "${d.id}" is recorded in .artgraph.json but its distribution directory ${d.skillsPath} is missing. Re-run \`artgraph init --force --agents=${d.id}\` to restore or update the config to drop it.`,
+        });
+      }
+      for (const descriptor of AGENT_DESCRIPTORS) {
+        if (recordedSet.has(descriptor.id)) continue;
+        if (isAgentDistributionOnDisk(rootAbs, descriptor, canonicalTopLevels)) {
+          // Also feed it into `detectedDescriptors` — it IS installed on
+          // disk, just unrecorded, so it should still get the full Step
+          // 3/4/5 skill-file / wrapper diagnostics (and show up in
+          // `summary.agents`) rather than only this advisory.
+          detectedDescriptors.push(descriptor);
+          configFindings.push({
+            severity: "pass",
+            agent: descriptor.id,
+            kind: "agent-installed-not-recorded",
+            path: descriptor.skillsPath,
+            expected: "recorded in .artgraph.json agents",
+            actual: "not recorded",
+            message: `Agent "${descriptor.id}" has a distribution directory at ${descriptor.skillsPath} but is not recorded in .artgraph.json's "agents". Run \`artgraph init --force --agents=${descriptor.id}\` to persist it (union with existing).`,
+          });
+        }
+      }
+    }
+  }
+
+  if (
+    detectedDescriptors.length === 0 &&
+    absentDescriptors.length === 0 &&
+    configFindings.length === 0
+  ) {
     return {
       version: 1,
       summary: {
@@ -202,18 +324,28 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
   const findings: DoctorFinding[] = [];
 
   // D1 — explicit --agents ids whose distribution dir does not exist get a
-  // single `distribution-absent` finding, no per-file scanning.
-  for (const d of absentDescriptors) {
-    findings.push({
-      severity: "fail",
-      agent: d.id,
-      kind: "distribution-absent",
-      path: d.skillsPath,
-      expected: "distribution present",
-      actual: "no distribution directory",
-      message: `${d.displayName} distribution is not installed under ${d.skillsPath}/. Run \`artgraph init --agents=${d.id}\` to install it.`,
-    });
+  // single `distribution-absent` finding, no per-file scanning. Skipped when
+  // `absentDescriptors` was derived from `config.agents` (#158, usingConfigAgents)
+  // — those ids get the more specific `agent-recorded-but-missing` finding
+  // instead, pushed via `configFindings` below.
+  if (!usingConfigAgents) {
+    for (const d of absentDescriptors) {
+      findings.push({
+        severity: "fail",
+        agent: d.id,
+        kind: "distribution-absent",
+        path: d.skillsPath,
+        expected: "distribution present",
+        actual: "no distribution directory",
+        message: `${d.displayName} distribution is not installed under ${d.skillsPath}/. Run \`artgraph init --agents=${d.id}\` to install it.`,
+      });
+    }
   }
+
+  // spec 013 follow-up (#158) — config ↔ disk cross-check findings computed
+  // above (config-missing-agents-field / agent-recorded-but-missing /
+  // agent-installed-not-recorded).
+  findings.push(...configFindings);
 
   // Step 3 — per-agent Skills + extraneous-file diagnostics.
   for (const descriptor of detectedDescriptors) {
@@ -255,6 +387,32 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
 // ---------------------------------------------------------------------------
 // Sub-checks
 // ---------------------------------------------------------------------------
+
+// spec 013 follow-up (#158) — same D5 "has at least one canonical top-level"
+// test as the legacy auto-detect loop in `runDoctor`, factored out so the
+// `agent-installed-not-recorded` cross-check (which must scan every Tier 1
+// descriptor regardless of `config.agents` membership) can reuse it.
+function isAgentDistributionOnDisk(
+  rootAbs: string,
+  descriptor: AgentDescriptor,
+  canonicalTopLevels: Set<string>,
+): boolean {
+  const dist = resolve(rootAbs, descriptor.skillsPath);
+  let stat;
+  try {
+    stat = lstatSync(dist);
+  } catch {
+    return false;
+  }
+  if (!stat.isDirectory()) return false;
+  let entries: string[];
+  try {
+    entries = readdirSync(dist);
+  } catch {
+    return false;
+  }
+  return entries.some((e) => canonicalTopLevels.has(e));
+}
 
 function addSkillFindings(
   rootAbs: string,
@@ -634,16 +792,31 @@ export function formatDoctorReportText(report: DoctorReport): string {
     lines.push("");
   }
 
-  // AGENTS.md section — single shared finding (or its FAIL variants).
-  const sharedFindings = report.findings.filter((f) => f.agent === null);
-  for (const f of sharedFindings) {
+  // AGENTS.md section — single shared finding (or its FAIL variants). Scoped
+  // to `agents-md-*` kinds specifically (not just `agent === null`) since
+  // #158 added a second `agent: null` finding kind (config-missing-agents-field)
+  // that is NOT about AGENTS.md's marker block.
+  const agentsMdFindings = report.findings.filter(
+    (f) => f.agent === null && f.kind.startsWith("agents-md"),
+  );
+  for (const f of agentsMdFindings) {
     if (f.severity === "pass") {
       lines.push(`AGENTS.md: ✓ marker block intact`);
     } else {
       lines.push(`AGENTS.md: ✗ ${f.kind} — ${f.message}`);
     }
   }
-  if (sharedFindings.length > 0) lines.push("");
+  if (agentsMdFindings.length > 0) lines.push("");
+
+  // spec 013 follow-up (#158) — config-level advisory, surfaced once as a
+  // NOTICE line (mirrors the agents-md-body-stale NOTICE convention).
+  const configLevelFindings = report.findings.filter(
+    (f) => f.agent === null && f.kind === "config-missing-agents-field",
+  );
+  for (const f of configLevelFindings) {
+    lines.push(`NOTICE: ${f.message}`);
+  }
+  if (configLevelFindings.length > 0) lines.push("");
 
   lines.push(`Summary: ${report.summary.passCount} pass, ${report.summary.failCount} fail`);
   return lines.join("\n");

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -17,7 +17,7 @@
 // only side effects are reads of `<rootDir>/...` and `templates/skills/`.
 
 import { createHash } from "node:crypto";
-import { lstatSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
 import { resolve, sep } from "node:path";
 import {
   AGENT_DESCRIPTORS,
@@ -210,14 +210,12 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
       // config. Skip rather than throw — unlike the `opts.agents` path this
       // isn't direct per-call caller input.
       if (!d) continue;
-      const dist = resolve(rootAbs, d.skillsPath);
-      let stat;
-      try {
-        stat = lstatSync(dist);
-      } catch {
-        stat = undefined;
-      }
-      if (stat && stat.isDirectory()) {
+      // PR #233 review (any-artifact check) — a recorded agent is only
+      // "missing" (→ `agent-recorded-but-missing`) when NEITHER its Skills
+      // directory nor its wrapper file is on disk. `--no-skills
+      // --agents=X` still leaves the wrapper (CLAUDE.md); requiring the
+      // Skills directory alone would flag that as missing.
+      if (isAgentDistributionOnDisk(rootAbs, d, canonicalTopLevels)) {
         detectedDescriptors.push(d);
       } else {
         absentDescriptors.push(d);
@@ -272,6 +270,16 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
     } else {
       const recordedSet = new Set<AgentId>(config.agents);
       for (const d of absentDescriptors) {
+        // PR #233 review (MAJOR) — the old message ("update the config to
+        // drop it") pointed at a nonexistent CLI affordance: union-only
+        // persistence means there is no `artgraph` flag to remove an agent
+        // from `.artgraph.json` today. Be honest about the two real options
+        // — restore via `--force`, or hand-edit the JSON — and point at the
+        // tracked follow-up (#131) for a proper `artgraph uninstall`.
+        const artifactsDesc =
+          d.wrapperFile !== null
+            ? `no ${d.skillsPath}/ and no ${d.wrapperFile}`
+            : `no ${d.skillsPath}/`;
         configFindings.push({
           severity: "fail",
           agent: d.id,
@@ -279,7 +287,7 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
           path: d.skillsPath,
           expected: "distribution present",
           actual: "no distribution directory",
-          message: `Agent "${d.id}" is recorded in .artgraph.json but its distribution directory ${d.skillsPath} is missing. Re-run \`artgraph init --force --agents=${d.id}\` to restore or update the config to drop it.`,
+          message: `Agent "${d.id}" is recorded in .artgraph.json but no distribution artifacts are on disk (${artifactsDesc}). Re-run \`artgraph init --force --agents=${d.id}\` to restore, or hand-edit .artgraph.json to drop it. (A dedicated \`artgraph uninstall\` command is tracked in #131.)`,
         });
       }
       for (const descriptor of AGENT_DESCRIPTORS) {
@@ -389,10 +397,10 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
 // ---------------------------------------------------------------------------
 
 // spec 013 follow-up (#158) — same D5 "has at least one canonical top-level"
-// test as the legacy auto-detect loop in `runDoctor`, factored out so the
-// `agent-installed-not-recorded` cross-check (which must scan every Tier 1
-// descriptor regardless of `config.agents` membership) can reuse it.
-function isAgentDistributionOnDisk(
+// test as the legacy auto-detect loop in `runDoctor`, factored out so
+// `isAgentDistributionOnDisk` (and any other caller needing the Skills-only
+// half of the check) can reuse it.
+function skillsDirHasCanonicalTopLevel(
   rootAbs: string,
   descriptor: AgentDescriptor,
   canonicalTopLevels: Set<string>,
@@ -412,6 +420,23 @@ function isAgentDistributionOnDisk(
     return false;
   }
   return entries.some((e) => canonicalTopLevels.has(e));
+}
+
+// PR #233 review — an agent is "installed" if EITHER its Skills directory
+// has canonical content OR its wrapper file exists. `--no-skills
+// --agents=X` still leaves CLAUDE.md, so requiring both would produce a
+// false-positive `agent-recorded-but-missing` (BLOCKER, #158 review).
+// `existsSync` (not `lstatSync`) is enough here — the wrapper is a regular
+// file the init writer creates; symlinks aren't an expected shape.
+function isAgentDistributionOnDisk(
+  rootAbs: string,
+  descriptor: AgentDescriptor,
+  canonicalTopLevels: Set<string>,
+): boolean {
+  const skillsPresent = skillsDirHasCanonicalTopLevel(rootAbs, descriptor, canonicalTopLevels);
+  const wrapperPresent =
+    descriptor.wrapperFile !== null && existsSync(resolve(rootAbs, descriptor.wrapperFile));
+  return skillsPresent || wrapperPresent;
 }
 
 function addSkillFindings(

--- a/src/init.ts
+++ b/src/init.ts
@@ -708,17 +708,32 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
   // init doesn't silently drop previously installed agents. undefined
   // (legacy config / fresh init) is treated as an empty base — new agents
   // get persisted fresh.
-  const existingAgentsDefined = config.agents !== undefined;
-  const existingAgentsSet = new Set<AgentId>(config.agents ?? []);
-  for (const id of agentsList) existingAgentsSet.add(id);
-  const finalAgents: AgentId[] = [...existingAgentsSet].sort();
-  // Only write the field when it has content OR it was already defined —
-  // don't write an empty-array field on a fresh init that didn't touch
-  // agents (keeps configs minimal). Once populated, preserve it even if the
-  // union comes out empty for some weird reason: that's still user state.
-  if (finalAgents.length > 0 || existingAgentsDefined) {
-    config.agents = finalAgents;
+  //
+  // Persist `agents` only when at least one distribution stage that actually
+  // installs per-agent artifacts ran this invocation. If both Skills and
+  // agent-context stages are off (--no-skills --no-agent-context, or
+  // --minimal), nothing was distributed for these ids and recording them
+  // would create a self-inflicted `agent-recorded-but-missing` FAIL on the
+  // next doctor run (PR #233 review).
+  const anyDistributionStageActive = skillsStageActive || agentContextStageActive;
+  if (anyDistributionStageActive) {
+    const existingAgentsDefined = config.agents !== undefined;
+    const existingAgentsSet = new Set<AgentId>(config.agents ?? []);
+    for (const id of agentsList) existingAgentsSet.add(id);
+    const finalAgents: AgentId[] = [...existingAgentsSet].sort();
+    // Only write the field when it has content OR it was already defined —
+    // don't write an empty-array field on a fresh init that didn't touch
+    // agents (keeps configs minimal). Once populated, preserve it even if the
+    // union comes out empty for some weird reason: that's still user state.
+    if (finalAgents.length > 0 || existingAgentsDefined) {
+      config.agents = finalAgents;
+    }
   }
+  // else: no distribution stage ran this invocation — leave `config.agents`
+  // exactly as loaded (untouched for a fresh init with no prior config,
+  // preserved as-is on a `--force` re-run that opts out via --no-skills
+  // --no-agent-context / --minimal). Do not union `agentsList` in — nothing
+  // was actually installed for those ids this run.
 
   // B3 — atomic write. Previously a raw `writeFileSync` on `.artgraph.json`
   // could leave a truncated/empty JSON on SIGKILL / ENOSPC mid-write, and

--- a/src/init.ts
+++ b/src/init.ts
@@ -697,6 +697,29 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
     }
   }
 
+  // spec 013 follow-up (#158) — persist the effective `--agents=<csv>` set so
+  // downstream tooling (doctor cross-check, future rename Skill etc.) can
+  // trust `.artgraph.json` as SSOT instead of blind on-disk observation.
+  //
+  // `config.agents` at this point already reflects whichever agents were
+  // previously persisted: `loadConfig(abs)` populated it on a `--force`
+  // re-init (existing config), and `generateConfig()` never sets it on a
+  // fresh init. Union with existing config.agents on --force so re-running
+  // init doesn't silently drop previously installed agents. undefined
+  // (legacy config / fresh init) is treated as an empty base — new agents
+  // get persisted fresh.
+  const existingAgentsDefined = config.agents !== undefined;
+  const existingAgentsSet = new Set<AgentId>(config.agents ?? []);
+  for (const id of agentsList) existingAgentsSet.add(id);
+  const finalAgents: AgentId[] = [...existingAgentsSet].sort();
+  // Only write the field when it has content OR it was already defined —
+  // don't write an empty-array field on a fresh init that didn't touch
+  // agents (keeps configs minimal). Once populated, preserve it even if the
+  // union comes out empty for some weird reason: that's still user state.
+  if (finalAgents.length > 0 || existingAgentsDefined) {
+    config.agents = finalAgents;
+  }
+
   // B3 — atomic write. Previously a raw `writeFileSync` on `.artgraph.json`
   // could leave a truncated/empty JSON on SIGKILL / ENOSPC mid-write, and
   // the next `runInit` would throw on `loadConfig`. `atomicWriteFile` stages

--- a/src/types.ts
+++ b/src/types.ts
@@ -516,6 +516,15 @@ export interface ArtgraphConfig {
    * project; the CLI treats every nested field as defaulted to false.
    */
   planCoverage?: PlanCoverageConfig;
+  /**
+   * spec 013 follow-up (#158) — Tier 1 agent ids persisted by `artgraph init
+   * --agents=<csv>`. Alpha-sorted, deduped. When defined, `artgraph doctor`
+   * cross-checks against on-disk agent distribution directories and reports
+   * drift. When `undefined` (legacy configs pre-dating this field), doctor
+   * falls back to on-disk observation and emits an advisory finding.
+   * Empty array is an explicit opt-out (--minimal / --no-skills).
+   */
+  agents?: import("./agents/descriptors.js").AgentId[];
 }
 
 export const DEFAULT_CONFIG: ArtgraphConfig = {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -611,6 +611,65 @@ describe("loadConfig", () => {
     );
   });
 
+  describe("agents validation (spec 013 follow-up, #158)", () => {
+    it("should accept a valid agents array, alpha-sorted", () => {
+      mkdirSync(TMP_DIR, { recursive: true });
+      writeFileSync(CONFIG_PATH, JSON.stringify({ agents: ["cursor", "claude"] }));
+      expect(loadConfig(TMP_DIR).agents).toEqual(["claude", "cursor"]);
+    });
+
+    it("should be undefined when the field is absent (legacy config round-trips as undefined)", () => {
+      mkdirSync(TMP_DIR, { recursive: true });
+      writeFileSync(CONFIG_PATH, "{}");
+      expect(loadConfig(TMP_DIR).agents).toBeUndefined();
+    });
+
+    it("should accept an empty array (explicit opt-out)", () => {
+      mkdirSync(TMP_DIR, { recursive: true });
+      writeFileSync(CONFIG_PATH, JSON.stringify({ agents: [] }));
+      expect(loadConfig(TMP_DIR).agents).toEqual([]);
+    });
+
+    it("should reject a non-array value", () => {
+      mkdirSync(TMP_DIR, { recursive: true });
+      writeFileSync(CONFIG_PATH, JSON.stringify({ agents: "claude" }));
+      expect(() => loadConfig(TMP_DIR)).toThrow(/must be an array of strings/);
+    });
+
+    it("should reject an invalid agent id (windsurf is not Tier 1)", () => {
+      mkdirSync(TMP_DIR, { recursive: true });
+      writeFileSync(CONFIG_PATH, JSON.stringify({ agents: ["windsurf"] }));
+      expect(() => loadConfig(TMP_DIR)).toThrow(/not a supported agent id/);
+    });
+
+    it("should reject duplicate entries", () => {
+      mkdirSync(TMP_DIR, { recursive: true });
+      writeFileSync(CONFIG_PATH, JSON.stringify({ agents: ["claude", "claude"] }));
+      expect(() => loadConfig(TMP_DIR)).toThrow(/duplicate entry/);
+    });
+
+    it("should reject a non-string entry", () => {
+      mkdirSync(TMP_DIR, { recursive: true });
+      writeFileSync(CONFIG_PATH, JSON.stringify({ agents: [42] }));
+      expect(() => loadConfig(TMP_DIR)).toThrow(/non-empty string/);
+    });
+
+    it("should reject an empty-string entry", () => {
+      mkdirSync(TMP_DIR, { recursive: true });
+      writeFileSync(CONFIG_PATH, JSON.stringify({ agents: [""] }));
+      expect(() => loadConfig(TMP_DIR)).toThrow(/non-empty string/);
+    });
+
+    it("should accept all 5 Tier 1 ids", () => {
+      mkdirSync(TMP_DIR, { recursive: true });
+      writeFileSync(
+        CONFIG_PATH,
+        JSON.stringify({ agents: ["kiro", "copilot", "codex", "cursor", "claude"] }),
+      );
+      expect(loadConfig(TMP_DIR).agents).toEqual(["claude", "codex", "copilot", "cursor", "kiro"]);
+    });
+  });
+
   describe("top-level JSON shape", () => {
     // Hand-edited configs can accidentally produce a non-object root
     // (array / number / string / null). The old code silently fell back to

--- a/tests/doctor.test.ts
+++ b/tests/doctor.test.ts
@@ -724,6 +724,127 @@ describe("runDoctor — D-adj-1: throws on unknown agent id", () => {
   });
 });
 
+describe("runDoctor — config.agents cross-check (spec 013 follow-up, #158)", () => {
+  let proj: ReturnType<typeof createFreshProject>;
+
+  beforeEach(() => {
+    proj = createFreshProject();
+  });
+
+  afterEach(() => {
+    proj.cleanup();
+  });
+
+  function readConfig(): Record<string, unknown> {
+    return JSON.parse(readFileSync(join(proj.dir, ".artgraph.json"), "utf-8"));
+  }
+
+  function writeConfig(patch: Record<string, unknown>): void {
+    const config = readConfig();
+    writeFileSync(
+      join(proj.dir, ".artgraph.json"),
+      JSON.stringify({ ...config, ...patch }, null, 2) + "\n",
+    );
+  }
+
+  it("emits config-missing-agents-field when config has no agents and disk has at least one agent", () => {
+    // initProject persists `agents` by default now (#158) — strip it back off
+    // to simulate a legacy config predating this feature.
+    initProject(proj.dir, ["claude"]);
+    const config = readConfig();
+    delete config.agents;
+    writeFileSync(join(proj.dir, ".artgraph.json"), JSON.stringify(config, null, 2) + "\n");
+
+    const report = runDoctor({ rootDir: proj.dir });
+    const f = findFinding(report.findings, (x) => x.kind === "config-missing-agents-field");
+    expect(f, JSON.stringify(report.findings, null, 2)).toBeDefined();
+    expect(f!.severity).toBe("pass");
+    expect(f!.agent).toBeNull();
+    expect(f!.message).toContain("--agents=<csv>");
+    // Advisory only — must not flip the exit code.
+    expect(report.summary.failCount).toBe(0);
+  });
+
+  it("does not emit config-missing-agents-field once the agents field is persisted", () => {
+    initProject(proj.dir, ["claude"]);
+    expect(readConfig().agents).toEqual(["claude"]);
+    const report = runDoctor({ rootDir: proj.dir });
+    const f = findFinding(report.findings, (x) => x.kind === "config-missing-agents-field");
+    expect(f).toBeUndefined();
+  });
+
+  it("fires agent-recorded-but-missing when config lists an id but disk lacks its distribution dir", () => {
+    initProject(proj.dir, ["claude"]);
+    writeConfig({ agents: ["claude", "codex"] }); // codex never distributed
+    const report = runDoctor({ rootDir: proj.dir });
+    const f = findFinding(report.findings, (x) => x.kind === "agent-recorded-but-missing");
+    expect(f, JSON.stringify(report.findings, null, 2)).toBeDefined();
+    expect(f!.severity).toBe("fail");
+    expect(f!.agent).toBe("codex");
+    expect(f!.message).toContain("codex");
+    expect(f!.message).toContain("--force --agents=codex");
+    expect(report.summary.failCount).toBeGreaterThanOrEqual(1);
+    // The obsolete generic finding must not double-fire for the same agent.
+    expect(
+      findFinding(report.findings, (x) => x.kind === "distribution-absent" && x.agent === "codex"),
+    ).toBeUndefined();
+  });
+
+  it("fires agent-installed-not-recorded when config lists a subset and disk has more", () => {
+    initProject(proj.dir, ["claude", "codex"]);
+    writeConfig({ agents: ["claude"] }); // codex is installed but not recorded
+    const report = runDoctor({ rootDir: proj.dir });
+    const f = findFinding(report.findings, (x) => x.kind === "agent-installed-not-recorded");
+    expect(f, JSON.stringify(report.findings, null, 2)).toBeDefined();
+    expect(f!.severity).toBe("pass");
+    expect(f!.agent).toBe("codex");
+    expect(f!.message).toContain("codex");
+    // Advisory only — must not flip the exit code (codex's own distribution
+    // is byte-identical, just unrecorded).
+    expect(report.summary.failCount).toBe(0);
+    // The unrecorded-but-installed agent still gets full diagnostics and
+    // shows up in the summary, matching legacy on-disk-observation coverage.
+    expect(report.summary.agents).toContain("codex");
+    expect(
+      report.findings.some((x) => x.agent === "codex" && x.kind === "skill-file-present"),
+    ).toBe(true);
+  });
+
+  it("emits no new #158 finding kinds when config.agents matches on-disk exactly", () => {
+    initProject(proj.dir, ["claude", "codex"]);
+    expect(readConfig().agents).toEqual(["claude", "codex"]);
+    const report = runDoctor({ rootDir: proj.dir });
+    const newKinds = report.findings.filter((f) =>
+      [
+        "config-missing-agents-field",
+        "agent-recorded-but-missing",
+        "agent-installed-not-recorded",
+      ].includes(f.kind),
+    );
+    expect(newKinds, JSON.stringify(newKinds, null, 2)).toEqual([]);
+  });
+
+  it("opts.agents explicit override skips the config cross-check entirely", () => {
+    initProject(proj.dir, ["claude"]);
+    // Config only records claude, but the caller explicitly asks about codex
+    // (never distributed). The explicit-override path must still report the
+    // legacy `distribution-absent` finding, not `agent-recorded-but-missing`,
+    // and must not synthesize any #158 finding kind.
+    const report = runDoctor({ rootDir: proj.dir, agents: ["codex"] });
+    const newKinds = report.findings.filter((f) =>
+      [
+        "config-missing-agents-field",
+        "agent-recorded-but-missing",
+        "agent-installed-not-recorded",
+      ].includes(f.kind),
+    );
+    expect(newKinds).toEqual([]);
+    const absent = findFinding(report.findings, (x) => x.kind === "distribution-absent");
+    expect(absent, JSON.stringify(report.findings, null, 2)).toBeDefined();
+    expect(absent!.agent).toBe("codex");
+  });
+});
+
 describe("runDoctor — dogfood (this repo)", () => {
   // Cheap standing guard for SC-002 byte-identical distribution: run the
   // production doctor engine against the repo root itself. When template ↔

--- a/tests/init-doctor-integration.test.ts
+++ b/tests/init-doctor-integration.test.ts
@@ -1,0 +1,176 @@
+// #158 review (MINOR) — init→doctor round-trip integration tests.
+//
+// PR #233's adversarial review found that the `runInit` unit tests and the
+// `runDoctor` unit tests each mocked/constructed their own fixtures and
+// never actually chained `runInit(...)` output into `runDoctor(...)`. That
+// gap is exactly why the BLOCKER (persisting `config.agents` for a
+// distribution stage that never ran) slipped through: no test exercised the
+// combination `artgraph init --no-skills --agents=X` followed immediately by
+// `artgraph doctor`.
+//
+// These tests close that gap by always calling `runInit` then `runDoctor`
+// against the same tmp dir, mirroring what a user actually does.
+//
+// Two of the seven scenarios below (case 2 and case 3) deliberately assert
+// something narrower than "doctor reports zero failures" — see the comments
+// on each for why; that's a documented, verified compromise, not an
+// oversight (see the PR trailer / session notes for the full rationale).
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { runInit } from "../src/init.js";
+import { runDoctor, type DoctorFinding } from "../src/doctor.js";
+import { createFreshProject } from "./agents/helpers.js";
+
+function readConfig(dir: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(dir, ".artgraph.json"), "utf-8"));
+}
+
+function findFinding(
+  findings: DoctorFinding[],
+  pred: (f: DoctorFinding) => boolean,
+): DoctorFinding | undefined {
+  return findings.find(pred);
+}
+
+describe("init -> doctor integration (#158 review, MINOR)", () => {
+  let proj: ReturnType<typeof createFreshProject>;
+
+  beforeEach(() => {
+    proj = createFreshProject();
+  });
+
+  afterEach(() => {
+    proj.cleanup();
+  });
+
+  it("1. fresh init writes agents, doctor reports zero failures", () => {
+    runInit(proj.dir, { agents: ["claude"] });
+    expect(readConfig(proj.dir).agents).toEqual(["claude"]);
+
+    const report = runDoctor({ rootDir: proj.dir });
+    expect(report.summary.failCount, JSON.stringify(report.findings, null, 2)).toBe(0);
+    expect(
+      findFinding(report.findings, (f) => f.kind === "agent-recorded-but-missing"),
+    ).toBeUndefined();
+  });
+
+  // BLOCKER repro corner, precisely per Fix 1's own gating comment: persistence
+  // is skipped only when BOTH the skills and agent-context stages are off
+  // this invocation (`--no-skills --no-agent-context`, or `--minimal`).
+  // `--no-skills` alone leaves agent-context active, so it still persists
+  // (see case 3 below, and src/init.ts `anyDistributionStageActive`) — that
+  // narrower case is exercised separately in tests/init.test.ts's
+  // "--force --agents=cursor with --no-skills --no-agent-context ..." test.
+  it("2. --no-skills --no-agent-context --agents=claude does not persist, doctor reports zero findings", () => {
+    runInit(proj.dir, { agents: ["claude"], noSkills: true, noAgentContext: true });
+    const config = readConfig(proj.dir);
+    expect("agents" in config).toBe(false);
+    expect(existsSync(join(proj.dir, ".claude", "skills"))).toBe(false);
+    expect(existsSync(join(proj.dir, "CLAUDE.md"))).toBe(false);
+
+    // Nothing was distributed and nothing is recorded, so doctor's
+    // zero-detected short-circuit applies: an empty report, not just a
+    // zero fail count.
+    const report = runDoctor({ rootDir: proj.dir });
+    expect(report.findings).toEqual([]);
+    expect(report.summary.failCount).toBe(0);
+  });
+
+  // `--no-agent-context --agents=claude` alone still runs the skills stage,
+  // so per Fix 1's gating `config.agents` IS persisted (agent-context is
+  // also a "distribution stage that installs per-agent artifacts" —
+  // `anyDistributionStageActive = skillsStageActive || agentContextStageActive`).
+  // The any-artifact check (Fix 2) then correctly treats claude as
+  // "installed" (Skills present) so the config cross-check does NOT
+  // false-positive `agent-recorded-but-missing`.
+  //
+  // Doctor's *unrelated* per-file diagnostics (Step 4 `agents-md-missing` /
+  // Step 5 `wrapper-missing`) are or­thogonal to these 3 fixes — they assume
+  // every detected agent has a complete distribution (skills AND
+  // agent-context) and were not in scope for the #158 review's cross-check
+  // fixes. They correctly still fire here since AGENTS.md/CLAUDE.md were
+  // genuinely never written. This test asserts the narrow claim the fixes
+  // actually make (no false-positive cross-check finding), not an overall
+  // zero fail count — see PR trailer / session notes for the full
+  // discrepancy writeup against the original task description.
+  it("3. --no-agent-context --agents=claude persists (skills stage ran); config cross-check does not false-positive", () => {
+    runInit(proj.dir, { agents: ["claude"], noAgentContext: true });
+    expect(readConfig(proj.dir).agents).toEqual(["claude"]);
+    expect(existsSync(join(proj.dir, ".claude", "skills"))).toBe(true);
+    expect(existsSync(join(proj.dir, "CLAUDE.md"))).toBe(false);
+
+    const report = runDoctor({ rootDir: proj.dir });
+    expect(
+      findFinding(
+        report.findings,
+        (f) => f.kind === "agent-recorded-but-missing" && f.agent === "claude",
+      ),
+    ).toBeUndefined();
+    expect(
+      findFinding(
+        report.findings,
+        (f) => f.kind === "agent-installed-not-recorded" && f.agent === "claude",
+      ),
+    ).toBeUndefined();
+    // Skills themselves are fully healthy.
+    expect(
+      report.findings.some((f) => f.agent === "claude" && f.kind === "skill-file-missing"),
+    ).toBe(false);
+  });
+
+  it("4. deleting BOTH the skills dir and the wrapper fires agent-recorded-but-missing", () => {
+    runInit(proj.dir, { agents: ["claude"] });
+    rmSync(join(proj.dir, ".claude", "skills"), { recursive: true, force: true });
+    rmSync(join(proj.dir, "CLAUDE.md"), { force: true });
+
+    const report = runDoctor({ rootDir: proj.dir });
+    const f = findFinding(
+      report.findings,
+      (x) => x.kind === "agent-recorded-but-missing" && x.agent === "claude",
+    );
+    expect(f, JSON.stringify(report.findings, null, 2)).toBeDefined();
+    expect(f!.severity).toBe("fail");
+    expect(f!.message).toContain(".claude/skills/");
+    expect(f!.message).toContain("CLAUDE.md");
+    expect(f!.message).toContain("hand-edit .artgraph.json");
+    expect(f!.message).toContain("#131");
+  });
+
+  it("5. deleting ONLY the skills dir does not false-positive (wrapper still covers it)", () => {
+    runInit(proj.dir, { agents: ["claude"] });
+    rmSync(join(proj.dir, ".claude", "skills"), { recursive: true, force: true });
+
+    const report = runDoctor({ rootDir: proj.dir });
+    expect(
+      findFinding(
+        report.findings,
+        (x) => x.kind === "agent-recorded-but-missing" && x.agent === "claude",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("6. manually creating .cursor/skills/ fires agent-installed-not-recorded for cursor", () => {
+    runInit(proj.dir, { agents: ["claude"] });
+    mkdirSync(join(proj.dir, ".cursor", "skills", "artgraph-verify"), { recursive: true });
+    writeFileSync(
+      join(proj.dir, ".cursor", "skills", "artgraph-verify", "SKILL.md"),
+      "# not the canonical content\n",
+    );
+
+    const report = runDoctor({ rootDir: proj.dir });
+    const f = findFinding(
+      report.findings,
+      (x) => x.kind === "agent-installed-not-recorded" && x.agent === "cursor",
+    );
+    expect(f, JSON.stringify(report.findings, null, 2)).toBeDefined();
+    expect(f!.severity).toBe("pass");
+  });
+
+  it("7. --minimal --agents=claude does not persist the agents field", () => {
+    runInit(proj.dir, { agents: ["claude"], minimal: true });
+    const config = readConfig(proj.dir);
+    expect("agents" in config).toBe(false);
+  });
+});

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1076,3 +1076,53 @@ describe("runInit — packageManager recording (spec 015, FR-007/008, SC-002)", 
     expect(readPm()).toBe("pnpm");
   });
 });
+
+describe("runInit — agents field persistence (#158)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = makeTmpDir();
+  });
+
+  afterEach(() => {
+    cleanup(tmp);
+  });
+
+  const readAgents = (): unknown =>
+    JSON.parse(readFileSync(join(tmp, ".artgraph.json"), "utf-8")).agents;
+
+  it("fresh init writes the agents field, alpha-sorted, when --agents=claude,cursor is given", () => {
+    runInit(tmp, { minimal: true, agents: ["cursor", "claude"] });
+    expect(readAgents()).toEqual(["claude", "cursor"]);
+  });
+
+  it("fresh init without --agents does NOT write an agents field", () => {
+    runInit(tmp, { minimal: true });
+    const config = JSON.parse(readFileSync(join(tmp, ".artgraph.json"), "utf-8"));
+    expect("agents" in config).toBe(false);
+  });
+
+  it('--force --agents=cursor on an existing config with agents:["claude"] unions to ["claude","cursor"]', () => {
+    writeFileSync(join(tmp, ".artgraph.json"), JSON.stringify({ agents: ["claude"] }));
+    runInit(tmp, { force: true, minimal: true, agents: ["cursor"] });
+    expect(readAgents()).toEqual(["claude", "cursor"]);
+  });
+
+  it('--force --agents=cursor on an existing legacy config (no agents field) writes just ["cursor"]', () => {
+    writeFileSync(join(tmp, ".artgraph.json"), JSON.stringify({ include: ["src/**/*.ts"] }));
+    runInit(tmp, { force: true, minimal: true, agents: ["cursor"] });
+    expect(readAgents()).toEqual(["cursor"]);
+  });
+
+  it("--force re-init with no --agents preserves a previously persisted agents field", () => {
+    writeFileSync(join(tmp, ".artgraph.json"), JSON.stringify({ agents: ["claude", "codex"] }));
+    runInit(tmp, { force: true, minimal: true });
+    expect(readAgents()).toEqual(["claude", "codex"]);
+  });
+
+  it("dedupes when the same agent id is requested again on --force", () => {
+    writeFileSync(join(tmp, ".artgraph.json"), JSON.stringify({ agents: ["claude"] }));
+    runInit(tmp, { force: true, minimal: true, agents: ["claude"] });
+    expect(readAgents()).toEqual(["claude"]);
+  });
+});

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -1091,9 +1091,16 @@ describe("runInit — agents field persistence (#158)", () => {
   const readAgents = (): unknown =>
     JSON.parse(readFileSync(join(tmp, ".artgraph.json"), "utf-8")).agents;
 
-  it("fresh init writes the agents field, alpha-sorted, when --agents=claude,cursor is given", () => {
+  // #158 review (BLOCKER) — `--minimal` gates off every distribution stage
+  // (skills AND agent-context), so no per-agent artifact is ever installed.
+  // Persisting `agents` in that case would create a self-inflicted
+  // `agent-recorded-but-missing` FAIL on the next `doctor` run. This test
+  // used to assert the opposite (field written); updated to match the new
+  // stage-gated persistence semantic (src/init.ts `anyDistributionStageActive`).
+  it("fresh init with --minimal does NOT write the agents field, even when --agents=claude,cursor is given (no distribution stage ran)", () => {
     runInit(tmp, { minimal: true, agents: ["cursor", "claude"] });
-    expect(readAgents()).toEqual(["claude", "cursor"]);
+    const config = JSON.parse(readFileSync(join(tmp, ".artgraph.json"), "utf-8"));
+    expect("agents" in config).toBe(false);
   });
 
   it("fresh init without --agents does NOT write an agents field", () => {
@@ -1102,15 +1109,33 @@ describe("runInit — agents field persistence (#158)", () => {
     expect("agents" in config).toBe(false);
   });
 
-  it('--force --agents=cursor on an existing config with agents:["claude"] unions to ["claude","cursor"]', () => {
+  // #158 review — these two union/legacy-config tests need at least one
+  // distribution stage active to exercise persistence at all post-fix
+  // (`--minimal` no longer triggers a write). Swapped `minimal: true` for
+  // `noScan/noHooks/noIntegrate` so the skills + agent-context stages stay
+  // on (cheap on an empty tmp dir — no project content required) while the
+  // heavier stages we don't care about here stay off.
+  it('--force --agents=cursor on an existing config with agents:["claude"] unions to ["claude","cursor"] (skills stage active)', () => {
     writeFileSync(join(tmp, ".artgraph.json"), JSON.stringify({ agents: ["claude"] }));
-    runInit(tmp, { force: true, minimal: true, agents: ["cursor"] });
+    runInit(tmp, {
+      force: true,
+      noScan: true,
+      noHooks: true,
+      noIntegrate: true,
+      agents: ["cursor"],
+    });
     expect(readAgents()).toEqual(["claude", "cursor"]);
   });
 
-  it('--force --agents=cursor on an existing legacy config (no agents field) writes just ["cursor"]', () => {
+  it('--force --agents=cursor on an existing legacy config (no agents field) writes just ["cursor"] (skills stage active)', () => {
     writeFileSync(join(tmp, ".artgraph.json"), JSON.stringify({ include: ["src/**/*.ts"] }));
-    runInit(tmp, { force: true, minimal: true, agents: ["cursor"] });
+    runInit(tmp, {
+      force: true,
+      noScan: true,
+      noHooks: true,
+      noIntegrate: true,
+      agents: ["cursor"],
+    });
     expect(readAgents()).toEqual(["cursor"]);
   });
 
@@ -1118,6 +1143,25 @@ describe("runInit — agents field persistence (#158)", () => {
     writeFileSync(join(tmp, ".artgraph.json"), JSON.stringify({ agents: ["claude", "codex"] }));
     runInit(tmp, { force: true, minimal: true });
     expect(readAgents()).toEqual(["claude", "codex"]);
+  });
+
+  // #158 review — Fix 1's documented corner case: a `--force` re-run that
+  // still passes `--agents=<X>` but opts out of BOTH distribution stages via
+  // the granular flags (as opposed to `--minimal`, tested above) must NOT
+  // union `agentsList` into the existing `config.agents` — nothing was
+  // actually installed for `cursor` this invocation, so recording it would
+  // be exactly the BLOCKER's self-inflicted `agent-recorded-but-missing`.
+  // The previously persisted set is carried through untouched.
+  it("--force --agents=cursor with --no-skills --no-agent-context preserves existing config.agents untouched (does not union in cursor)", () => {
+    writeFileSync(join(tmp, ".artgraph.json"), JSON.stringify({ agents: ["claude"] }));
+    runInit(tmp, {
+      force: true,
+      noSkills: true,
+      noAgentContext: true,
+      agents: ["cursor"],
+    });
+    expect(readAgents()).toEqual(["claude"]);
+    expect(existsSync(join(tmp, ".cursor", "skills"))).toBe(false);
   });
 
   it("dedupes when the same agent id is requested again on --force", () => {


### PR DESCRIPTION
## Summary

`ArtgraphConfig` に `agents?: AgentId[]` を追加し、`artgraph init` が `--agents=<csv>` の指定を `.artgraph.json` に persist するようにする。これにより doctor / rename / (将来の) uninstall が config を SSOT として cross-check できるようになる。

- `init`: 既存 config.agents との **union semantic** で再 init しても以前の agents が silently drop されない
- `doctor`: config.agents 定義済みなら on-disk と cross-check し drift finding を発報
- `doctor`: config.agents 未定義 (legacy config) は on-disk fallback + advisory finding で「`init --force --agents=...` で persist を」案内

Closes #158
Supersedes #133 (dup — 統合完了後 close 予定)

## Change type

- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## 主な変更

### `src/types.ts`
- `ArtgraphConfig` に `agents?: AgentId[]` を追加 (docstring 付き)
- `DEFAULT_CONFIG` は未指定のまま (legacy semantic を尊重)

### `src/config.ts`
- `validateAgents()` を追加: 非配列 / 不正 id / 重複 / 空文字列を reject、空配列は明示的 opt-out として受け入れ

### `src/init.ts`
- 既存 config.agents との **union** で書き込み (`alphaSort(dedup((existing ?? []) ∪ (options.agents ?? [])))`)
- **stage gate (レビュー指摘対応)**: `skillsStageActive || agentContextStageActive` が true のときのみ persist。`--minimal` / `--no-skills --no-agent-context` で agents 指定した場合に self-inflicted `agent-recorded-but-missing` を発生させない
- 既存の agents field は stage が inactive でも preserve (silent wipe しない)

### `src/doctor.ts`
新しい finding kinds 3 つと Step 1 の default detection ロジック更新:

| kind | 発生条件 | severity |
|---|---|---|
| `config-missing-agents-field` | `config.agents === undefined` かつ on-disk agent 存在 | pass (advisory) |
| `agent-recorded-but-missing` | `config.agents` にあり disk に無し (skillsPath **かつ** wrapperFile 両方無し) | fail (actionable) |
| `agent-installed-not-recorded` | disk にあり (skillsPath **または** wrapperFile) `config.agents` に無し | pass (advisory) |

**any-artifact check (レビュー指摘対応)**: `isAgentDistributionOnDisk` は skillsPath **または** wrapperFile のいずれかが存在すれば installed と判定。`--no-skills` / `--no-agent-context` の部分配布パターンで false-positive を出さない。

Default detection:
- `opts.agents` 明示指定 → それを使う (CLI override / 従来挙動)
- `opts.agents` 未指定 + `config.agents === undefined` → on-disk fallback + advisory finding
- `opts.agents` 未指定 + `config.agents` 定義済み → `config.agents ∪ on-disk` を評価対象に

## Testing

- [x] `pnpm test:unit`: 72 files, 1635 passed / 5 skipped, 0 failed
- [x] `pnpm knip`: clean (exit 0)
- [x] Pre-push hook: e2e (41 passed / 2 skipped) + unit + typecheck + knip 全 green
- [x] Added tests where needed:
  - config.test.ts +9 (validation)
  - init.test.ts +6 + 3 修正 (persist / union / stage gate)
  - doctor.test.ts +6 (drift findings)
  - **init-doctor-integration.test.ts (新規) +7** — init→doctor round-trip、レビュー指摘の BLOCKER 再現ケースを含む

## Breaking change

- [ ] Yes (described below)
- [x] No

**互換性メモ**: legacy config (`agents` field 無し) は `agents === undefined` を保持し、doctor は on-disk fallback + advisory finding で従来挙動を維持。既存 dogfood config (本リポの `.artgraph.json`) を含め `failCount === 0` を保つよう検証済み。

## レビュー指摘対応 (commit `b104b5c`)

敵対的レビューで検出された **BLOCKER + MAJOR + MINOR** を修正:

1. **[BLOCKER] init.ts stage gate**: `--no-skills --no-agent-context --agents=claude` で `config.agents=["claude"]` が書かれるが `.claude/skills/` は作られず、次 doctor が self-inflicted FAIL を返していた。`anyDistributionStageActive` gate で解消
2. **[BLOCKER→部分対応] doctor.ts any-artifact check**: `--no-skills --agents=claude` は wrapperFile (CLAUDE.md) は作られるが skillsPath は作られない。旧判定 (skillsPath のみ) では false-positive。skillsPath OR wrapperFile の any-artifact check に変更
3. **[MAJOR] doctor message 正直化**: `agent-recorded-but-missing` メッセージから nonexistent 「update the config to drop it」を削除。手動 JSON 編集 or 将来の `artgraph uninstall` (#131) を明記
4. **[MINOR] init→doctor integration tests**: 7 ケースの新規テストファイル追加。BLOCKER 再現ケース (`--minimal --agents=X` 後の doctor 実行で FAIL しないこと) を含む

## Notes

**設計判断ハイライト**:

1. **Union semantic on --force**: 既存 config.agents=[X] に `--force --agents=Y` → `[X, Y]`。subset drop は将来 `--set-agents` 相当 flag で別途対応 (別 follow-up 化)
2. **Legacy = undefined**: `agents` field 無しは canonical schema の一部として `undefined` を保持。auto-heal (loadConfig で on-disk 補間) は行わず doctor advisory finding で明示化
3. **Severity mapping**: `DoctorFindingSeverity` が現状 `"pass" | "fail"` の 2 値のため、advisory は `pass`, actionable は `fail` に mapping。仕様上「info/warn」レベルを分けたい場合は将来 severity 拡張の別 issue で
4. **Stage gate semantic**: `--no-skills` 単独では agent-context は走るので persist する。`--no-skills --no-agent-context` (両方 off) or `--minimal` のときのみ persist しない
5. **`agent-installed-not-recorded` は detectedDescriptors にも feed**: Step 3-5 (Skill / wrapper 診断) がスキップされないよう挙動を維持

**Follow-up 検討事項**:
- `--set-agents` flag (explicit subset install / drop)
- `artgraph uninstall` (#131) で agents field を正式に drop
- `artgraph-detect` Skill を実体化する場合、本 field を primary source として利用
- rename Skill が agents を iterate するようになった際、config.agents を SSOT に

## Related

- Issue #158 (本 PR で対応)
- Issue #133 (dup — 統合完了後 close 予定)
- Enables: #131 (uninstall — agents field を「何を消すか」の source of truth として利用)
