### PR TITLE
fix(trace): constructor @impl の unexercised 偽陽性を解消 — .constructor claim 限定の親方向照合 + 子孫 claim の suggestedImpls 抑制 (#267)

### DIFF
--- a/src/trace/report.ts
+++ b/src/trace/report.ts
@@ -144,6 +144,16 @@ function reqExercises(
  * further `reqExercises` roll-down from the parent, which would reopen the
  * "sibling method corroborates via the class" hole this function exists to
  * avoid while staying narrow.
+ *
+ * JS additionally permits `static constructor() {}` — a static method
+ * literally named "constructor" — which spec 021 FR-003's same-name
+ * convergence resolves to the SAME `symbol:<path>#Class.constructor` node as
+ * the instance ctor, so a claim on that node is corroborated by
+ * instantiation evidence exactly as above; this is just FR-003's existing
+ * "a merged symbol's claim is corroborated by evidence from any of its
+ * occurrences" semantics, not a new case. TypeScript rejects the same code
+ * with TS1089 (`'static' modifier cannot appear on a constructor
+ * declaration`), so this path is unreachable there.
  */
 function ctorClassExercised(
   containerIndex: Map<string, string[]>,

--- a/src/trace/report.ts
+++ b/src/trace/report.ts
@@ -85,6 +85,19 @@ function pairCompare(a: ClaimEvidencePair, b: ClaimEvidencePair): number {
  * evidence (`perReq`/`reqsByNode`) at all, only pre-existing `implements`
  * claims, so it cannot reintroduce the double-counting this note warns
  * against. See that function's doc, below `buildContainerIndex`.
+ *
+ * issue #267 adds a THIRD, narrower exception, `ctorClassExercised` (below):
+ * a constructor's evidence is recorded by the capture engine under the
+ * CLASS's own name (V8-compatible naming — see `src/vitest/plugin.ts`'s
+ * `kind === "constructor" ? className : ...`), never under the ctor's own
+ * `Class.constructor` symbol id (spec 021), so it lands one containment
+ * level ABOVE the claim instead of below it — the mirror image of the
+ * class-claim / method-evidence case this function's roll-up already
+ * handles. That direction is intentionally NOT generalized here (a claim
+ * corroborating from ANY exercised descendant OR ancestor would let a
+ * sibling method's evidence corroborate an unrelated method's claim); it is
+ * special-cased to `.constructor`-suffixed claim nodes only, directly in
+ * `classifyEvidence`'s loop, not folded into this function.
  */
 function reqExercises(
   containsIndex: Map<string, string[]>,
@@ -100,6 +113,48 @@ function reqExercises(
   seen.add(node);
   for (const target of containsIndex.get(node) ?? []) {
     if (reqExercises(containsIndex, trace, reqId, target, seen)) return true;
+  }
+  return false;
+}
+
+/**
+ * issue #267 — ctor-only, PARENT-ward corroboration check, the mirror image
+ * of `reqExercises`'s child-ward roll-up above. A `symbol:<path>#Class.
+ * constructor` `@impl` claim's evidence is recorded by the capture engine
+ * (cdp AND instrument both — `src/vitest/plugin.ts`) under the CLASS's own
+ * V8-compatible name, because V8 itself has no distinct `functionName` for a
+ * constructor call; `src/trace/symbol-table.ts` Source 1 then resolves that
+ * class name straight to the class's OWN symbol id, never to the ctor's. So
+ * a real constructor execution always shows up as evidence on the CLASS
+ * node, one containment level ABOVE the ctor claim, never below it or on
+ * the ctor node itself — `reqExercises`'s existing (child-ward) roll-up
+ * structurally cannot see it.
+ *
+ * Deliberately NOT a general "roll evidence up to any claim" rule (that
+ * direction is exactly what `reqExercises`'s own doc above forbids — it
+ * would let a sibling method's or property's evidence corroborate an
+ * unrelated method's claim). It is safe ONLY for `.constructor`: a method
+ * hit is recorded under the method's OWN name, a getter/setter under `"get
+ * <key>"`/`"set <key>"` (`src/vitest/plugin.ts`'s `accessorName`), and a
+ * static block is not attributed to any member symbol at all — none of
+ * those ever land on the bare class name, so resolving a class-name hit as
+ * ctor-corroboration can never accidentally corroborate a different
+ * member's claim. Checked at ONE level only (the direct container via
+ * `containerIndex`), and only the parent's OWN direct evidence — NOT a
+ * further `reqExercises` roll-down from the parent, which would reopen the
+ * "sibling method corroborates via the class" hole this function exists to
+ * avoid while staying narrow.
+ */
+function ctorClassExercised(
+  containerIndex: Map<string, string[]>,
+  trace: IngestedTrace,
+  reqId: string,
+  node: string,
+): boolean {
+  const coverage = trace.perReq.get(reqId);
+  if (!coverage) return false;
+  for (const parent of containerIndex.get(node) ?? []) {
+    if (coverage.symbols.includes(parent) || coverage.files.includes(parent)) return true;
   }
   return false;
 }
@@ -179,6 +234,41 @@ function hasAncestorClaim(
 }
 
 /**
+ * issue #267 F2 mirror-noise follow-up — the CHILD-ward counterpart of
+ * `hasAncestorClaim` immediately above (same non-evidence, claims-only
+ * nature: walks `claimsByNode` via `containsIndex`, never touches
+ * `perReq`/`reqsByNode`). Asks "does any DESCENDANT of `node`, at any depth,
+ * already carry an `@impl reqId` CLAIM?" Used ONLY to hold back a
+ * `suggestedImpls` candidate, same as `hasAncestorClaim`.
+ *
+ * Motivating case (issue #267's ctor corroboration, above): a constructor
+ * claims REQ-X, and the instantiation evidence resolves to the CLASS node
+ * (never the ctor's own id — see `ctorClassExercised`'s doc). Once the ctor
+ * claim corroborates via that mechanism, the class node's OWN evidence entry
+ * in `trace.reqsByNode` still exists and, without this check, would surface
+ * a redundant "@impl REQ-X on the class" suggestion — the class is already
+ * covered one level down, so the suggestion is noise, not signal. As with
+ * `hasAncestorClaim`, this only suppresses a same-`reqId` match: a
+ * descendant claiming a DIFFERENT REQ says nothing about whether `node`
+ * itself should claim reqId.
+ */
+function hasDescendantClaim(
+  containsIndex: Map<string, string[]>,
+  claimsByNode: Map<string, Set<string>>,
+  reqId: string,
+  node: string,
+  seen: Set<string> = new Set(),
+): boolean {
+  for (const child of containsIndex.get(node) ?? []) {
+    if (seen.has(child)) continue;
+    seen.add(child);
+    if (claimsByNode.get(child)?.has(reqId)) return true;
+    if (hasDescendantClaim(containsIndex, claimsByNode, reqId, child, seen)) return true;
+  }
+  return false;
+}
+
+/**
  * FR-013 exclusivity predicate: exactly one distinct REQ's evidence reaches
  * `node`. Factored out of `classifyEvidence` (below) so `src/coverage.ts`'s
  * `exercised` status computation (FR-014) shares the EXACT same "what counts
@@ -228,7 +318,16 @@ export function classifyEvidence(
     const reqIdsForNode = claimsByNode.get(node);
     if (reqIdsForNode) reqIdsForNode.add(reqId);
     else claimsByNode.set(node, new Set([reqId]));
-    if (reqExercises(containsIndex, trace, reqId, node)) {
+    // issue #267: a `.constructor`-suffixed symbol claim ALSO corroborates
+    // when the DIRECT containing class node itself is exercised for the
+    // same reqId — see `ctorClassExercised`'s doc for why this parent-ward
+    // check is safe only for constructors (never generalized to any claim
+    // node, which would let a sibling's evidence corroborate this one).
+    const isCtorClaim = node.startsWith("symbol:") && node.endsWith(".constructor");
+    if (
+      reqExercises(containsIndex, trace, reqId, node) ||
+      (isCtorClaim && ctorClassExercised(containerIndex, trace, reqId, node))
+    ) {
       corroborated.push({ reqId, node });
     } else {
       unexercisedClaims.push({ reqId, node });
@@ -247,8 +346,14 @@ export function classifyEvidence(
       // means a class-granularity `@impl` has already "found" this
       // requirement's code — suppress the redundant member-level nudge (see
       // `hasAncestorClaim`'s doc above for why this is not a `reqExercises`
-      // roll-up).
-      if (!hasAncestorClaim(containerIndex, claimsByNode, reqId!, node)) {
+      // roll-up). issue #267 F2 follow-up: the mirror case — a DESCENDANT
+      // (typically a `.constructor` claim whose evidence rolled up to this
+      // very node, per `ctorClassExercised`) already claiming this SAME
+      // reqId is equally redundant noise (see `hasDescendantClaim`'s doc).
+      if (
+        !hasAncestorClaim(containerIndex, claimsByNode, reqId!, node) &&
+        !hasDescendantClaim(containsIndex, claimsByNode, reqId!, node)
+      ) {
         suggestedImpls.push({ reqId: reqId!, node });
       }
     }

--- a/src/trace/symbol-table.ts
+++ b/src/trace/symbol-table.ts
@@ -193,10 +193,18 @@ export function buildSymbolNameTable(rootDir: string, includePatterns: string[])
         // CLASS's own name (never "constructor"), so registering
         // "constructor" as a candidate name here would never match a real
         // hit — it's simply not the name V8 ever reports. That is a
-        // different gap from this fix (member-id resolution) and isn't
-        // rescued by the `contains` roll-up added in report.ts either,
-        // since a constructor hit already resolves straight to the class
-        // via its own name, never via a member name lookup at all.
+        // different gap from this fix (member-id resolution): a constructor
+        // hit already resolves straight to the class via its own name,
+        // never via a member name lookup at all, so there is nothing for
+        // THIS table to fix. `report.ts`'s `contains` roll-up (`reqExercises`,
+        // child-ward only) doesn't rescue it either, since the evidence
+        // lands one level ABOVE a `.constructor` claim, not below it.
+        // issue #267's actual fix lives entirely in `report.ts`: a narrow,
+        // `.constructor`-suffixed-claim-only PARENT-ward check
+        // (`ctorClassExercised`, called from `classifyEvidence`) that
+        // corroborates the ctor claim when the class node itself is
+        // exercised for the same reqId — see that function's doc for why
+        // it's safe to special-case only constructors this way.
         if (member.kind === "constructor") continue;
         if (member.key?.type !== "Identifier" || !member.key.name) continue;
         const memberSymbolId = `symbol:${relPath}#${exportedName}.${member.key.name}`;

--- a/tests/trace-method-grain.test.ts
+++ b/tests/trace-method-grain.test.ts
@@ -552,3 +552,40 @@ describe("issue #255 (8): sharedThreshold interaction — 3 methods on one class
     expect(result.suggestedImpls).toEqual([]);
   });
 });
+
+describe("PR #271 meta-review META-D: hasDescendantClaim pin for a NON-ctor case", () => {
+  it("class-node evidence + a method's OWN claim on the SAME reqId -> suggestedImpls suppressed even though the method's claim is itself unexercised (hasDescendantClaim is claim-only, symmetric with hasAncestorClaim)", async () => {
+    const tmp = makeRepo({
+      "src/pump.ts": ["export class Pump {", "  // @impl " + "REQ-1", "  run() {}", "}", ""].join(
+        "\n",
+      ),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-1] instantiates pump",
+        testFile: "tests/req1.test.ts",
+        // No constructor at all here -- this is a plain class-name landing
+        // (e.g. instantiation), unrelated to the `.constructor`-suffixed
+        // mechanism in `ctorClassExercised`. It never touches `run` itself.
+        hits: [{ file: "src/pump.ts", fn: "Pump" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    // `run`'s own claim is never corroborated -- its REQ-1 evidence never
+    // lands on `run` itself (only on the class).
+    expect(result.unexercisedClaims).toEqual([
+      { reqId: "REQ-1", node: "symbol:src/pump.ts#Pump.run" },
+    ]);
+    expect(result.corroborated).toEqual([]);
+    // The CLASS node is exclusively exercised by REQ-1 and carries no claim
+    // of its own, so absent suppression it would be a `suggestedImpls`
+    // candidate. But `run` (a descendant, via `contains`) already claims
+    // this SAME reqId -- `hasDescendantClaim` suppresses the suggestion
+    // regardless of whether that descendant claim is itself corroborated
+    // (mirrors `hasAncestorClaim`'s symmetric claims-only semantics; see
+    // `hasDescendantClaim`'s doc in src/trace/report.ts).
+    expect(result.suggestedImpls).toEqual([]);
+  });
+});

--- a/tests/trace-method-grain.test.ts
+++ b/tests/trace-method-grain.test.ts
@@ -15,6 +15,14 @@
 // + hand-written shard JSONL, `mode: "symbol"`, driven end-to-end through the
 // real `trace report` CLI command so the real graph — including spec 021's
 // class -> method `contains` edges — is what `classifyEvidence` sees).
+//
+// issue #267 (below, "issue #267 (1..3)") adds the ctor-specific follow-up:
+// a constructor claim (`symbol:<path>#Class.constructor`) whose evidence the
+// capture engine records under the CLASS's own V8-compatible name, landing
+// one containment level ABOVE the claim — the mirror image of #255's
+// class-claim / method-evidence case, needing its own narrow, ctor-only
+// PARENT-ward check (`src/trace/report.ts`'s `ctorClassExercised`) plus a
+// matching `suggestedImpls` noise suppression (`hasDescendantClaim`).
 import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join, dirname } from "node:path";
@@ -384,6 +392,111 @@ describe("issue #255 (7): get/set same-name pin (PR #242 FR-003 convergence)", (
       ...result.suggestedImpls.map((p: { node: string }) => p.node),
     ];
     expect(allNodes).not.toContain("file:src/toggle.ts");
+  });
+});
+
+describe("issue #267 (1): ctor claim + instantiation evidence (recorded under the class name) -> corroborated at the ctor's OWN node", () => {
+  it("a `.constructor`-suffixed claim corroborates via the ctor-only parent-ward check, and the class gets no redundant suggestion", async () => {
+    const tmp = makeRepo({
+      "src/widget267.ts": [
+        "export class Widget267 {",
+        "  // @impl " + "REQ-1",
+        "  constructor() {}",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-1] instantiates widget267",
+        testFile: "tests/req1.test.ts",
+        // The capture engine records a constructor call under the CLASS's
+        // own V8-compatible name (`src/vitest/plugin.ts`), never the literal
+        // string "constructor" — so this hit's `fn` is the class name.
+        hits: [{ file: "src/widget267.ts", fn: "Widget267" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    expect(result.corroborated).toEqual([
+      { reqId: "REQ-1", node: "symbol:src/widget267.ts#Widget267.constructor" },
+    ]);
+    expect(result.unexercisedClaims).toEqual([]);
+    // Without F2's descendant-claim suppression, the class node (which DOES
+    // carry this exact instantiation evidence) would look like an
+    // unclaimed, exclusively-exercised node and spuriously suggest
+    // `@impl REQ-1` on the class too — redundant with the ctor's own claim.
+    const suggestedNodes = result.suggestedImpls.map((p: { node: string }) => p.node);
+    expect(suggestedNodes).not.toContain("symbol:src/widget267.ts#Widget267");
+    expect(result.suggestedImpls).toEqual([]);
+  });
+});
+
+describe("issue #267 (2): ctor claims REQ-1, instantiation evidence is REQ-2 only -> REQ-1 stays unexercised, REQ-2's class suggestion is NOT suppressed", () => {
+  it("ctor-only corroboration and descendant-claim suppression are both reqId-scoped, not blanket", async () => {
+    const tmp = makeRepo({
+      "src/gadget267.ts": [
+        "export class Gadget267 {",
+        "  // @impl " + "REQ-1",
+        "  constructor() {}",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-2] instantiates gadget267 under a different requirement",
+        testFile: "tests/req2.test.ts",
+        hits: [{ file: "src/gadget267.ts", fn: "Gadget267" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    // REQ-1's claim has no REQ-1 evidence anywhere (the only evidence here is
+    // REQ-2's) -> stays unexercised; the ctor-only parent-ward check must not
+    // corroborate across a DIFFERENT reqId.
+    expect(result.unexercisedClaims).toEqual([
+      { reqId: "REQ-1", node: "symbol:src/gadget267.ts#Gadget267.constructor" },
+    ]);
+    expect(result.corroborated).toEqual([]);
+    // The class is exclusively exercised by REQ-2, and the only existing
+    // claim (the ctor's) is for REQ-1, a DIFFERENT reqId -> descendant-claim
+    // suppression (reqId-scoped, like `hasAncestorClaim`) must NOT apply, so
+    // the REQ-2 suggestion on the class stands.
+    expect(result.suggestedImpls).toEqual([
+      { reqId: "REQ-2", node: "symbol:src/gadget267.ts#Gadget267" },
+    ]);
+  });
+});
+
+describe("issue #267 (3): class-level claim + ctor execution -> direct match corroborated (no regression)", () => {
+  it("a class-level claim already sits on the SAME node the ctor hit resolves to, so this needs no new machinery", async () => {
+    const tmp = makeRepo({
+      "src/lamp267.ts": [
+        "// @impl " + "REQ-1",
+        "export class Lamp267 {",
+        "  constructor() {}",
+        "}",
+        "",
+      ].join("\n"),
+    });
+    writeShard(tmp, "w1.jsonl", [
+      metaLine(),
+      testLine({
+        testName: "[" + "REQ-1] instantiates lamp267",
+        testFile: "tests/req1.test.ts",
+        hits: [{ file: "src/lamp267.ts", fn: "Lamp267" }],
+      }),
+    ]);
+
+    const result = await report(tmp);
+    expect(result.corroborated).toEqual([
+      { reqId: "REQ-1", node: "symbol:src/lamp267.ts#Lamp267" },
+    ]);
+    expect(result.unexercisedClaims).toEqual([]);
+    expect(result.suggestedImpls).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

#255 の調査で発見された別経路の同種バグ (E2E 再現済み)。spec 021 は constructor を `symbol:<path>#Class.constructor` としてシンボル化し `@impl` claim はそこに付くが、capture engine (cdp / instrument 両方) は ctor 実行を V8 互換命名で**クラス名そのもの**で記録するため、evidence がクラス symbol に着地して claim と不一致になり、実行済み ctor が `unexercisedClaims` に載る偽陽性が出ていた。

#255 (PR #268) のロールアップは「claim の**子**が exercised なら corroborated」の向きで、evidence が**親**に着地する本ケースは対象外 (逆向きの一般化は兄弟メソッドへの偽 corroboration を生むため禁止のまま)。

Closes #267

**修正内容** (方針検討で承認された「候補1改 — report 側 ctor 限定の親方向照合」):

- **`src/trace/report.ts` `ctorClassExercised`**: `symbol:` かつ `.constructor` で終わる claim ノードに限り、`containerIndex` で辿る**直接の親** (所属クラス) が同一 REQ で直接 exercised なら corroborated。親への `reqExercises` 再帰は意図的にしない — 親の `contains` 経由で兄弟メソッドの evidence を拾う偽 corroboration を防ぐ 1 階層限定。根拠: クラス名でのヒット記録は事実上 ctor 実行そのもの (メソッドは自分の名前、getter/setter は `get/set <key>` で記録される)
- **`src/trace/report.ts` `hasDescendantClaim`**: `hasAncestorClaim` (PR #268 F2) の対 — contains 子孫が同一 REQ を claim 済みなら `suggestedImpls` を抑制。ctor が claim 済みの REQ をクラスノードに「@impl を付けろ」と提案する鏡像ノイズ対策。evidence を読まない claim 存在チェックである点も対称
- **`src/trace/symbol-table.ts`**: Source 2 の constructor skip コメントを report.ts 側の修正に合わせて更新 (コード変更なし)

読み取り側のみの変更で**過去の trace shard にもそのまま効く**。capture 記録名契約 (spec 022 FR-005) の改訂による根本解決は #270 に切り出し済み。

## Change type

- [x] fix (bug fix)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — 全 suite green (unit 2063 passed / 5 skipped)
- [x] Added tests where needed — 交差テスト 3 本追加 (`tests/trace-method-grain.test.ts`): (1) ctor claim + インスタンス化 evidence → corroborated + クラス提案抑制、(2) 別 REQ の evidence では corroborate も抑制もしない、(3) クラス直上 claim + ctor 実行の直接一致リグレッションなし。既存 11 ケース (#255 系) は無変更で green
- [x] Ran `pnpm -r knip` and `pnpm -r build`
- `artgraph check --diff`: No new issues introduced by this change (dogfood 確認済み)

## Breaking change

- [ ] Yes (described below)
- [x] No

graph / lock / shard スキーマの変更なし。`.constructor` symbol claim が存在しないプロジェクトでは挙動は完全に従来どおり。

## Notes

- 対応方針 3 候補の比較と「候補1改 + 候補2の将来 issue 化」の決定経緯は #267 / #270 参照
- `.constructor` 判定は `symbol:` プレフィックス + `.constructor` サフィックスの両ガード (意図しないノード種別を ctor 扱いしない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg)_