### PR TITLE
feat(config): include の先頭 ! 負パターンをサポート + buildGraph warnings を全 graph 構築コマンドに配線 (#265, #266)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,19 @@ convention; excluded files are dropped from both scanning and `artgraph
 rename`'s rewrite scope. A list made up entirely of exclusions matches zero
 files.
 
+**Put exclusions in `include`, not `testPatterns`.** A negative pattern on
+`testPatterns` narrows the scanned file set the same way it does on
+`include`, so it lines up with the graph — but trace evaluation
+(`buildSymbolNameTable`) only ever consults `include` when it resolves
+symbol names, never `testPatterns`. A negative pattern that only lives in
+`testPatterns` therefore drifts from what trace evaluation sees, and can
+surface a suggested `@impl` / drift candidate that points at a symbol with
+no corresponding node in the graph. See issue #275.
+
+Degenerate patterns behave as inert rather than as errors: a doubled
+negation (`"!!foo/**"`), a bare `"!"`, and an empty string (`""`) are all
+accepted without complaint and simply do not produce a working exclusion.
+
 ## `reqPatterns` — requirement ID grammar
 
 By default artgraph recognizes `REQ-001`, `auth/FR-2`, and `Requirement-3`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,16 @@ README's end-to-end example. This page documents the blocks users typically
 touch: `reqPatterns`, `ignoreIdPrefixes`, `docGraph`, `taskConventions`, and
 how edge provenance is surfaced.
 
+## `include` / `testPatterns` — code and test file globs
+
+Both are lists of [fast-glob](https://github.com/mrmlnc/fast-glob) patterns
+resolved relative to the repo root (defaults: `include: ["src/**/*.ts",
+"src/**/*.tsx"]`). A leading `!` marks a pattern as an exclusion (e.g.
+`"!src/generated/**"`), matching fast-glob's own negative-pattern
+convention; excluded files are dropped from both scanning and `artgraph
+rename`'s rewrite scope. A list made up entirely of exclusions matches zero
+files.
+
 ## `reqPatterns` — requirement ID grammar
 
 By default artgraph recognizes `REQ-001`, `auth/FR-2`, and `Requirement-3`.

--- a/src/commands/impact.ts
+++ b/src/commands/impact.ts
@@ -2,7 +2,7 @@
 
 import { Command } from "commander";
 import type { SymbolEntry } from "../types.js";
-import { pathsToEntries, TRACE_NO_SHARDS_GUIDANCE } from "./shared.js";
+import { pathsToEntries, reportGraphWarnings, TRACE_NO_SHARDS_GUIDANCE } from "./shared.js";
 import { printImpactText } from "./presenters/impact.js";
 
 // spec 014 (FR-001 / FR-003): REQ-ID inputs are no longer accepted here.
@@ -121,7 +121,13 @@ export function registerImpactCommand(program: Command): void {
         process.exit(1);
       }
 
-      const { graph } = scan(rootDir, config);
+      // issue #265 — `warnings` used to be discarded here, so a
+      // `pathological-bracket-nesting` / `class-member-collision` build
+      // warning was invisible via `artgraph impact`. Threaded through to the
+      // `--diff` "no changes" early-exit JSON payload below (mirrors
+      // `check --diff`'s equivalent branch) and to the final output at the
+      // bottom of this action.
+      const { graph, warnings } = scan(rootDir, config);
       const lock = readLock(rootDir, config.lockFile);
 
       // spec 020 (FR-017) — load evidence once, resolve the staleness
@@ -167,6 +173,7 @@ export function registerImpactCommand(program: Command): void {
                 drifted: [],
                 originReqs: [],
                 summary: { docs: 0, reqs: 0, files: 0, tasks: 0 },
+                warnings,
                 message: "No changes detected in git diff.",
               }),
             );
@@ -357,9 +364,10 @@ export function registerImpactCommand(program: Command): void {
       }
 
       if (opts.format === "json") {
-        console.log(JSON.stringify(result));
+        console.log(JSON.stringify({ ...result, warnings }));
       } else {
         printImpactText(result);
+        reportGraphWarnings(warnings, opts.format);
       }
     });
 }

--- a/src/commands/impact.ts
+++ b/src/commands/impact.ts
@@ -179,6 +179,11 @@ export function registerImpactCommand(program: Command): void {
             );
           } else {
             console.log("No changes detected in git diff.");
+            // review F1 — the json branch above already folds `warnings` into
+            // the payload; this text branch was the asymmetric gap (PR
+            // discussion said "and to the final output" but only actually
+            // wired the json side here).
+            reportGraphWarnings(warnings, opts.format);
           }
           process.exit(0);
         }
@@ -215,6 +220,11 @@ export function registerImpactCommand(program: Command): void {
               "       to enable symbol-mode lookup.",
             ].join("\n"),
           );
+          // review F1 — this hard error exits before any JSON payload is ever
+          // produced, so warnings would otherwise be silently lost regardless
+          // of `--format`. Print unconditionally (no `format` arg) rather
+          // than gating on `opts.format`.
+          reportGraphWarnings(warnings);
           process.exit(1);
         }
       }
@@ -262,11 +272,16 @@ export function registerImpactCommand(program: Command): void {
             `        or verify that \`mode: "symbol"\` is set in \`.artgraph.json\` and re-scan.`,
           );
         }
+        // review F1 — same rationale as the scan-mode-mismatch exit above:
+        // no JSON payload is produced on this path, so print unconditionally.
+        reportGraphWarnings(warnings);
         process.exit(1);
       }
 
       if (startIds.length === 0) {
         console.error(`No matching nodes found for: ${inputDisplayLabels.join(", ")}`);
+        // review F1 — ditto: hard error, no JSON payload produced.
+        reportGraphWarnings(warnings);
         process.exit(1);
       }
 

--- a/src/commands/plan-coverage.ts
+++ b/src/commands/plan-coverage.ts
@@ -3,6 +3,7 @@
 import { Command, Option } from "commander";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
+import { reportGraphWarnings } from "./shared.js";
 
 // spec 014 (FR-013 — FR-020): plan-coverage subcommand. Reads tasks.md /
 // plan.md (and the current spec.md) to detect REQs that are *affected*
@@ -97,9 +98,12 @@ export function registerPlanCoverageCommand(program: Command): void {
         });
 
         if (format === "json") {
-          console.log(JSON.stringify(result.json));
+          // review F2 — fold `buildGraph()`'s warnings into the JSON payload,
+          // matching `impact`/`trace`/`check`'s convention (issue #265).
+          console.log(JSON.stringify({ ...result.json, warnings: result.warnings }));
         } else {
           process.stdout.write(result.text);
+          reportGraphWarnings(result.warnings, format);
         }
         if (result.exitCode !== 0) {
           process.exit(result.exitCode);

--- a/src/commands/presenters/rename.ts
+++ b/src/commands/presenters/rename.ts
@@ -2,10 +2,15 @@
 // verbatim from `src/cli.ts` (issue #162) — no behavior change.
 
 import type { RenameResult } from "../../rename-executor.js";
+import { printWarnings } from "./warnings.js";
 
 export function printRenameText(result: RenameResult) {
   if (result.changes.length === 0 && result.lockChanges.length === 0) {
     console.log("No references found.");
+    // issue #265 — build warnings (pathological-bracket-nesting,
+    // class-member-collision, …) matter regardless of whether this
+    // particular rename found any references to rewrite.
+    printWarnings(result.buildWarnings);
     return;
   }
 
@@ -38,6 +43,9 @@ export function printRenameText(result: RenameResult) {
   if (!result.applied) {
     console.log("(dry-run: no files were modified)");
   }
+
+  // issue #265 — see the note in printRenameText's early-return branch above.
+  printWarnings(result.buildWarnings);
 }
 
 export function printRenameJson(result: RenameResult) {

--- a/src/commands/reconcile.ts
+++ b/src/commands/reconcile.ts
@@ -1,6 +1,7 @@
 // `artgraph reconcile` — extracted verbatim from `src/cli.ts` (issue #162).
 
 import { Command } from "commander";
+import { reportGraphWarnings } from "./shared.js";
 
 export function registerReconcileCommand(program: Command): void {
   program
@@ -11,8 +12,14 @@ export function registerReconcileCommand(program: Command): void {
       const { loadConfig } = await import("../config.js");
       const { scan, reconcile } = await import("../scan.js");
       const config = loadConfig(rootDir);
-      const { graph } = scan(rootDir, config);
+      // issue #265 — `warnings` used to be discarded here, so a
+      // `pathological-bracket-nesting` / `class-member-collision` build
+      // warning was invisible via `artgraph reconcile`. `reconcile` has no
+      // `--format json` mode, so this always prints (mirrors scan/init/check's
+      // text-mode behavior).
+      const { graph, warnings } = scan(rootDir, config);
       reconcile(rootDir, config, graph);
       console.log(`Lock file updated: ${config.lockFile}`);
+      reportGraphWarnings(warnings);
     });
 }

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -6,6 +6,8 @@
 import type { ArtgraphConfig, SymbolEntry, TestResultMap } from "../types.js";
 import { parseAgentsList, AgentsParseError } from "../agents/parse-agents.js";
 import { AGENT_IDS, type AgentId } from "../agents/descriptors.js";
+import type { BuildWarning } from "../graph/builder.js";
+import { printWarnings } from "./presenters/warnings.js";
 
 // spec 016 (R-003) — direct CLI / --diff inputs come in as raw
 // strings (file paths or `path:symbol` declarations). lift each into the
@@ -82,6 +84,28 @@ export function parseAgentsFlag(raw: string): AgentId[] {
     }
     throw e;
   }
+}
+
+// issue #265 — `scan`/`init`/`check` were the only commands wiring
+// `printWarnings` to their `buildGraph()`-derived `BuildWarning[]`;
+// `impact`/`trace`/`reconcile`/`rename` all build the same graph (directly
+// or via `scan()`/`rename-executor.ts`) but silently discarded its warnings
+// — a `pathological-bracket-nesting` or `class-member-collision` warning
+// was invisible through any of those four commands. This helper centralizes
+// the "when do we print" policy so a FUTURE command that builds the graph
+// only has to call it, rather than re-deriving the format-aware rule itself
+// (or forgetting to).
+//
+// Mirrors the scan/init/check convention exactly: text mode prints via
+// `printWarnings` (stderr only, never stdout — see warnings.ts). In
+// `--format json` mode this is a no-op: JSON-emitting commands fold
+// `warnings` into their own structured payload instead (as scan/init/check
+// already do), so the same information is never shown twice. Commands with
+// no `--format json` mode at all (e.g. `reconcile`) simply call this with
+// `format` left `undefined`, which also prints.
+export function reportGraphWarnings(warnings: BuildWarning[], format?: string): void {
+  if (format === "json") return;
+  printWarnings(warnings);
 }
 
 // spec 020 (contracts/cli-surface.md §2 / §5, FR-018) — verbatim error UX

--- a/src/commands/trace.ts
+++ b/src/commands/trace.ts
@@ -8,7 +8,8 @@
 import { Command } from "commander";
 import type { ArtifactGraph } from "../types.js";
 import type { TraceDiagnostics } from "../trace/schema.js";
-import { TRACE_NO_SHARDS_GUIDANCE } from "./shared.js";
+import type { BuildWarning } from "../graph/builder.js";
+import { reportGraphWarnings, TRACE_NO_SHARDS_GUIDANCE } from "./shared.js";
 import { printTraceReportText, printTraceStatusText } from "./presenters/trace.js";
 
 export interface TraceStatusResult {
@@ -19,6 +20,11 @@ export interface TraceStatusResult {
   /** stale / (# distinct nodes with a recorded trace-capture hash), 0 when
    * there are none — avoids a NaN in the JSON/text output on an empty trace. */
   staleRate: number;
+  // issue #265 — `buildGraph()`'s warnings (pathological-bracket-nesting,
+  // class-member-collision, …), threaded through so `--format json` embeds
+  // them like scan/init/check do; text mode prints them via
+  // `reportGraphWarnings` instead of embedding.
+  warnings: BuildWarning[];
 }
 
 export interface TraceReportResult {
@@ -27,6 +33,8 @@ export interface TraceReportResult {
   suggestedImpls: Array<{ reqId: string; node: string }>;
   infrastructure: Array<{ node: string; reqCount: number }>;
   diagnostics: TraceDiagnostics & { stale: number };
+  // issue #265 — see TraceStatusResult.warnings above.
+  warnings: BuildWarning[];
 }
 
 // `status`'s "record counts" are derived from `IngestedTrace` itself rather
@@ -54,14 +62,17 @@ async function loadTraceInputs(rootDir: string): Promise<{
   config: import("../types.js").ArtgraphConfig;
   graph: ArtifactGraph;
   trace: import("../trace/ingest.js").IngestedTrace;
+  // issue #265 — previously discarded (`const { graph } = scan(...)`), so
+  // `trace status` / `trace report` never surfaced build warnings.
+  warnings: BuildWarning[];
 }> {
   const { loadConfig } = await import("../config.js");
   const { scan } = await import("../scan.js");
   const { ingestTrace } = await import("../trace/ingest.js");
   const config = loadConfig(rootDir);
-  const { graph } = scan(rootDir, config);
+  const { graph, warnings } = scan(rootDir, config);
   const trace = ingestTrace(config, rootDir);
-  return { config, graph, trace };
+  return { config, graph, trace, warnings };
 }
 
 export function registerTraceCommand(program: Command): void {
@@ -75,7 +86,7 @@ export function registerTraceCommand(program: Command): void {
     .option("--format <format>", "Output format: json | text", "text")
     .action(async (opts) => {
       const rootDir = process.cwd();
-      const { graph, trace: ingested } = await loadTraceInputs(rootDir);
+      const { graph, trace: ingested, warnings } = await loadTraceInputs(rootDir);
       const { computeStaleNodeIds } = await import("../trace/report.js");
 
       const staleNodeIds = computeStaleNodeIds(graph, ingested);
@@ -88,12 +99,14 @@ export function registerTraceCommand(program: Command): void {
         skippedCount: ingested.diagnostics.skipped,
         diagnostics: buildDiagnostics(ingested.diagnostics, staleNodeIds.size),
         staleRate,
+        warnings,
       };
 
       if (opts.format === "json") {
         console.log(JSON.stringify(result));
       } else {
         printTraceStatusText(result);
+        reportGraphWarnings(warnings, opts.format);
       }
     });
 
@@ -103,7 +116,7 @@ export function registerTraceCommand(program: Command): void {
     .option("--format <format>", "Output format: json | text", "text")
     .action(async (opts) => {
       const rootDir = process.cwd();
-      const { config, graph, trace: ingested } = await loadTraceInputs(rootDir);
+      const { config, graph, trace: ingested, warnings } = await loadTraceInputs(rootDir);
 
       // contracts/cli-surface.md §2 — zero shards is a hard error, not an
       // empty report: the report's entire premise (evidence exists to
@@ -122,12 +135,14 @@ export function registerTraceCommand(program: Command): void {
       const result: TraceReportResult = {
         ...evidence,
         diagnostics: buildDiagnostics(ingested.diagnostics, staleNodeIds.size),
+        warnings,
       };
 
       if (opts.format === "json") {
         console.log(JSON.stringify(result));
       } else {
         printTraceReportText(result);
+        reportGraphWarnings(warnings, opts.format);
       }
     });
 }

--- a/src/commands/trace.ts
+++ b/src/commands/trace.ts
@@ -124,6 +124,11 @@ export function registerTraceCommand(program: Command): void {
       // arrays would hide the real problem (no trace was ever captured).
       if (ingested.shardCount === 0) {
         console.error(TRACE_NO_SHARDS_GUIDANCE);
+        // review F1 — this hard error exits before any JSON payload is ever
+        // produced, so warnings would otherwise be silently lost regardless
+        // of `--format`. Print unconditionally, mirroring `impact.ts`'s
+        // early-exit paths.
+        reportGraphWarnings(warnings);
         process.exit(1);
       }
 

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -205,8 +205,11 @@ function splitIncludePatterns(
 // issue #266 — an include list made up ENTIRELY of negative patterns (or an
 // empty list) has no positive pattern to match anything against, so it
 // degenerates to zero files rather than an error — the natural reading of
-// "exclude everything, include nothing" (fast-glob itself would otherwise
-// throw on an empty `patterns` array).
+// "exclude everything, include nothing". fast-glob@3.3.3's `sync([])` already
+// returns `[]` on its own (it's an empty *string* pattern, e.g. `sync([""])`,
+// that throws) — this early return isn't working around a throw, it's just
+// making the "nothing to match" intent explicit rather than leaning on
+// fast-glob's incidental empty-array behavior.
 export function globCodeFiles(rootDir: string, patterns: string[]): string[] {
   const { include, ignore } = splitIncludePatterns(rootDir, patterns);
   if (include.length === 0) return [];

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -168,15 +168,49 @@ export function createTSParser(
   };
 }
 
+// issue #266 — every pattern used to be blindly run through `resolve(rootDir,
+// p)`, which mangles fast-glob's `!`-prefixed negative-pattern convention
+// (e.g. `"!src/generated/**"` becomes the absolute path
+// `<rootDir>/!src/generated/**`, which is not a negation — the `!` is no
+// longer at position 0 of the string — so fast-glob just fails to match that
+// bogus path and the exclusion silently does nothing). Recognize the leading
+// `!` BEFORE resolving, strip it, resolve the remainder exactly like a
+// positive pattern, and route the result through fast-glob's dedicated
+// `ignore` option instead of leaving it in the main pattern list. Shared by
+// `globCodeFiles` and `enumerateFiles` below so the two independent
+// file-enumeration paths (used respectively by `buildGraph`'s incremental
+// parse-cache path and by `createTSParser`'s direct parse — see
+// `src/trace/symbol-table.ts`'s `buildSymbolNameTable`, which calls both and
+// depends on them agreeing) never disagree on which files a negative pattern
+// excludes.
+function splitIncludePatterns(
+  rootDir: string,
+  patterns: string[],
+): { include: string[]; ignore: string[] } {
+  const include: string[] = [];
+  const ignore: string[] = [];
+  for (const p of patterns) {
+    const negated = p.startsWith("!");
+    const resolved = resolve(rootDir, negated ? p.slice(1) : p).replace(/\\/g, "/");
+    (negated ? ignore : include).push(resolved);
+  }
+  return { include, ignore };
+}
+
 // Resolve the code-file set for `patterns` in one fast-glob call (cwd =
 // process.cwd(), absolute results). The parse-cache path discovers the file
 // set through this helper so warm runs see byte-for-byte the same set a full
 // createTSParser scan enumerates, without loading the parser.
+//
+// issue #266 — an include list made up ENTIRELY of negative patterns (or an
+// empty list) has no positive pattern to match anything against, so it
+// degenerates to zero files rather than an error — the natural reading of
+// "exclude everything, include nothing" (fast-glob itself would otherwise
+// throw on an empty `patterns` array).
 export function globCodeFiles(rootDir: string, patterns: string[]): string[] {
-  return fastGlob.sync(
-    patterns.map((p) => resolve(rootDir, p).replace(/\\/g, "/")),
-    { cwd: resolve(), absolute: true },
-  );
+  const { include, ignore } = splitIncludePatterns(rootDir, patterns);
+  if (include.length === 0) return [];
+  return fastGlob.sync(include, { cwd: resolve(), absolute: true, ignore });
 }
 
 // Parse exactly the given files (used by the parse-cache path to reparse only
@@ -202,13 +236,23 @@ export function parseTSFilePaths(
 // backend's project.getSourceFiles() iterated. Preserving that order keeps
 // node/edge output — and therefore `.trace.lock` bytes — stable across the
 // backend swap.
+//
+// issue #266 — negative (`!`-prefixed) patterns are split out via
+// `splitIncludePatterns` and applied as a shared `ignore` list across every
+// remaining positive pattern's glob call, mirroring `globCodeFiles` so this
+// function (used by `createTSParser`, in turn used by
+// `buildSymbolNameTable`) never disagrees with it on which files a negative
+// pattern excludes. An include list with no positive pattern degenerates to
+// zero files, same as `globCodeFiles`.
 function enumerateFiles(rootDir: string, patterns: string[]): string[] {
   const seen = new Set<string>();
   const files: string[] = [];
-  for (const pattern of patterns) {
-    const matches = fastGlob.sync(resolve(rootDir, pattern).replace(/\\/g, "/"), {
+  const { include, ignore } = splitIncludePatterns(rootDir, patterns);
+  for (const pattern of include) {
+    const matches = fastGlob.sync(pattern, {
       cwd: resolve(),
       absolute: true,
+      ignore,
     });
     for (const filePath of matches) {
       if (!seen.has(filePath)) {

--- a/src/plan-coverage/index.ts
+++ b/src/plan-coverage/index.ts
@@ -46,6 +46,7 @@ import { readLock } from "../lock.js";
 import { entryOriginIds, impact, resolveStartIds, resolveOriginReqs } from "../graph/traverse.js";
 import { extractFiles, type TaskBlock } from "../parsers/sdd-files.js";
 import type { SymbolEntry } from "../types.js";
+import type { BuildWarning } from "../graph/builder.js";
 import { detectMentions } from "./mention.js";
 
 export interface PlanCoverageOptions {
@@ -157,6 +158,14 @@ export interface PlanCoverageRunResult {
   json: PlanCoverageResult;
   exitCode: 0 | 1;
   text: string;
+  // review F2 (issue #265's own follow-up gap) — `buildGraph()`'s warnings
+  // (pathological-bracket-nesting, class-member-collision, …) used to be
+  // discarded here (`const { graph } = scan(...)`), so `artgraph
+  // plan-coverage` was the one graph-building command #265 missed wiring up.
+  // Threaded through exactly like `impact`/`trace`/`check`: the CLI layer
+  // folds this into the JSON payload for `--format json` and prints it via
+  // `reportGraphWarnings` for text.
+  warnings: BuildWarning[];
 }
 
 // ---------------------------------------------------------------------------
@@ -432,7 +441,7 @@ export function runPlanCoverage(options: PlanCoverageOptions): PlanCoverageRunRe
 
   // Load graph + lock once.
   const config = loadConfig(repoRoot);
-  const { graph } = scan(repoRoot, config);
+  const { graph, warnings } = scan(repoRoot, config);
   const lock = readLock(repoRoot, config.lockFile);
 
   // Read source texts. tasks.md is the spine; plan.md / spec.md are
@@ -457,6 +466,7 @@ export function runPlanCoverage(options: PlanCoverageOptions): PlanCoverageRunRe
         taskCount: 0,
         tasksWithFilesSection: 0,
       }),
+      warnings,
     };
   }
 
@@ -555,6 +565,7 @@ export function runPlanCoverage(options: PlanCoverageOptions): PlanCoverageRunRe
       json: result,
       exitCode: gate && diagnostics.length > 0 ? 1 : 0,
       text: formatText(result, ignore, { requireFilesSection, ...textCounts }),
+      warnings,
     };
   }
 
@@ -642,5 +653,5 @@ export function runPlanCoverage(options: PlanCoverageOptions): PlanCoverageRunRe
 
   const text =
     format === "text" ? formatText(json, ignore, { requireFilesSection, ...textCounts }) : "";
-  return { json, exitCode, text };
+  return { json, exitCode, text, warnings };
 }

--- a/src/rename-executor.ts
+++ b/src/rename-executor.ts
@@ -66,11 +66,11 @@ export interface RenameResult {
   // issue #265 — `buildGraph()`'s own warnings (pathological-bracket-nesting,
   // class-member-collision, …) from the pre-rewrite scan that resolved
   // `existingIds` below. Kept as a separate field from `warnings` above (a
-  // different, rename-specific warning type) to avoid conflating the two.
-  // Only the pre-rewrite scan's warnings are surfaced — `reconcileAfterWrite`
-  // runs a SECOND scan after files are written purely to refresh the lock,
-  // and re-surfacing that scan's warnings here would just print the same
-  // findings twice for the common case where the rewrite doesn't change them.
+  // different, rename-specific warning type). `reconcileAfterWrite` runs a
+  // SECOND scan after files are written purely to refresh the lock, and that
+  // second scan's warnings are currently discarded outright — not deduped
+  // against these, just dropped. See issue #273 for surfacing (or properly
+  // deduping) that post-write scan's warnings.
   buildWarnings: BuildWarning[];
   applied: boolean;
 }
@@ -133,6 +133,9 @@ function assertRenameableSource(id: string): void {
 function reconcileAfterWrite(rootDir: string, config: ArtgraphConfig): void {
   const lockFilePath = resolve(rootDir, config.lockFile);
   if (!existsSync(lockFilePath)) return;
+  // This second scan's `warnings` are discarded outright (see the
+  // `buildWarnings` doc on `RenameResult` above — issue #273 tracks properly
+  // surfacing them instead of dropping them on the floor).
   const { graph } = scan(rootDir, config);
   reconcile(rootDir, config, graph);
 }

--- a/src/rename-executor.ts
+++ b/src/rename-executor.ts
@@ -20,6 +20,7 @@ import { readLock } from "./lock.js";
 import { scan, reconcile } from "./scan.js";
 import { loadConfig } from "./config.js";
 import { globCodeFiles } from "./parsers/typescript.js";
+import type { BuildWarning } from "./graph/builder.js";
 import { assertValidTargetId } from "./rename-validate-id.js";
 import { rewriteTraceShards } from "./rename-trace.js";
 import type { ArtgraphConfig, LockFile } from "./types.js";
@@ -62,6 +63,15 @@ export interface RenameResult {
   changes: RewriteChange[];
   lockChanges: LockChange[];
   warnings: RenameWarning[];
+  // issue #265 — `buildGraph()`'s own warnings (pathological-bracket-nesting,
+  // class-member-collision, …) from the pre-rewrite scan that resolved
+  // `existingIds` below. Kept as a separate field from `warnings` above (a
+  // different, rename-specific warning type) to avoid conflating the two.
+  // Only the pre-rewrite scan's warnings are surfaced — `reconcileAfterWrite`
+  // runs a SECOND scan after files are written purely to refresh the lock,
+  // and re-surfacing that scan's warnings here would just print the same
+  // findings twice for the common case where the rewrite doesn't change them.
+  buildWarnings: BuildWarning[];
   applied: boolean;
 }
 
@@ -131,11 +141,14 @@ interface ScanContext {
   config: ArtgraphConfig;
   existingIds: Set<string>;
   rewriteOpts: RewriteOptions;
+  // issue #265 — the pre-rewrite scan's build warnings, threaded into
+  // `RenameResult.buildWarnings` by each `execute*` below.
+  graphWarnings: BuildWarning[];
 }
 
 function loadScanContext(rootDir: string): ScanContext {
   const config = loadConfig(rootDir);
-  const { graph } = scan(rootDir, config);
+  const { graph, warnings } = scan(rootDir, config);
   return {
     config,
     existingIds: new Set(graph.nodes.keys()),
@@ -144,6 +157,7 @@ function loadScanContext(rootDir: string): ScanContext {
       taskConventions: config.taskConventions,
       disableBuiltinTaskConventions: config.disableBuiltinTaskConventions,
     },
+    graphWarnings: warnings,
   };
 }
 
@@ -164,7 +178,7 @@ function applyWrites(
 
 export function executeRename(options: RenameOptions & { from: string; to: string }): RenameResult {
   const { rootDir, dryRun, from, to } = options;
-  const { config, existingIds, rewriteOpts } = loadScanContext(rootDir);
+  const { config, existingIds, rewriteOpts, graphWarnings } = loadScanContext(rootDir);
 
   // Validate
   if (from === to) {
@@ -238,6 +252,7 @@ export function executeRename(options: RenameOptions & { from: string; to: strin
     changes: allChanges,
     lockChanges,
     warnings,
+    buildWarnings: graphWarnings,
     applied: !dryRun,
   };
 }
@@ -248,7 +263,7 @@ export function executeSplit(
   options: RenameOptions & { splitId: string; intoIds: string[] },
 ): RenameResult {
   const { rootDir, dryRun, splitId, intoIds } = options;
-  const { config, existingIds, rewriteOpts } = loadScanContext(rootDir);
+  const { config, existingIds, rewriteOpts, graphWarnings } = loadScanContext(rootDir);
 
   // Validate
   assertRenameableSource(splitId);
@@ -347,6 +362,7 @@ export function executeSplit(
     changes: allChanges,
     lockChanges,
     warnings,
+    buildWarnings: graphWarnings,
     applied: !dryRun,
   };
 }
@@ -357,7 +373,7 @@ export function executeMerge(
   options: RenameOptions & { mergeIds: string[]; intoId: string },
 ): RenameResult {
   const { rootDir, dryRun, mergeIds, intoId } = options;
-  const { config, existingIds, rewriteOpts } = loadScanContext(rootDir);
+  const { config, existingIds, rewriteOpts, graphWarnings } = loadScanContext(rootDir);
 
   // Validate
   if (mergeIds.length < 1) {
@@ -475,6 +491,7 @@ export function executeMerge(
     changes: allChanges,
     lockChanges,
     warnings,
+    buildWarnings: graphWarnings,
     applied: !dryRun,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -592,6 +592,12 @@ export interface PlanCoverageConfig {
 export type PackageManager = "npm" | "pnpm" | "bun" | "deno";
 
 export interface ArtgraphConfig {
+  /**
+   * fast-glob patterns for source files, resolved relative to the repo root.
+   * A leading `!` marks a pattern as an exclusion (issue #266) — see
+   * `globCodeFiles` in `src/parsers/typescript.ts`. Applies identically to
+   * `testPatterns` below.
+   */
   include: string[];
   specDirs: string[];
   testPatterns: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -595,11 +595,21 @@ export interface ArtgraphConfig {
   /**
    * fast-glob patterns for source files, resolved relative to the repo root.
    * A leading `!` marks a pattern as an exclusion (issue #266) — see
-   * `globCodeFiles` in `src/parsers/typescript.ts`. Applies identically to
-   * `testPatterns` below.
+   * `globCodeFiles` in `src/parsers/typescript.ts`.
    */
   include: string[];
   specDirs: string[];
+  /**
+   * fast-glob patterns for test files, resolved relative to the repo root.
+   * A leading `!` exclusion is mechanically supported here too, but prefer
+   * putting exclusions in `include` instead: trace evaluation
+   * (`buildSymbolNameTable`) resolves symbol names against `include` only,
+   * never `testPatterns`, so a `testPatterns`-only negative pattern narrows
+   * the scanned/graph file set without narrowing what trace evaluation sees
+   * — the two can disagree and surface a suggested `@impl` / drift
+   * candidate for a symbol that isn't actually a graph node (issue #275).
+   * See docs/configuration.md's `include` / `testPatterns` section.
+   */
   testPatterns: string[];
   lockFile: string;
   /**

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
-import { join, resolve } from "node:path";
+import { describe, it, expect, afterEach, beforeAll, afterAll, vi } from "vitest";
+import { dirname, join, resolve } from "node:path";
 import {
   writeFileSync,
   unlinkSync,
@@ -1497,5 +1497,73 @@ describe("buildGraph: class-member symbol collision determinism (spec 021 / T020
     expect(symbolIdsA.filter((id) => id === "symbol:src/collision.ts#Sample.methodA")).toHaveLength(
       1,
     );
+  });
+});
+
+// issue #266 — config-level integration test: a `.artgraph.json`-shaped
+// `include` list with a `!`-prefixed negative pattern must actually exclude
+// the matched files from the graph (file/symbol nodes, and any @impl edges
+// they'd otherwise contribute), not just fail to error.
+describe("buildGraph: negative include patterns (issue #266)", () => {
+  let root: string;
+
+  const write = (relPath: string, content: string): void => {
+    const abs = join(root, relPath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  };
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "artgraph-t266-builder-"));
+    mkdirSync(join(root, "specs"), { recursive: true });
+    writeFileSync(
+      join(root, "specs", "spec.md"),
+      "# Spec\n\n- REQ-500: kept file requirement\n- REQ-600: generated-file requirement (should stay uncovered)\n",
+    );
+    // Literal tags below are string-literal-split (`"@" + "impl ..."`) so
+    // artgraph's OWN dogfood scan of THIS repo never mistakes this fixture
+    // text for a real code tag on `tests/builder.test.ts` itself — the
+    // temp-directory fixture file still receives the concatenated,
+    // unbroken tag. Mirrors the convention in
+    // tests/check-baseline-diff.test.ts / tests/helpers.ts.
+    write("src/keep.ts", "// @" + "impl REQ-500\nexport const keep = 1;\n");
+    // A generated file that (if scanned) would satisfy REQ-600 — the whole
+    // point of the exclusion is that it must NOT be scanned.
+    write("src/generated/gen.ts", "// @" + "impl REQ-600\nexport const gen = 1;\n");
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("excludes files matched by a `!`-prefixed include pattern", () => {
+    const excludeConfig: ArtgraphConfig = {
+      include: ["src/**/*.ts", "!src/generated/**"],
+      specDirs: ["specs"],
+      testPatterns: [],
+      lockFile: ".trace.lock",
+    };
+    const { graph } = buildGraph(root, excludeConfig);
+
+    expect(graph.nodes.has("file:src/keep.ts")).toBe(true);
+    expect(graph.nodes.has("file:src/generated/gen.ts")).toBe(false);
+
+    const implEdges = graph.edges.filter((e) => e.kind === "implements");
+    expect(implEdges.map((e) => e.target).sort()).toEqual(["REQ-500"]);
+  });
+
+  it("regression: without the negative pattern, the generated file is scanned as before", () => {
+    const plainConfig: ArtgraphConfig = {
+      include: ["src/**/*.ts"],
+      specDirs: ["specs"],
+      testPatterns: [],
+      lockFile: ".trace.lock",
+    };
+    const { graph } = buildGraph(root, plainConfig);
+
+    expect(graph.nodes.has("file:src/keep.ts")).toBe(true);
+    expect(graph.nodes.has("file:src/generated/gen.ts")).toBe(true);
+    const implEdges = graph.edges.filter((e) => e.kind === "implements");
+    expect(implEdges.map((e) => e.target).sort()).toEqual(["REQ-500", "REQ-600"]);
   });
 });

--- a/tests/commands-shared.test.ts
+++ b/tests/commands-shared.test.ts
@@ -1,0 +1,64 @@
+// issue #265 — unit tests for `reportGraphWarnings` (src/commands/shared.ts),
+// the shared helper that centralizes "when do we print BuildWarning[] to
+// stderr" for every command that builds the graph (`impact`/`trace`/
+// `reconcile`/`rename`, alongside `scan`/`init`/`check`'s pre-existing
+// direct `printWarnings` wiring). Two representative CLI integration tests
+// (tests/impact-cli.test.ts, tests/trace-cli.test.ts) cover the end-to-end
+// wiring; this file pins the helper's own text/json/empty-input contract in
+// isolation.
+
+import { describe, it, expect, vi } from "vitest";
+import { reportGraphWarnings } from "../src/commands/shared.js";
+import type { BuildWarning } from "../src/graph/builder.js";
+
+const collisionWarning: BuildWarning = {
+  type: "class-member-collision",
+  id: "symbol:src/x.ts#Sample.methodA",
+  files: ["src/x.ts"],
+  message: "class-member-collision: some class member context.",
+};
+
+describe("reportGraphWarnings", () => {
+  it("format omitted (text default): prints via printWarnings to stderr", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      reportGraphWarnings([collisionWarning]);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(String(spy.mock.calls[0]![0])).toContain("class-member-collision");
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('format: "text": prints via printWarnings to stderr', () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      reportGraphWarnings([collisionWarning], "text");
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('format: "json": no-op — the caller is responsible for folding warnings into its JSON payload instead', () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      reportGraphWarnings([collisionWarning], "json");
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("empty warnings array: no-op regardless of format", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      reportGraphWarnings([]);
+      reportGraphWarnings([], "text");
+      reportGraphWarnings([], "json");
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/tests/impact-cli.test.ts
+++ b/tests/impact-cli.test.ts
@@ -19,6 +19,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, cpSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
 import { runAt, FIXTURE_DIR } from "./helpers.js";
 
 // ---------------------------------------------------------------------------
@@ -941,6 +942,44 @@ describe("artgraph impact — build warnings surfaced (issue #265)", () => {
       ).toBe(true);
       // scan/init/check convention: json mode doesn't ALSO print to stderr.
       expect(stderr).not.toContain("WARNING:");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // meta-review F1 — early-exit paths that fire AFTER `scan()` but BEFORE any
+  // output (JSON or text) used to swallow `warnings` entirely: the command
+  // exits via `process.exit(1)` (or, for `--diff` with no changes, an early
+  // `process.exit(0)`) without ever reaching the bottom-of-action
+  // `reportGraphWarnings` call. Two representative early-exit paths below.
+  it('"No matching nodes found" error exit still prints the WARNING to stderr', async () => {
+    const root = makeCollisionRepo();
+    try {
+      const { stderr, exitCode } = await runAt(root, ["impact", "src/does/not/exist.ts"]);
+      expect(exitCode).toBe(1);
+      expect(stderr).toContain("No matching nodes found");
+      expect(stderr).toContain("WARNING:");
+      expect(stderr).toContain("collides with an existing export");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("`--diff` with no changes (text) still prints the WARNING to stderr", async () => {
+    const root = makeCollisionRepo();
+    execFileSync("git", ["init"], { cwd: root, stdio: "pipe" });
+    execFileSync("git", ["add", "-A"], { cwd: root, stdio: "pipe" });
+    execFileSync(
+      "git",
+      ["-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", "init"],
+      { cwd: root, stdio: "pipe" },
+    );
+    try {
+      const { stdout, stderr, exitCode } = await runAt(root, ["impact", "--diff"]);
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("No changes detected in git diff.");
+      expect(stderr).toContain("WARNING:");
+      expect(stderr).toContain("collides with an existing export");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/tests/impact-cli.test.ts
+++ b/tests/impact-cli.test.ts
@@ -875,3 +875,74 @@ describe("CLI: impact — issue #215 minimal repro (spec 019 contains direction,
     expect(result.affectedFiles).toContain("src/other.ts");
   });
 });
+
+// issue #265 — `artgraph impact` used to discard `buildGraph()`'s
+// `BuildWarning[]` entirely (`const { graph } = scan(...)`), so a
+// `class-member-collision` warning (or any other build warning) was
+// invisible via this command. Fixture below triggers a collision with no
+// `@impl` tags at all (a string-literal export alias colliding with a class
+// member's synthesized symbol name — see tests/typescript.test.ts's T020
+// fixture), so it needs no REQ coverage and carries zero orphan risk for
+// artgraph's own dogfood scan.
+describe("artgraph impact — build warnings surfaced (issue #265)", () => {
+  function makeCollisionRepo(): string {
+    const dir = mkdtempSync(join(tmpdir(), "artgraph-impact-265-"));
+    writeFileSync(
+      join(dir, ".artgraph.json"),
+      JSON.stringify({
+        include: ["src/**/*.ts"],
+        specDirs: ["specs"],
+        mode: "symbol",
+      }),
+    );
+    mkdirSync(join(dir, "specs"), { recursive: true });
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "specs", "spec.md"), "# Spec\n\n- REQ-001: unrelated requirement\n");
+    writeFileSync(
+      join(dir, "src", "collision.ts"),
+      [
+        "function helper(): void {}",
+        'export { helper as "Sample.methodA" };',
+        "",
+        "export class Sample {",
+        "  methodA(): void {}",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    return dir;
+  }
+
+  it("text mode: prints the class-member-collision warning to stderr", async () => {
+    const root = makeCollisionRepo();
+    try {
+      const { stderr, exitCode } = await runAt(root, ["impact", "src/collision.ts"]);
+      expect(exitCode).toBe(0);
+      expect(stderr).toContain("WARNING:");
+      expect(stderr).toContain("collides with an existing export");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("--format json: embeds warnings[] in the JSON payload and does not also print to stderr", async () => {
+    const root = makeCollisionRepo();
+    try {
+      const { stdout, stderr, exitCode } = await runAt(root, [
+        "impact",
+        "src/collision.ts",
+        "--format",
+        "json",
+      ]);
+      expect(exitCode).toBe(0);
+      const result = JSON.parse(stdout);
+      expect(
+        result.warnings.some((w: { type: string }) => w.type === "class-member-collision"),
+      ).toBe(true);
+      // scan/init/check convention: json mode doesn't ALSO print to stderr.
+      expect(stderr).not.toContain("WARNING:");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/plan-coverage-integration.test.ts
+++ b/tests/plan-coverage-integration.test.ts
@@ -1150,3 +1150,81 @@ describe("plan-coverage symbol-mode E2E — `export *` chain entry (specs/018 T1
     expect(drift).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// build warnings surfaced (meta-review F2 — issue #265 follow-up gap)
+// ---------------------------------------------------------------------------
+//
+// `runPlanCoverage` used to discard `scan()`'s `BuildWarning[]` entirely
+// (`const { graph } = scan(...)`), so `artgraph plan-coverage` was the one
+// graph-building command issue #265's warning-wiring pass missed. Mirrors
+// the equivalent coverage for `artgraph impact` in
+// tests/impact-cli.test.ts's "build warnings surfaced (issue #265)" block —
+// same fixture shape (a string-literal export alias colliding with a class
+// member's synthesized symbol name), same two assertions (text → stderr,
+// json → payload).
+describe("plan-coverage E2E — build warnings surfaced (meta-review F2)", () => {
+  function makeCollisionFixture(): Fixture {
+    const fx = setupFixture();
+    // Switch the fixture's graph to symbol mode and add a colliding file —
+    // scan() warns about this regardless of what tasks.md's `Files:` list
+    // references, since the warning comes from building the whole graph.
+    writeFileSync(
+      join(fx.root, ".artgraph.json"),
+      JSON.stringify({
+        include: ["src/**/*.ts"],
+        specDirs: ["specs"],
+        testPatterns: ["tests/**/*.test.ts"],
+        lockFile: ".trace.lock",
+        mode: "symbol",
+      }),
+    );
+    mkdirSync(join(fx.root, "src/other"), { recursive: true });
+    writeFileSync(
+      join(fx.root, "src/other/collision.ts"),
+      [
+        "function helper(): void {}",
+        'export { helper as "Sample.methodA" };',
+        "",
+        "export class Sample {",
+        "  methodA(): void {}",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    return fx;
+  }
+
+  it("text mode: prints the class-member-collision warning to stderr", async () => {
+    const fx = makeCollisionFixture();
+    try {
+      const { stderr, exitCode } = await runCli(["plan-coverage", "--spec", fx.specDirAbsolute], {
+        cwd: fx.root,
+      });
+      expect(exitCode).toBe(0);
+      expect(stderr).toContain("WARNING:");
+      expect(stderr).toContain("collides with an existing export");
+    } finally {
+      rmSync(fx.root, { recursive: true, force: true });
+    }
+  });
+
+  it("--format json: embeds warnings[] in the payload and does not also print to stderr", async () => {
+    const fx = makeCollisionFixture();
+    try {
+      const { stdout, stderr, exitCode } = await runCli(
+        ["plan-coverage", "--spec", fx.specDirAbsolute, "--format", "json"],
+        { cwd: fx.root },
+      );
+      expect(exitCode).toBe(0);
+      const json = JSON.parse(stdout);
+      expect(json.warnings.some((w: { type: string }) => w.type === "class-member-collision")).toBe(
+        true,
+      );
+      // scan/init/check convention: json mode doesn't ALSO print to stderr.
+      expect(stderr).not.toContain("WARNING:");
+    } finally {
+      rmSync(fx.root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/trace-cli.test.ts
+++ b/tests/trace-cli.test.ts
@@ -354,3 +354,53 @@ describe("CLI: trace report is read-only (Phase A contract)", () => {
     expect(existsSync(join(tmp, ".trace.lock"))).toBe(false);
   });
 });
+
+// issue #265 — `trace status` / `trace report` used to discard
+// `buildGraph()`'s `BuildWarning[]` (`const { graph } = scan(...)` in
+// `loadTraceInputs`), so a `class-member-collision` warning was invisible
+// via either subcommand. Fixture triggers the collision with no `@impl`
+// tags (see tests/typescript.test.ts's T020 fixture), so it needs no REQ
+// coverage and carries zero orphan risk for artgraph's own dogfood scan.
+describe("artgraph trace status/report — build warnings surfaced (issue #265)", () => {
+  function collisionFiles(): Record<string, string> {
+    return {
+      "src/collision.ts": [
+        "function helper(): void {}",
+        'export { helper as "Sample.methodA" };',
+        "",
+        "export class Sample {",
+        "  methodA(): void {}",
+        "}",
+        "",
+      ].join("\n"),
+      "specs/spec.md": "# Spec\n\n- REQ-001: unrelated requirement\n",
+    };
+  }
+
+  it("`trace status` text mode prints the class-member-collision warning to stderr", async () => {
+    const tmp = makeRepo(collisionFiles());
+    const { stderr, exitCode } = await runAt(tmp, ["trace", "status"]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("WARNING:");
+    expect(stderr).toContain("collides with an existing export");
+  });
+
+  it("`trace status --format json` embeds warnings[] and stays quiet on stderr", async () => {
+    const tmp = makeRepo(collisionFiles());
+    const { stdout, stderr, exitCode } = await runAt(tmp, ["trace", "status", "--format", "json"]);
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.warnings.some((w: { type: string }) => w.type === "class-member-collision")).toBe(
+      true,
+    );
+    expect(stderr).not.toContain("WARNING:");
+  });
+
+  it("`trace report` text mode also prints the warning (requires at least one shard)", async () => {
+    const tmp = makeRepo(collisionFiles());
+    writeShard(tmp, "w1.jsonl", [metaLine()]);
+    const { stderr, exitCode } = await runAt(tmp, ["trace", "report"]);
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("collides with an existing export");
+  });
+});

--- a/tests/typescript.test.ts
+++ b/tests/typescript.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import { createTSParser, hash } from "../src/parsers/typescript.js";
+import { createTSParser, globCodeFiles, hash } from "../src/parsers/typescript.js";
 
 const FIXTURE_DIR = resolve(import.meta.dirname, "fixtures");
 
@@ -1690,5 +1690,75 @@ describe("createTSParser (symbol mode — same-line multi-member trailing tag pi
       .parse()
       .edges.filter((e) => e.kind === "implements" && e.target === "REQ-1080");
     expect(again).toEqual(implEdges);
+  });
+});
+
+// issue #266 — `globCodeFiles` used to `resolve(rootDir, p)` EVERY pattern,
+// including fast-glob-convention negative patterns (`"!src/generated/**"`),
+// which mangled the leading `!` into the middle of an absolute path and
+// silently matched nothing — the exclusion had no effect. Fixture below has
+// three code files under different subdirectories so a positive-only run
+// (regression case) picks up all of them, and each negative-pattern case can
+// assert a specific subset is excluded.
+describe("globCodeFiles (issue #266 — negative glob patterns)", () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "artgraph-t266-"));
+    const write = (relPath: string): void => {
+      const abs = join(root, relPath);
+      mkdirSync(dirname(abs), { recursive: true });
+      writeFileSync(abs, "export const x = 1;\n");
+    };
+    write("src/keep.ts");
+    write("src/generated/gen.ts");
+    write("src/other/skip.ts");
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const relFiles = (files: string[]): string[] => files.map((f) => f.slice(root.length + 1)).sort();
+
+  it("regression: a plain (no `!`) pattern list matches every file, unchanged", () => {
+    const files = globCodeFiles(root, ["src/**/*.ts"]);
+    expect(relFiles(files)).toEqual(["src/generated/gen.ts", "src/keep.ts", "src/other/skip.ts"]);
+  });
+
+  it("mixed positive/negative: a leading `!` pattern excludes its matches", () => {
+    const files = globCodeFiles(root, ["src/**/*.ts", "!src/generated/**"]);
+    expect(relFiles(files)).toEqual(["src/keep.ts", "src/other/skip.ts"]);
+  });
+
+  it("multiple negative patterns compose (all excluded subsets are dropped)", () => {
+    const files = globCodeFiles(root, ["src/**/*.ts", "!src/generated/**", "!src/other/**"]);
+    expect(relFiles(files)).toEqual(["src/keep.ts"]);
+  });
+
+  it("negative-only pattern list matches zero files (natural degenerate case)", () => {
+    const files = globCodeFiles(root, ["!src/**/*.ts"]);
+    expect(files).toEqual([]);
+  });
+
+  it("empty pattern list matches zero files", () => {
+    expect(globCodeFiles(root, [])).toEqual([]);
+  });
+
+  // Consistency check (buildSymbolNameTable's own invariant, spec 020):
+  // `createTSParser`'s internal file enumeration (`enumerateFiles`) must
+  // agree with `globCodeFiles` on which files a negative pattern excludes —
+  // they used to be two independent glob call sites and only `globCodeFiles`
+  // is directly under test above.
+  it("createTSParser (via enumerateFiles) excludes the same files as globCodeFiles", () => {
+    const patterns = ["src/**/*.ts", "!src/generated/**"];
+    const globbed = relFiles(globCodeFiles(root, patterns));
+    const parsed = createTSParser(root, patterns).parse();
+    const parsedFiles = parsed.nodes
+      .filter((n) => n.kind === "file" || n.kind === "test")
+      .map((n) => n.filePath)
+      .sort();
+    expect(parsedFiles).toEqual(globbed);
+    expect(parsedFiles).toEqual(["src/keep.ts", "src/other/skip.ts"]);
   });
 });


### PR DESCRIPTION
## Summary

parser 堅牢性まとめ対応の PR 1/2 (可視化基盤)。PR 2/2 (#263 fail-fast / #264 readFileSync ガード / #269 safeParseSync 統一) はこの基盤の上に乗せる。

**#265 — impact / trace / reconcile / rename / plan-coverage が buildGraph の warnings を破棄**

`printWarnings` の配線が scan / init / check の3コマンドのみだったため、pathological-bracket-nesting や class-member-collision 等のユーザーが見るべき警告が他のコマンド経由では一切見えなかった。

- `commands/shared.ts` に `reportGraphWarnings(warnings, format?)` を新設 — 既存3コマンドの規約 (text は stderr へ `printWarnings` / json はペイロードに畳み込み stderr 二重出力なし) を関数化して一元化
- impact / trace (`loadTraceInputs` 経由) / reconcile / rename (`RenameResult.buildWarnings`) / plan-coverage に配線
- impact / trace の**早期終了経路** (存在しないシンボル指定、shard 0件エラー、`--diff` 差分なし等) でも警告を出力 — 警告 (例: bracket-nesting によるシンボル欠落) がエラーの根本原因そのものを説明するケースがあるため
- rename の throw 経路と post-write scan warnings の扱いは #273 に切り出し

**#266 — include の先頭 `!` 負パターンが resolve() でパス化けして黙って無機能**

- `splitIncludePatterns` を新設し、`!` 始まりを resolve 前に分離して fast-glob の `ignore` オプションへ (承認済み方針: サポートする)
- `globCodeFiles` と `enumerateFiles` (`createTSParser`) の**両経路**に適用 (`buildSymbolNameTable` が2経路のファイルセット一致を前提)
- 全パターンが負または空なら 0 件。縮退パターン (`!!` / `!` 単体 / 空文字列) はエラーにせず inert (docs に明記)
- docs は「除外は include 側に書く」ガイダンスに統一 — testPatterns 側の負パターンは trace 評価と乖離しうるため (#275)

Closes #265
Closes #266

## Change type

- [x] feat (new feature) — #266 の負パターンサポート
- [x] fix (bug fix) — #265 の警告配線

## Testing

- [x] Existing tests pass (`pnpm -r test`) — 全 suite green (86 files / 2085 passed / 5 skipped)
- [x] Added tests where needed — glob 単体 (正負混在/負のみ/複数負/回帰/空)、`globCodeFiles`×`enumerateFiles` 一致性、builder 統合、`reportGraphWarnings` 単体、impact / trace / plan-coverage CLI 統合 (text=stderr / json=payload)、impact 早期終了 2 経路
- [x] Ran `pnpm -r knip` and `pnpm -r build`
- `artgraph check --diff`: No new issues introduced by this change
- **実機確認済み**: main と本ブランチの両方で実 CLI を実行し、#265 (5コマンド + 早期終了経路) / #266 (負パターン除外・lock 反映・回帰なし) の before/after を確認

## Breaking change

- [ ] Yes (described below)
- [x] No

**アップグレード注意 (breaking ではないが挙動変化)**: `.artgraph.json` にこれまで**黙って無効だった** `!` 始まりのパターンが書かれている場合、本バージョンからその除外が有効になり、該当ファイルのノードが graph / lock から外れます。心当たりがある場合はアップグレード後に `artgraph check` で確認してください。json 出力への `warnings` フィールド追加は additive です。

## Notes

- 敵対的レビュー + メタレビュー実施済み。本PR反映分: plan-coverage 配線 / 早期終了経路の警告 / docs の testPatterns 負パターン推奨撤回 / コメント2件。切り出し: #273 (rename 警告経路)、#274 (scan --serve 分岐 + 既存3コマンド統一)、#275 (trace ingest のファイル集合乖離、major)
- lefthook が表面化させた lint 警告 (未使用 import 等) は pre-existing のため未対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg