### PR TITLE
fix(trace): メソッド粒度 @impl の unexercised 偽陽性を解消 — メンバー id 解決 + claim 照合限定の contains ロールアップ (#255)

### DIFF
--- a/src/trace/report.ts
+++ b/src/trace/report.ts
@@ -79,7 +79,12 @@ function pairCompare(a: ClaimEvidencePair, b: ClaimEvidencePair): number {
  * suggestedImpls-on-class-node this fix closes (verified experimentally
  * while designing this fix — a naive "resolve members to the class"
  * approach broke corroboration; the inverse "roll up everywhere" approach
- * broke exclusivity).
+ * broke exclusivity). PR #268 review F2 (issue #255 follow-up) later adds
+ * `hasAncestorClaim`, a SEPARATE `contains`-walking helper that DOES touch
+ * `suggestedImpls` — it is not a relaxation of this rule: it never reads
+ * evidence (`perReq`/`reqsByNode`) at all, only pre-existing `implements`
+ * claims, so it cannot reintroduce the double-counting this note warns
+ * against. See that function's doc, below `buildContainerIndex`.
  */
 function reqExercises(
   containsIndex: Map<string, string[]>,
@@ -122,6 +127,58 @@ function buildContainsIndex(graph: ArtifactGraph): Map<string, string[]> {
 }
 
 /**
+ * `contains` adjacency inverted (target -> sources, i.e. a node's direct
+ * CONTAINERS) — the parent-ward mirror of `buildContainsIndex` above, built
+ * ONCE per `classifyEvidence` call for the same reason: `hasAncestorClaim`
+ * (below) walks upward per `suggestedImpls` candidate, and rescanning
+ * `graph.edges` per candidate would reintroduce the O(candidates x edges)
+ * cost `buildContainsIndex`'s doc already measured on the forward direction.
+ */
+function buildContainerIndex(graph: ArtifactGraph): Map<string, string[]> {
+  const index = new Map<string, string[]>();
+  for (const edge of graph.edges) {
+    if (edge.kind !== "contains") continue;
+    const sources = index.get(edge.target);
+    if (sources) sources.push(edge.source);
+    else index.set(edge.target, [edge.source]);
+  }
+  return index;
+}
+
+/**
+ * PR #268 review F2 (issue #255 follow-up) — a DIFFERENT mechanism from
+ * `reqExercises`'s evidence roll-up above, despite the superficial
+ * similarity (both walk `contains`, both cycle-guard with `seen`). This one
+ * never touches `trace.perReq`/`reqsByNode` at all: it asks "does any
+ * CONTAINER of `node`, at any depth, already carry an `@impl reqId` CLAIM?"
+ * purely from `claimsByNode` (the `implements`-edge map built in
+ * `classifyEvidence` below). Used ONLY to decide whether to hold back a
+ * `suggestedImpls` entry, never to affect `corroborated`/`unexercisedClaims`
+ * — `reqExercises`'s SCOPE note above still holds: evidence never rolls up
+ * into `suggestedImpls`. Rationale: in repos that tag `@impl` at class
+ * granularity, a class-level claim already answers "is REQ-X's code
+ * identified" for that REQ; once the class claims REQ-X, member-level
+ * suggestions to ALSO tag REQ-X are noise, not signal — but a claim on
+ * REQ-X's ancestor says nothing about a DIFFERENT REQ-Y the same member is
+ * exclusively exercised for, so this only suppresses a same-`reqId` match.
+ */
+function hasAncestorClaim(
+  containerIndex: Map<string, string[]>,
+  claimsByNode: Map<string, Set<string>>,
+  reqId: string,
+  node: string,
+  seen: Set<string> = new Set(),
+): boolean {
+  for (const parent of containerIndex.get(node) ?? []) {
+    if (seen.has(parent)) continue;
+    seen.add(parent);
+    if (claimsByNode.get(parent)?.has(reqId)) return true;
+    if (hasAncestorClaim(containerIndex, claimsByNode, reqId, parent, seen)) return true;
+  }
+  return false;
+}
+
+/**
  * FR-013 exclusivity predicate: exactly one distinct REQ's evidence reaches
  * `node`. Factored out of `classifyEvidence` (below) so `src/coverage.ts`'s
  * `exercised` status computation (FR-014) shares the EXACT same "what counts
@@ -159,13 +216,18 @@ export function classifyEvidence(
   const corroborated: ClaimEvidencePair[] = [];
   const unexercisedClaims: ClaimEvidencePair[] = [];
   const claimedNodes = new Set<string>();
+  const claimsByNode = new Map<string, Set<string>>();
   const containsIndex = buildContainsIndex(graph);
+  const containerIndex = buildContainerIndex(graph);
 
   for (const edge of graph.edges) {
     if (edge.kind !== "implements") continue;
     const node = edge.source;
     const reqId = edge.target;
     claimedNodes.add(node);
+    const reqIdsForNode = claimsByNode.get(node);
+    if (reqIdsForNode) reqIdsForNode.add(reqId);
+    else claimsByNode.set(node, new Set([reqId]));
     if (reqExercises(containsIndex, trace, reqId, node)) {
       corroborated.push({ reqId, node });
     } else {
@@ -181,7 +243,14 @@ export function classifyEvidence(
       infrastructure.push({ node, reqCount: reqIds.size });
     } else if (isExclusiveNode(trace, node)) {
       const [reqId] = reqIds;
-      suggestedImpls.push({ reqId: reqId!, node });
+      // PR #268 review F2: an ancestor already claiming this SAME reqId
+      // means a class-granularity `@impl` has already "found" this
+      // requirement's code — suppress the redundant member-level nudge (see
+      // `hasAncestorClaim`'s doc above for why this is not a `reqExercises`
+      // roll-up).
+      if (!hasAncestorClaim(containerIndex, claimsByNode, reqId!, node)) {
+        suggestedImpls.push({ reqId: reqId!, node });
+      }
     }
     // 2 .. sharedThreshold-1: silent by design (FR-013).
   }

--- a/src/trace/report.ts
+++ b/src/trace/report.ts
@@ -53,11 +53,51 @@ function pairCompare(a: ClaimEvidencePair, b: ClaimEvidencePair): number {
  * file-grain fallback still counts as exercised at that same grain (FR-007
  * fail-safe symmetry: the claim and the evidence must be compared at
  * whatever grain the evidence actually landed at).
+ *
+ * spec 020 x spec 021 (issue #255) — `contains` ROLL-UP, claim-corroboration
+ * ONLY. When `node` itself isn't directly exercised, this also checks every
+ * node reachable from it via a `contains` edge (e.g. spec 021's class ->
+ * method edge, FR-006) and counts `node` as exercised if ANY of them is
+ * exercised for the SAME `reqId`. Rationale: a class-level `@impl` claim and
+ * a method-level trace hit are both real signal for the same requirement —
+ * `symbol-table.ts`'s Source 2 now resolves a method hit to the METHOD's own
+ * symbol id when one exists, so without this roll-up a class-level claim
+ * would go "unexercised" purely because the evidence lands one containment
+ * level below the claimed node, not because the requirement is actually
+ * unproven. Recursive with a cycle guard (`seen`) — today's only `contains`
+ * producer is one level deep (class -> method), but nothing here assumes
+ * that stays true. Forward-only, mirroring `graph/traverse.ts`'s `contains`
+ * BFS (spec 019 FR-001〜003) — a node never rolls UP into its container,
+ * only DOWN into what it contains.
+ *
+ * SCOPE: used ONLY inside `classifyEvidence`'s `implements`-edge loop below
+ * (claim corroboration: `corroborated` / `unexercisedClaims`). Do NOT reuse
+ * this for `suggestedImpls`, `infrastructure`, or `isExclusiveNode` — those
+ * intentionally read `trace.reqsByNode` / `perReq` directly, unrolled.
+ * Rolling evidence up through `contains` for THOSE would double-count a
+ * method's exercised evidence at its class and reintroduce the false
+ * suggestedImpls-on-class-node this fix closes (verified experimentally
+ * while designing this fix — a naive "resolve members to the class"
+ * approach broke corroboration; the inverse "roll up everywhere" approach
+ * broke exclusivity).
  */
-function reqExercises(trace: IngestedTrace, reqId: string, node: string): boolean {
+function reqExercises(
+  graph: ArtifactGraph,
+  trace: IngestedTrace,
+  reqId: string,
+  node: string,
+  seen: Set<string> = new Set(),
+): boolean {
   const coverage = trace.perReq.get(reqId);
   if (!coverage) return false;
-  return coverage.symbols.includes(node) || coverage.files.includes(node);
+  if (coverage.symbols.includes(node) || coverage.files.includes(node)) return true;
+  if (seen.has(node)) return false;
+  seen.add(node);
+  for (const edge of graph.edges) {
+    if (edge.kind !== "contains" || edge.source !== node) continue;
+    if (reqExercises(graph, trace, reqId, edge.target, seen)) return true;
+  }
+  return false;
 }
 
 /**
@@ -104,7 +144,7 @@ export function classifyEvidence(
     const node = edge.source;
     const reqId = edge.target;
     claimedNodes.add(node);
-    if (reqExercises(trace, reqId, node)) {
+    if (reqExercises(graph, trace, reqId, node)) {
       corroborated.push({ reqId, node });
     } else {
       unexercisedClaims.push({ reqId, node });

--- a/src/trace/report.ts
+++ b/src/trace/report.ts
@@ -82,7 +82,7 @@ function pairCompare(a: ClaimEvidencePair, b: ClaimEvidencePair): number {
  * broke exclusivity).
  */
 function reqExercises(
-  graph: ArtifactGraph,
+  containsIndex: Map<string, string[]>,
   trace: IngestedTrace,
   reqId: string,
   node: string,
@@ -93,11 +93,32 @@ function reqExercises(
   if (coverage.symbols.includes(node) || coverage.files.includes(node)) return true;
   if (seen.has(node)) return false;
   seen.add(node);
-  for (const edge of graph.edges) {
-    if (edge.kind !== "contains" || edge.source !== node) continue;
-    if (reqExercises(graph, trace, reqId, edge.target, seen)) return true;
+  for (const target of containsIndex.get(node) ?? []) {
+    if (reqExercises(containsIndex, trace, reqId, target, seen)) return true;
   }
   return false;
+}
+
+/**
+ * `contains` adjacency (source -> targets), built ONCE per `classifyEvidence`
+ * call so `reqExercises` doesn't rescan `graph.edges` per claim — that scan
+ * is O(claims x edges), quadratic-ish on repos where class-level `@impl` is
+ * the norm (measured: ~13s at 20k classes vs milliseconds with this index).
+ * Deliberately kind-blind beyond `contains`: today's producers (spec 021's
+ * class -> method, builder.ts's doc -> req|task) live in disjoint id
+ * namespaces so a symbol-node lookup can never reach a doc-sourced edge —
+ * revisit this assumption before adding any new `contains` producer whose
+ * source can be a `symbol:`/`file:` node.
+ */
+function buildContainsIndex(graph: ArtifactGraph): Map<string, string[]> {
+  const index = new Map<string, string[]>();
+  for (const edge of graph.edges) {
+    if (edge.kind !== "contains") continue;
+    const targets = index.get(edge.source);
+    if (targets) targets.push(edge.target);
+    else index.set(edge.source, [edge.target]);
+  }
+  return index;
 }
 
 /**
@@ -138,13 +159,14 @@ export function classifyEvidence(
   const corroborated: ClaimEvidencePair[] = [];
   const unexercisedClaims: ClaimEvidencePair[] = [];
   const claimedNodes = new Set<string>();
+  const containsIndex = buildContainsIndex(graph);
 
   for (const edge of graph.edges) {
     if (edge.kind !== "implements") continue;
     const node = edge.source;
     const reqId = edge.target;
     claimedNodes.add(node);
-    if (reqExercises(graph, trace, reqId, node)) {
+    if (reqExercises(containsIndex, trace, reqId, node)) {
       corroborated.push({ reqId, node });
     } else {
       unexercisedClaims.push({ reqId, node });

--- a/src/trace/symbol-table.ts
+++ b/src/trace/symbol-table.ts
@@ -14,13 +14,18 @@
 //      duplicate implementations).
 //   2. Class member names. V8 reports a class method's OWN name as the
 //      `functionName` (e.g. `add` on `class Cart { add() {} }`), never the
-//      declaring class's name, so a hit on a class method never matches
-//      source (1) directly. `extractSymbols` only emits nodes for top-level
-//      exports (no per-member nodes), so this is a second, narrowly-scoped
-//      walk — class body member names only, mapped to the OWNING class's own
-//      exported symbol id — rather than a re-implementation of export
-//      enumeration (issue #218's "class symbol convergence" applied to
-//      execution evidence).
+//      dotted `Class.member` form `extractClassMembers` (spec 021) registers
+//      that member's OWN symbol node under, so a hit on a class method never
+//      matches source (1) directly under its bare name. This is a second,
+//      narrowly-scoped walk — class body member names only — that resolves a
+//      bare member name to that member's OWN symbol id
+//      (`symbol:<path>#Class.member`) when `extractClassMembers` actually
+//      symbolized it, else falls back to the OWNING class's own exported
+//      symbol id (issue #255 — a class-grain fallback stays correct for
+//      members `extractClassMembers` never gives a node of their own, e.g. a
+//      non-function property). Never re-implements export enumeration
+//      (issue #218's "class symbol convergence" applied to execution
+//      evidence).
 //
 // A name that resolves to more than one candidate symbol id within the same
 // file (e.g. a top-level `export function add()` alongside an unrelated
@@ -122,16 +127,42 @@ export function buildSymbolNameTable(rootDir: string, includePatterns: string[])
   };
 
   // Source 1: exported top-level symbols (extractSymbols, via the parser's
-  // public "symbol" mode — same file set, same name-resolution rules).
+  // public "symbol" mode — same file set, same name-resolution rules). This
+  // ALSO includes one node per spec-021 class member (`extractClassMembers`'s
+  // `symbol:<path>#Class.member` ids, registered here under their FULL dotted
+  // name) — `symbolIds` below reuses this exact set as the "does this member
+  // actually get its own symbol node" existence check for Source 2, instead
+  // of re-deriving `extractClassMembers`'s inclusion rules a second time.
+  const symbolIds = new Set<string>();
   const { nodes } = createTSParser(rootDir, includePatterns, "symbol").parse();
   for (const node of nodes) {
     if (node.kind !== "symbol") continue;
     const hashIdx = node.id.indexOf("#");
     if (hashIdx === -1) continue;
+    symbolIds.add(node.id);
     addCandidate(node.filePath, node.id.slice(hashIdx + 1), node.id);
   }
 
-  // Source 2: class member names -> owning class's own symbol id.
+  // Source 2: class member names -> the MEMBER's own symbol id when one was
+  // actually synthesized for it (issue #255), else the owning class's id.
+  //
+  // V8 reports a class method's OWN name as the `functionName` (e.g. `add` on
+  // `class Cart { add() {} }`), never the dotted `Class.member` form
+  // `extractClassMembers` (spec 021) registers its symbol node under — so a
+  // hit on a class method never matches Source 1's candidate table directly.
+  // This walk re-derives the bare member name -> owning class mapping so such
+  // a hit resolves at all, then upgrades the target to the MEMBER's own
+  // symbol id (`symbol:<path>#Class.member`) whenever `extractClassMembers`
+  // actually symbolized that member — checked via `symbolIds.has(...)` above,
+  // not by re-deriving its inclusion rules here. That existence guard matters
+  // because THIS walk's own member filter (MethodDefinition | PropertyDefinition,
+  // non-computed, non-constructor) is intentionally broader than
+  // `extractClassMembers`'s (e.g. a non-function `PropertyDefinition` like
+  // `foo = 3`, a `declare` member, or an abstract member is never symbolized
+  // by `extractClassMembers` — see its own doc comment for the full
+  // exclusion list): for those, the guard falls back to the class's own id,
+  // exactly as before this fix, rather than pointing at a symbol node that
+  // was never created.
   for (const filePath of files) {
     const relPath = relative(rootDir, filePath);
     let content: string;
@@ -158,9 +189,19 @@ export function buildSymbolNameTable(rootDir: string, includePatterns: string[])
       for (const member of decl.body?.body ?? []) {
         if (member.type !== "MethodDefinition" && member.type !== "PropertyDefinition") continue;
         if (member.computed) continue;
+        // issue #267: a constructor CALL is reported by V8 under the
+        // CLASS's own name (never "constructor"), so registering
+        // "constructor" as a candidate name here would never match a real
+        // hit — it's simply not the name V8 ever reports. That is a
+        // different gap from this fix (member-id resolution) and isn't
+        // rescued by the `contains` roll-up added in report.ts either,
+        // since a constructor hit already resolves straight to the class
+        // via its own name, never via a member name lookup at all.
         if (member.kind === "constructor") continue;
         if (member.key?.type !== "Identifier" || !member.key.name) continue;
-        addCandidate(relPath, member.key.name, classSymbolId);
+        const memberSymbolId = `symbol:${relPath}#${exportedName}.${member.key.name}`;
+        const resolvedId = symbolIds.has(memberSymbolId) ? memberSymbolId : classSymbolId;
+        addCandidate(relPath, member.key.name, resolvedId);
       }
     }
   }

--- a/tests/trace-ingest.test.ts
+++ b/tests/trace-ingest.test.ts
@@ -304,7 +304,7 @@ describe("(d) name-join edge cases fall back to file grain without losing REQ re
     expect(cov.files).toEqual(["file:src/a.ts"]);
   });
 
-  it("a class member name maps to the OWNING CLASS's symbol id (V8 reports method-level names)", () => {
+  it("a class member name maps to the MEMBER's OWN symbol id when extractClassMembers symbolized it (issue #255, V8 reports method-level names)", () => {
     const tmp = makeRepo({ "src/cart.ts": "export class Cart {\n  add() {}\n}\n" });
     writeShard(tmp, "w1.jsonl", [
       metaLine(),
@@ -316,6 +316,26 @@ describe("(d) name-join edge cases fall back to file grain without losing REQ re
     ]);
     const result = ingest(tmp);
     const cov = result.perReq.get("REQ-004")!;
+    expect(cov.symbols).toEqual(["symbol:src/cart.ts#Cart.add"]);
+    expect(cov.files).toEqual([]);
+  });
+
+  it("a class member name falls back to the OWNING CLASS's symbol id when extractClassMembers never symbolized that member (issue #255, non-function property)", () => {
+    // `count = 3` is a non-function PropertyDefinition — extractClassMembers
+    // (src/parsers/typescript.ts) never gives it a symbol node of its own, so
+    // Source 2's existence guard must fall back to the class, exactly as the
+    // pre-issue-255 behavior did for every member.
+    const tmp = makeRepo({ "src/cart.ts": "export class Cart {\n  count = 3;\n}\n" });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-014] non-function property",
+        hits: [{ file: "src/cart.ts", fn: "count" }],
+        hashes: { "src/cart.ts": "h1" },
+      }),
+    ]);
+    const result = ingest(tmp);
+    const cov = result.perReq.get("REQ-014")!;
     expect(cov.symbols).toEqual(["symbol:src/cart.ts#Cart"]);
     expect(cov.files).toEqual([]);
   });

--- a/tests/trace-method-grain.test.ts
+++ b/tests/trace-method-grain.test.ts
@@ -1,0 +1,374 @@
+// issue #255 — spec 020 (trace evidence) x spec 021 (class-method-grain
+// symbols) cross-cutting behavior. Before this fix, `src/trace/symbol-table.ts`
+// Source 2 always resolved a class member's V8-reported bare name to the
+// OWNING CLASS's symbol id, never the member's own id — so a method-level
+// `@impl` claim (which attributes to `symbol:<path>#Class.method`, per spec
+// 021) and a method-level trace hit (which landed on `symbol:<path>#Class`)
+// never agreed on a node, producing false `unexercisedClaims` AND false
+// `suggestedImpls` on the class. Fixed by (1) resolving a member name to its
+// OWN symbol id when `extractClassMembers` actually symbolized it
+// (`src/trace/symbol-table.ts`), and (2) a `contains`-edge roll-up scoped to
+// claim corroboration only (`src/trace/report.ts`'s `reqExercises`) so a
+// class-level claim still corroborates against a method-level hit.
+//
+// Follows `tests/trace-cli.test.ts`'s fixture style (hand-written TS sources
+// + hand-written shard JSONL, `mode: "symbol"`, driven end-to-end through the
+// real `trace report` CLI command so the real graph — including spec 021's
+// class -> method `contains` edges — is what `classifyEvidence` sees).
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { runAt } from "./helpers.js";
+import { SCHEMA_VERSION } from "../src/trace/schema.js";
+
+const created: string[] = [];
+function track(dir: string): string {
+  created.push(dir);
+  return dir;
+}
+afterEach(() => {
+  while (created.length) {
+    rmSync(created.pop()!, { recursive: true, force: true });
+  }
+});
+
+function makeRepo(
+  files: Record<string, string>,
+  configExtra: Record<string, unknown> = {},
+): string {
+  const tmp = track(mkdtempSync(join(tmpdir(), "artgraph-trace-method-grain-")));
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(tmp, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content, "utf-8");
+  }
+  writeFileSync(
+    join(tmp, ".artgraph.json"),
+    JSON.stringify({
+      include: ["src/**/*.ts"],
+      specDirs: ["specs"],
+      mode: "symbol",
+      ...configExtra,
+    }),
+    "utf-8",
+  );
+  return tmp;
+}
+
+function metaLine(): string {
+  return JSON.stringify({
+    schemaVersion: SCHEMA_VERSION,
+    kind: "meta",
+    runToken: "run-1",
+    pool: "forks",
+    vitest: "4.1.10",
+    startedAt: "2026-07-10T14:00:00Z",
+  });
+}
+
+function testLine(overrides: Record<string, unknown>): string {
+  return JSON.stringify({
+    kind: "test",
+    testName: "[" + "REQ-900] a test",
+    suitePath: [],
+    testFile: "tests/x.test.ts",
+    passed: true,
+    hits: [],
+    hashes: {},
+    ...overrides,
+  });
+}
+
+function writeShard(tmp: string, name: string, lines: string[]): void {
+  const dir = join(tmp, ".artgraph/trace");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), lines.join("\n"), "utf-8");
+}
+
+async function report(tmp: string): Promise<any> {
+  const { stdout, exitCode } = await runAt(tmp, ["trace", "report", "--format", "json"]);
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout);
+}
+
+describe("issue #255 (1): method-level claim + that method's hit -> corroborated, not unexercised", () => {
+  it("resolves the hit to the method's OWN symbol id, matching the method-level @impl claim", async () => {
+    const tmp = makeRepo({
+      "src/widget.ts": [
+        "export class Widget {",
+        "  // @impl " + "REQ-101",
+        "  start() {}",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-101] starts",
+        testFile: "tests/req101.test.ts",
+        hits: [{ file: "src/widget.ts", fn: "start" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    expect(result.corroborated).toEqual([
+      { reqId: "REQ-101", node: "symbol:src/widget.ts#Widget.start" },
+    ]);
+    expect(result.unexercisedClaims).toEqual([]);
+  });
+});
+
+describe("issue #255 (2): class-level claim + method hit -> corroborated via contains roll-up", () => {
+  it("a claim on the class corroborates when only a member's evidence lands (roll-up), not a class-level regression", async () => {
+    const tmp = makeRepo({
+      "src/engine.ts": [
+        "// @impl " + "REQ-102",
+        "export class Engine {",
+        "  run() {}",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-102] engine runs",
+        testFile: "tests/req102.test.ts",
+        hits: [{ file: "src/engine.ts", fn: "run" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    // The claim attributes to the CLASS (leading-trivia widening above the
+    // class decl), while the hit resolves to the MEMBER's own id — without
+    // the `contains` roll-up in `reqExercises` this would wrongly show up in
+    // `unexercisedClaims` (the exact issue #255 false positive).
+    expect(result.corroborated).toEqual([
+      { reqId: "REQ-102", node: "symbol:src/engine.ts#Engine" },
+    ]);
+    expect(result.unexercisedClaims).toEqual([]);
+    // Intended side effect of member-id resolution, not a regression: the
+    // class-level claim only covers the CLASS node (rolled up for
+    // corroboration above), so `Engine.run` itself — now a distinct,
+    // unclaimed node with exactly one REQ's evidence — separately qualifies
+    // as its own suggestion. `suggestedImpls`/`isExclusiveNode` deliberately
+    // do NOT roll up (see `reqExercises`'s doc in src/trace/report.ts), so
+    // this entry existing alongside the class's corroboration is correct.
+    expect(result.suggestedImpls).toEqual([
+      { reqId: "REQ-102", node: "symbol:src/engine.ts#Engine.run" },
+    ]);
+  });
+});
+
+describe("issue #255 (3): an unhit method's claim stays unexercised (true positive preserved)", () => {
+  it("a method claimed but never hit by its REQ's test is still reported unexercised", async () => {
+    const tmp = makeRepo({
+      "src/reporter.ts": [
+        "export class Reporter {",
+        "  // @impl " + "REQ-103",
+        "  send() {}",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-103] something else entirely",
+        testFile: "tests/req103.test.ts",
+        hits: [], // REQ-103's test runs but never touches Reporter#send
+      }),
+    ]);
+
+    const result = await report(tmp);
+    expect(result.unexercisedClaims).toEqual([
+      { reqId: "REQ-103", node: "symbol:src/reporter.ts#Reporter.send" },
+    ]);
+    expect(result.corroborated).toEqual([]);
+  });
+});
+
+describe("issue #255 (4): a claimed+hit method does not spuriously suggest an @impl on its class", () => {
+  it("suggestedImpls contains neither the method (already claimed) nor the class (never itself exercised)", async () => {
+    const tmp = makeRepo({
+      "src/mailer.ts": [
+        "export class Mailer {",
+        "  // @impl " + "REQ-104",
+        "  deliver() {}",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-104] delivers",
+        testFile: "tests/req104.test.ts",
+        hits: [{ file: "src/mailer.ts", fn: "deliver" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    expect(result.corroborated).toEqual([
+      { reqId: "REQ-104", node: "symbol:src/mailer.ts#Mailer.deliver" },
+    ]);
+    const suggestedNodes = result.suggestedImpls.map((p: { node: string }) => p.node);
+    expect(suggestedNodes).not.toContain("symbol:src/mailer.ts#Mailer");
+    expect(suggestedNodes).not.toContain("symbol:src/mailer.ts#Mailer.deliver");
+    expect(result.suggestedImpls).toEqual([]);
+  });
+});
+
+describe("issue #255 (5): a non-function property's hit falls back to the class (extractClassMembers never symbolizes it)", () => {
+  it("no @impl anywhere; a hit on a data property lands on the class and is exclusive -> suggestedImpls on the CLASS", async () => {
+    const tmp = makeRepo({
+      "src/cache.ts": ["export class Cache {", "  size = 0;", "}", ""].join("\n"),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-105] touches size",
+        testFile: "tests/req105.test.ts",
+        hits: [{ file: "src/cache.ts", fn: "size" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    expect(result.suggestedImpls).toEqual([
+      { reqId: "REQ-105", node: "symbol:src/cache.ts#Cache" },
+    ]);
+    expect(result.corroborated).toEqual([]);
+    expect(result.unexercisedClaims).toEqual([]);
+  });
+});
+
+describe("issue #255 (6): same-named method on two classes in one file -> file-fallback fail-safe unchanged", () => {
+  it("an ambiguous bare name across two classes still falls back to file grain, never guesses a class", async () => {
+    const tmp = makeRepo({
+      "src/shapes.ts": [
+        "export class Foo {",
+        "  run() {}",
+        "}",
+        "",
+        "export class Bar {",
+        "  run() {}",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-106] ambiguous run",
+        testFile: "tests/req106.test.ts",
+        hits: [{ file: "src/shapes.ts", fn: "run" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    expect(result.suggestedImpls).toEqual([{ reqId: "REQ-106", node: "file:src/shapes.ts" }]);
+    const allNodes = [
+      ...result.corroborated.map((p: { node: string }) => p.node),
+      ...result.unexercisedClaims.map((p: { node: string }) => p.node),
+      ...result.suggestedImpls.map((p: { node: string }) => p.node),
+    ];
+    expect(allNodes).not.toContain("symbol:src/shapes.ts#Foo");
+    expect(allNodes).not.toContain("symbol:src/shapes.ts#Bar");
+    expect(allNodes).not.toContain("symbol:src/shapes.ts#Foo.run");
+    expect(allNodes).not.toContain("symbol:src/shapes.ts#Bar.run");
+  });
+});
+
+describe("issue #255 (7): get/set same-name pin (PR #242 FR-003 convergence)", () => {
+  it('get x / set x converge to ONE member symbol node, so a hit on "x" resolves unambiguously (not file-fallback)', async () => {
+    // Per src/parsers/typescript.ts's extractClassMembers doc (FR-003), a
+    // getter and setter of the same name converge to a SINGLE symbol node
+    // (`Class.x`) rather than colliding as two candidates — so unlike case
+    // (6) (two DIFFERENT classes sharing a name), this is not ambiguous at
+    // all: both `get x` and `set x` resolve to the exact same member id.
+    const tmp = makeRepo({
+      "src/toggle.ts": [
+        "export class Toggle {",
+        "  private _x = false;",
+        "  get x() { return this._x; }",
+        "  set x(v) { this._x = v; }",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-107] toggles x",
+        testFile: "tests/req107.test.ts",
+        hits: [{ file: "src/toggle.ts", fn: "x" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    expect(result.suggestedImpls).toEqual([
+      { reqId: "REQ-107", node: "symbol:src/toggle.ts#Toggle.x" },
+    ]);
+    const allNodes = [
+      ...result.corroborated.map((p: { node: string }) => p.node),
+      ...result.unexercisedClaims.map((p: { node: string }) => p.node),
+      ...result.suggestedImpls.map((p: { node: string }) => p.node),
+    ];
+    expect(allNodes).not.toContain("file:src/toggle.ts");
+  });
+});
+
+describe("issue #255 (8): sharedThreshold interaction — 3 methods on one class, each claimed+hit by its OWN distinct REQ", () => {
+  it("each method is classified independently at method grain; no false class-level infrastructure grouping", async () => {
+    const tmp = makeRepo({
+      "src/multi.ts": [
+        "export class Multi {",
+        "  // @impl " + "REQ-201",
+        "  a() {}",
+        "",
+        "  // @impl " + "REQ-202",
+        "  b() {}",
+        "",
+        "  // @impl " + "REQ-203",
+        "  c() {}",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-201] a",
+        testFile: "tests/req201.test.ts",
+        hits: [{ file: "src/multi.ts", fn: "a" }],
+      }),
+      testLine({
+        testName: "[" + "REQ-202] b",
+        testFile: "tests/req202.test.ts",
+        hits: [{ file: "src/multi.ts", fn: "b" }],
+      }),
+      testLine({
+        testName: "[" + "REQ-203] c",
+        testFile: "tests/req203.test.ts",
+        hits: [{ file: "src/multi.ts", fn: "c" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    expect(result.corroborated).toEqual([
+      { reqId: "REQ-201", node: "symbol:src/multi.ts#Multi.a" },
+      { reqId: "REQ-202", node: "symbol:src/multi.ts#Multi.b" },
+      { reqId: "REQ-203", node: "symbol:src/multi.ts#Multi.c" },
+    ]);
+    expect(result.unexercisedClaims).toEqual([]);
+    // Current (intended) behavior: `reqsByNode` is keyed per resolved node —
+    // each method individually reaches exactly ONE distinct REQ, so nothing
+    // hits `sharedThreshold`; the CLASS node itself never appears in
+    // `reqsByNode` at all (no hit ever resolves directly to it here), so it
+    // cannot be misclassified as infrastructure either.
+    expect(result.infrastructure).toEqual([]);
+    expect(result.suggestedImpls).toEqual([]);
+  });
+});

--- a/tests/trace-method-grain.test.ts
+++ b/tests/trace-method-grain.test.ts
@@ -149,15 +149,82 @@ describe("issue #255 (2): class-level claim + method hit -> corroborated via con
       { reqId: "REQ-102", node: "symbol:src/engine.ts#Engine" },
     ]);
     expect(result.unexercisedClaims).toEqual([]);
-    // Intended side effect of member-id resolution, not a regression: the
-    // class-level claim only covers the CLASS node (rolled up for
-    // corroboration above), so `Engine.run` itself — now a distinct,
-    // unclaimed node with exactly one REQ's evidence — separately qualifies
-    // as its own suggestion. `suggestedImpls`/`isExclusiveNode` deliberately
-    // do NOT roll up (see `reqExercises`'s doc in src/trace/report.ts), so
-    // this entry existing alongside the class's corroboration is correct.
+    // PR #268 review F2: `Engine.run` is exclusively exercised by REQ-102,
+    // and `Engine` (its ancestor via `contains`) already claims REQ-102 —
+    // `hasAncestorClaim` suppresses the redundant member-level suggestion,
+    // since the class-granularity `@impl` already "found" this requirement.
+    // Before F2 this asserted the OPPOSITE (the entry existing was pinned as
+    // intended behavior); the new spec treats that as noise instead.
+    expect(result.suggestedImpls).toEqual([]);
+  });
+});
+
+describe("PR #268 review F2: ancestor-claim suppression of suggestedImpls", () => {
+  it("(a) ancestor class claims REQ-1; method exclusively exercised by REQ-1 -> suggestion suppressed", async () => {
+    const tmp = makeRepo({
+      "src/alpha.ts": ["// @impl " + "REQ-1", "export class Alpha {", "  run() {}", "}", ""].join(
+        "\n",
+      ),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-1] alpha runs",
+        testFile: "tests/req1.test.ts",
+        hits: [{ file: "src/alpha.ts", fn: "run" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    expect(result.corroborated).toEqual([{ reqId: "REQ-1", node: "symbol:src/alpha.ts#Alpha" }]);
+    const suggestedNodes = result.suggestedImpls.map((p: { node: string }) => p.node);
+    expect(suggestedNodes).not.toContain("symbol:src/alpha.ts#Alpha.run");
+    expect(result.suggestedImpls).toEqual([]);
+  });
+
+  it("(b) ancestor class claims REQ-1; method exclusively exercised by a DIFFERENT REQ-2 -> suggestion NOT suppressed", async () => {
+    const tmp = makeRepo({
+      "src/beta.ts": ["// @impl " + "REQ-1", "export class Beta {", "  run() {}", "}", ""].join(
+        "\n",
+      ),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-2] beta runs under a different requirement",
+        testFile: "tests/req2.test.ts",
+        hits: [{ file: "src/beta.ts", fn: "run" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    // The class's REQ-1 claim is unexercised (REQ-1 has no evidence at all
+    // here), and `Beta.run` is exclusively exercised by REQ-2 — a claim on
+    // an ancestor for a DIFFERENT reqId must not suppress this suggestion.
+    expect(result.unexercisedClaims).toEqual([{ reqId: "REQ-1", node: "symbol:src/beta.ts#Beta" }]);
     expect(result.suggestedImpls).toEqual([
-      { reqId: "REQ-102", node: "symbol:src/engine.ts#Engine.run" },
+      { reqId: "REQ-2", node: "symbol:src/beta.ts#Beta.run" },
+    ]);
+  });
+
+  it("(c) no ancestor claim at all -> suggestion reported as before (unaffected by F2)", async () => {
+    const tmp = makeRepo({
+      "src/gamma.ts": ["export class Gamma {", "  run() {}", "}", ""].join("\n"),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-3] gamma runs",
+        testFile: "tests/req3.test.ts",
+        hits: [{ file: "src/gamma.ts", fn: "run" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    expect(result.corroborated).toEqual([]);
+    expect(result.unexercisedClaims).toEqual([]);
+    expect(result.suggestedImpls).toEqual([
+      { reqId: "REQ-3", node: "symbol:src/gamma.ts#Gamma.run" },
     ]);
   });
 });


### PR DESCRIPTION
## Summary

spec 020 (trace / exercises エッジ) × spec 021 (クラスメソッド粒度) の併用時に、`symbol-table.ts` Source 2 がクラスメンバー名を**所属クラスの symbol id** に解決するため、メソッド直上の `@impl` claim (メソッド symbol に付く) と実行 evidence の着地先が粒度不一致になり、実行済みメソッドが `unexercisedClaims` に載る偽陽性 + クラスへの `suggestedImpls` 偽提案が発生していた (vitest runner の cdp / instrument 両エンジンで E2E 再現済み)。

Closes #255

**修正内容** (issue #255 コメントで確定した方針の実装):

- **`src/trace/symbol-table.ts` Source 2**: graph にメンバー自身の symbol ノード (`symbol:<path>#Class.member`) が実在する場合はメンバー id へ解決、無ければ従来どおりクラスへフォールバック (非関数プロパティ等、`extractClassMembers` がシンボル化しないメンバー向け)。constructor skip は維持 (別経路の #267 として切り出し済み、参照コメント追記)
- **`src/trace/report.ts` `reqExercises`**: claim 照合 (corroborated / unexercisedClaims) に**限定**した `contains` ロールアップを追加 — claim ノードの contains 子孫が同一 REQ で exercised なら corroborated (循環ガード付き再帰)。メンバー id 解決単体ではクラス直上 `@impl` の corroboration が壊れ偽陽性が鏡写しにクラス側へ移ることを実験で確認済みのため必須。evidence のロールアップは `suggestedImpls` / `infrastructure` / `isExclusiveNode` には意図的に不適用 (偽提案が別形で復活するため)

**敵対的レビュー (クリーン Sonnet 5 エージェント、7観点) の反映**:

- **F1 (Major)** `5687b61`: `reqExercises` が claim ごとに `graph.edges` を全走査する O(claims×edges) を、`contains` 隣接インデックスの一括構築で解消 (実測: 20k クラス / 120k エッジで 13.0s → 146ms、挙動変化なし)
- **F2 (設計判断・承認済み)** `1288c89`: 祖先ノードが**同一 REQ** を claim 済みの場合、配下メンバーの `suggestedImpls` を抑制 (`hasAncestorClaim` — evidence を読まない claim 存在チェックであり、上記ロールアップ禁則の緩和ではない)。別 REQ の提案は抑制しない
- **F3 (Info)** `5687b61`: 将来の `contains` プロデューサ追加時に id 名前空間分離前提を見直すべき旨をコメント明記
- **F4 (Major, pre-existing)**: `symbol-table.ts` が `safeParseSync` (#261 の SIGSEGV ガード) を経由していない件 → 本 PR のスコープ外として #269 に起票

## Change type

- [x] fix (bug fix)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — unit 2060 passed / e2e 118 passed / perf 5 passed
- [x] Added tests where needed — trace × メソッド粒度の交差テスト 8 本 + F2 抑制の 3 ケース (`tests/trace-method-grain.test.ts` 新設、従来この組み合わせはカバレッジゼロ)。`tests/trace-ingest.test.ts` の pin をメンバー id 解決の新仕様に更新 + クラスフォールバックのケースを追加
- [x] Ran `pnpm -r knip` and `pnpm -r build` — 両方グリーン
- `artgraph check --diff`: No new issues (テスト fixture の `[REQ]`/`@impl` リテラルは文字列連結で分割し、dogfood scan の新規 ORPHAN を回避)
- F1 の性能検証はレビューエージェントのベンチ (2k/8k/20k クラスの合成 graph) を修正後ビルドで再実行して確認

## Breaking change

- [ ] Yes (described below)
- [x] No

`.trace.lock` / graph スキーマの変更なし。メンバー symbol ノードが存在しないプロジェクト (メソッド粒度未使用) では解決結果は従来と完全に同一。F2 の抑制は report/check の**表示 (suggestedImpls) のみ**の変更で、gate の pass/fail には影響しない。

## Notes

- 修正方針の実験過程 (「Source 2 のメンバー id 解決だけでは不成立」の確認、ロールアップの適用範囲の線引き) は issue #255 のコメント参照
- 派生発見の constructor 経路の同種偽陽性は別メカニズム (ctor の記録名がクラス名) のため #267 に切り出し済み — 本 PR では対応しない
- レビューで問題なしと確認された観点: 境界条件 / 分岐組み合わせ / 不正な状態遷移 (stale evidence) / 例外系 (パース失敗・循環 contains) / 実運用パターン (rename・モノレポ・同名衝突) / エッジケース (private #member・static・default export・getter/setter 等)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg