### PR TITLE
fix(parser): oxc ロード失敗の fail-fast 化 + 読み取り不能ファイルの警告スキップ + symbol-table の safeParseSync 統一 (#263, #264, #269)

### DIFF
--- a/.agents/skills/_shared/output-schema.md
+++ b/.agents/skills/_shared/output-schema.md
@@ -84,7 +84,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/.claude/skills/_shared/output-schema.md
+++ b/.claude/skills/_shared/output-schema.md
@@ -84,7 +84,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/.cursor/skills/_shared/output-schema.md
+++ b/.cursor/skills/_shared/output-schema.md
@@ -84,7 +84,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/.github/skills/_shared/output-schema.md
+++ b/.github/skills/_shared/output-schema.md
@@ -84,7 +84,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/.kiro/skills/_shared/output-schema.md
+++ b/.kiro/skills/_shared/output-schema.md
@@ -84,7 +84,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,7 +214,7 @@ drift = 現在の hash ≠ lock の hash。
 | `artgraph init`                                                    | 設定・lock の雛形生成                                                                                 |
 | `artgraph scan`                                                    | 統合グラフ構築/更新（AST ＋ タグ ＋ frontmatter ＋ 実行トレース成果物 — spec 020）、キャッシュ更新                                     |
 | `artgraph impact <files\|--diff>`                                  | Plan 用: 変更から `{依存元 / 紐づく doc・仕様 / drift / 未カバー}` を出力(粒度は config の `mode` で選択) |
-| `artgraph check [--gate] [--diff]`                                 | 検証: drift（コード・doc 両方）/ orphan / 未カバー-vs-Plan / 未テスト。`--diff --gate` は変更が**新規に導入した**問題のみで exit 2（pre-existing 債務は baseline 差分でゲート対象外、spec 017 / issue #174）。baseline 構築不能時は exit 1 |
+| `artgraph check [--gate] [--diff]`                                 | 検証: drift（コード・doc 両方）/ orphan / 未カバー-vs-Plan / 未テスト。`--diff --gate` は変更が**新規に導入した**問題のみで exit 2（pre-existing 債務は baseline 差分でゲート対象外、spec 017 / issue #174）。baseline 構築不能時は exit 1。環境故障（例: oxc ネイティブバインディングのロード失敗 `OxcLoadError`）も「判定不能」として exit 1（非ブロック）— baseline 構築不能と同じファミリー。stderr に原因と対処法が出力される |
 | `artgraph rename --from … --to … / --split / --merge`              | ID ライフサイクル（req・doc のタグ一括書換 ＋ lock 更新）                                             |
 | `artgraph trace status\|report`                                   | 実行証拠: shard 診断 / `@impl` 宣言 × per-test カバレッジ証拠の突き合わせレポート（spec 020。graph/lock 非改変） |
 | `artgraph mcp-server`                                              | `impact` を MCP ツールとして公開（Plan 時にエージェントが呼ぶ）                                       |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { realpathSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 import { buildProgram } from "./build-program.js";
 import { installBaselineSignalHandlers } from "./baseline.js";
+import { OxcLoadError } from "./parsers/typescript.js";
 
 // @internal re-export — the in-process test harness lives in
 // `src/testing/run-cli.ts` (issue #162: composition root vs. test-harness
@@ -44,5 +45,28 @@ if (import.meta.url === resolveEntryHref()) {
   // Matches the parseAsync semantics runCli has always used. A rejected
   // handler surfaces as a top-level-await rejection — stack trace + exit 1 —
   // same outcome as the old sync-throw-through-parse() path.
-  await program.parseAsync();
+  //
+  // issue #263 — ONE deliberate, narrow exception to that "stack trace"
+  // default: `OxcLoadError` is a specifically-anticipated, actionable
+  // environment failure (oxc-parser's native binding missing/broken) whose
+  // whole point is a clear diagnostic FOR THE USER, not a debugging aid for
+  // artgraph's own internals — a Node stack trace under it (dist file paths,
+  // `node:internal/modules/cjs/loader` frames, …) is noise that competes
+  // with, rather than adds to, the message's own cause/fix guidance. This is
+  // NOT a general-purpose "pretty error" layer: every OTHER thrown error
+  // still falls through unchanged to the exact pre-existing behavior this
+  // comment describes (rethrown here, then the default stack-trace-and-exit
+  // path). Scoped to real CLI invocations only — `runCli` (the in-process
+  // test harness) has its own independent, pre-existing catch and is not
+  // touched by this.
+  try {
+    await program.parseAsync();
+  } catch (e) {
+    if (e instanceof OxcLoadError) {
+      console.error(e.message);
+      process.exitCode = 1;
+    } else {
+      throw e;
+    }
+  }
 }

--- a/src/commands/presenters/warnings.ts
+++ b/src/commands/presenters/warnings.ts
@@ -81,6 +81,17 @@ export function printWarnings(warnings: BuildWarning[]) {
           `WARNING: ${w.message ?? `pathological-bracket-nesting "${w.id}" in ${w.files.join(", ")}`}`,
         );
         break;
+      // issue #264 — a file that could not be read at all (e.g. a
+      // permission error). Shown by default (NOT in SILENT_WARNING_TYPES):
+      // the file's symbols/imports/@impl edges are missing from the graph
+      // until it becomes readable again, which the author needs to see. The
+      // parser-built message carries the file and the underlying I/O error,
+      // so print it verbatim with the id as fallback.
+      case "unreadable-file":
+        console.error(
+          `WARNING: ${w.message ?? `unreadable-file "${w.id}" in ${w.files.join(", ")}`}`,
+        );
+        break;
       // Filtered above via `isSilentWarning`, but the switch still needs
       // cases so the exhaustiveness check below stays happy.
       case "phantom-import-repaired":

--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -371,6 +371,14 @@ export function buildGraph(
   // call the parser's own file enumeration is built on), so hit and miss
   // paths see the same files a full scan would. Only changed files are
   // handed to the oxc parser; a fully-warm run never loads it at all.
+  // Deliberate constraint: because oxc never loads on a fully-warm run, a
+  // broken environment (see `OxcLoadError`, issue #263's fail-fast) still
+  // succeeds as long as the cache stays valid — the output is just a memo of
+  // a parse that already ran successfully, so this is correct, not a bug.
+  // `OxcLoadError` only fires on the first cache miss that actually needs
+  // oxc. This is an intentional trade-off: it avoids paying the cost of an
+  // unconditional oxc dlopen probe on every command just to fail fast
+  // earlier.
   const codePatterns = [...config.include, ...config.testPatterns];
   const tsMode = config.mode ?? "file";
   const codeId = config.reqPatterns?.codeId;

--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -58,7 +58,16 @@ export interface BuildWarning {
     // symbol/import edges are lost. Rare and still worth surfacing when it
     // fires, so NOT silent — shown by default like `class-member-collision`
     // above.
-    | "pathological-bracket-nesting";
+    | "pathological-bracket-nesting"
+    // issue #264 — a file `parseTSFile` could not even READ (permission
+    // errors, e.g. chmod 000; distinct from `pathological-bracket-nesting`,
+    // which reads the file fine but skips handing it to the native parser).
+    // No symbols/imports/@impl edges are extracted from this file until it
+    // becomes readable again, but scanning continues for every other file
+    // and a bare file node is still synthesized (see `parseTSFile`). NOT
+    // silent — a scan silently missing a whole file's coverage is exactly
+    // the kind of thing the author needs to see.
+    | "unreadable-file";
   id: string;
   files: string[];
   message?: string;
@@ -388,7 +397,33 @@ export function buildGraph(
   const missPaths: string[] = [];
   const missHashes = new Map<string, string>();
   for (let i = 0; i < codeFiles.length; i++) {
-    const content = readFileSync(codeFiles[i], "utf-8");
+    // issue #264 — this read (done purely to compute a cache-validity hash)
+    // can throw for exactly the same reason `parseTSFile`'s own read can
+    // (permission errors, e.g. chmod 000). Before this fix that uncaught
+    // throw crashed the WHOLE build here, before a miss path ever even
+    // reached `parseTSFilePaths` / `parseTSFile`'s own (now-guarded) read.
+    // On failure: force this file to always miss the cache (never treat a
+    // stale/sentinel hash as a legitimate match) using a fixed non-hash
+    // sentinel that can never collide with a real `hashContent` output (a
+    // 16-hex-char string) — including the degenerate case of a genuinely
+    // empty-but-READABLE file, which would otherwise coincide with
+    // `hashContent("")` if that were used as the sentinel instead. The
+    // actual "can't read, warn, synthesize a bare node" handling — and the
+    // ONLY place the `unreadable-file` warning is emitted from — lives in
+    // `parseTSFile`, which independently attempts (and fails) the same read
+    // for every path in `missPaths`; this catch only needs to avoid crashing
+    // and route the file there, not duplicate that diagnostic.
+    let content: string | undefined;
+    try {
+      content = readFileSync(codeFiles[i], "utf-8");
+    } catch {
+      content = undefined;
+    }
+    if (content === undefined) {
+      missPaths.push(codeFiles[i]);
+      missHashes.set(codeFiles[i], "unreadable-file:cannot-hash");
+      continue;
+    }
     const contentHash = hashContent(content);
     const hit = tsFragmentsValid ? prevCache!.data.ts[relCodeFiles[i]] : undefined;
     if (hit && hit.contentHash === contentHash && importTargetsExist(hit.edges, rootDir)) {

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -61,9 +61,82 @@ import { NAMESPACED_ID_TOKEN } from "../grammar/tokens.js";
 // dep is synchronous, so callers (buildGraph is sync) don't need to change
 // shape.
 const requireCjs = createRequire(import.meta.url);
+
+// issue #263 — when oxc-parser's native binding is missing/broken for this
+// platform (corrupted node_modules, a musl/glibc mismatch, an npm install
+// that skipped the optional platform package, …), `requireCjs("oxc-parser")`
+// itself throws — this is a fundamentally different failure from a per-file
+// parse error. Before this fix, that throw reached `safeParseSync`'s
+// try/catch (added for issue #247's UNRELATED "parseSync itself throws"
+// case) and was silently swallowed there: every file in the scan came back
+// with zero symbols/imports and NO warning at all (only the plain-text
+// `extractImplTags` regex scan kept working, so the tool looked superficially
+// alive while producing an empty graph), and — because the assignment
+// `oxcModule ??= requireCjs(...)` never completes on a throw — `oxcModule`
+// stayed `undefined` forever, so EVERY subsequent file re-attempted the same
+// (also slow) native dlopen and re-threw, once per file.
+//
+// Fixed by treating a load failure as its own distinct, fail-fast error
+// class (`OxcLoadError`) that is deliberately NOT caught by `safeParseSync`
+// (see its own comment) — it propagates all the way out of `buildGraph` /
+// `createTSParser` / `buildSymbolNameTable` uncaught, so the CLI exits
+// non-zero with a clear diagnostic instead of silently producing a
+// zero-extraction graph. The failure (and the resulting `OxcLoadError`
+// instance) is memoized in `oxcLoadError` below SEPARATELY from `oxcModule`
+// so a first-call failure short-circuits every later call in this process —
+// no repeated dlopen attempts — without needing the assignment to have
+// "succeeded" the way `??=` alone would require.
+export class OxcLoadError extends Error {
+  constructor(cause: unknown) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(
+      [
+        "artgraph: failed to load the oxc-parser native binding — TypeScript/JS parsing cannot proceed.",
+        "",
+        `Underlying error: ${detail}`,
+        "",
+        "This usually means one of the following:",
+        "  - oxc-parser's native binding is missing (e.g. an npm/pnpm install that",
+        "    skipped its optional platform-specific package)",
+        "  - node_modules is corrupted or only partially installed",
+        "  - the installed native binary does not match this machine's OS/CPU",
+        "    architecture (e.g. a lockfile/install from a different platform, or a",
+        "    Docker image built for a different target)",
+        "",
+        "To resolve, try:",
+        "  1. Reinstall dependencies from scratch (e.g. `rm -rf node_modules` then",
+        "     reinstall with your package manager)",
+        "  2. Confirm oxc-parser's platform-specific optional dependency is present",
+        "     for THIS OS/architecture (check node_modules/@oxc-parser/binding-*)",
+        "  3. If this happens in CI/Docker, make sure the image architecture matches",
+        "     what was used to install/lock dependencies",
+      ].join("\n"),
+    );
+    this.name = "OxcLoadError";
+    if (cause instanceof Error && cause.stack) {
+      this.stack = `${this.stack}\nCaused by: ${cause.stack}`;
+    }
+  }
+}
+
 let oxcModule: typeof import("oxc-parser") | undefined;
+// Negative cache (issue #263): once loading has failed, EVERY later call
+// re-throws this SAME error instance instead of re-attempting
+// `requireCjs("oxc-parser")` — a native dlopen failure is an environment
+// property that will not change mid-process, so retrying it per file (the
+// pre-fix behavior) only adds cost without any chance of a different
+// outcome.
+let oxcLoadError: OxcLoadError | undefined;
 function loadOxc(): typeof import("oxc-parser") {
-  return (oxcModule ??= requireCjs("oxc-parser") as typeof import("oxc-parser"));
+  if (oxcLoadError) throw oxcLoadError;
+  if (oxcModule) return oxcModule;
+  try {
+    oxcModule = requireCjs("oxc-parser") as typeof import("oxc-parser");
+  } catch (e) {
+    oxcLoadError = new OxcLoadError(e);
+    throw oxcLoadError;
+  }
+  return oxcModule;
 }
 
 type OxcParseResult = import("oxc-parser").ParseResult;
@@ -112,8 +185,14 @@ function buildIdMatchers(codeId?: string): IdMatchers {
 // warning for the pathological-bracket-nesting parse-skip guard below —
 // `symbolId` holds the FILE id (`file:<path>`) for that variant since there
 // is no symbol to attribute to (parsing never ran).
+// issue #264 — a file-level warning for a file `parseTSFile` could not even
+// READ (e.g. permission denied — chmod 000 — or some other transient I/O
+// failure), as opposed to `pathological-bracket-nesting`'s "read fine, but
+// deliberately not handed to the native parser" skip. `symbolId` holds the
+// FILE id (`file:<path>`), same convention as `pathological-bracket-nesting`,
+// since there is no symbol to attribute to (no content was ever read).
 export interface TsParseWarning {
-  type: "class-member-collision" | "pathological-bracket-nesting";
+  type: "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file";
   // Fully-qualified id the warning is about (`symbol:<path>#<name>`, or
   // `file:<path>` for a file-level warning).
   symbolId: string;
@@ -464,7 +543,7 @@ export function maxBracketNestingDepth(content: string): number {
   return max;
 }
 
-interface SafeParseResult {
+export interface SafeParseResult {
   parsed: OxcParseResult | undefined;
   // Set when parsing was skipped because maxBracketNestingDepth exceeded
   // MAX_BRACKET_NESTING_DEPTH — `parsed` is always undefined in that case.
@@ -474,19 +553,31 @@ interface SafeParseResult {
   depthExceeded?: { depth: number; limit: number };
 }
 
-// Single choke point for both parseSync call sites (issue #247): checks the
+// Single choke point for both parseSync call sites (issue #247, and — via
+// `src/trace/symbol-table.ts`'s own call, issue #269 — a third): checks the
 // nesting-depth guard BEFORE calling into the native parser, then falls back
 // to the pre-existing try/catch for the (unrelated, always-been-there) case
 // where parseSync itself throws a catchable JS exception. See
 // MAX_BRACKET_NESTING_DEPTH's doc comment for why the depth guard exists and
 // maxBracketNestingDepth's for why it over-approximates.
-function safeParseSync(filePath: string, content: string): SafeParseResult {
+//
+// issue #263 — `loadOxc()` is called OUTSIDE the try/catch below, on
+// purpose: a load failure (`OxcLoadError`) must propagate uncaught (see
+// `loadOxc`'s own doc comment for why swallowing it here was the actual bug),
+// while a genuinely catchable exception from `parseSync` itself (the
+// original, narrower reason this try/catch exists) is still swallowed exactly
+// as before. Exported so `symbol-table.ts` shares this exact guard instead of
+// calling `loadOxc().parseSync` directly (issue #269 — that direct call
+// bypassed both the depth guard AND, pre-#263, would have bypassed the
+// fail-fast load-error behavior too).
+export function safeParseSync(filePath: string, content: string): SafeParseResult {
   const depth = maxBracketNestingDepth(content);
   if (depth > MAX_BRACKET_NESTING_DEPTH) {
     return { parsed: undefined, depthExceeded: { depth, limit: MAX_BRACKET_NESTING_DEPTH } };
   }
+  const oxc = loadOxc();
   try {
-    return { parsed: loadOxc().parseSync(filePath, content) };
+    return { parsed: oxc.parseSync(filePath, content) };
   } catch {
     return { parsed: undefined };
   }
@@ -504,10 +595,48 @@ function parseTSFile(
   const warnings: TsParseWarning[] = [];
 
   const relPath = relative(rootDir, filePath);
-  const content = stripBom(readFileSync(filePath, "utf-8"));
-  const fileHash = hash(content);
-
   const isTest = /\.(test|spec)\.(ts|tsx)$/.test(filePath);
+
+  // issue #264 — `readFileSync` throws on a file that exists (so the earlier
+  // glob enumerated it) but cannot be READ (chmod 000 / other permission
+  // errors; verified empirically) — asymmetric with `isModuleFile` elsewhere
+  // in this file, which already guards its own read. Pre-fix, this one
+  // uncaught throw took down the ENTIRE scan (`createTSParser`'s `parse()`
+  // loop has no per-file isolation), so a single unreadable file anywhere in
+  // the tree made every command that builds the graph fail outright. Fixed
+  // fail-SAFE (unlike #263's fail-FAST oxc-load guard, which is an
+  // environment-wide condition, not a per-file one): warn, synthesize a bare
+  // file node so the file still exists in the graph (a silently missing node
+  // would surface as harder-to-diagnose downstream symptoms, e.g. spurious
+  // orphans on whatever pointed at it) with a fixed content hash (no content
+  // was ever read, so there is nothing real to hash), and return early —
+  // none of extractSymbols / extractImports / extractImplTags can run
+  // without content, so this file contributes no symbols, imports, or
+  // impl/verifies edges until it becomes readable again.
+  let rawContent: string;
+  try {
+    rawContent = readFileSync(filePath, "utf-8");
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    warnings.push({
+      type: "unreadable-file",
+      symbolId: `file:${relPath}`,
+      filePath: relPath,
+      message:
+        `could not read "${relPath}" (${message}); skipped symbol/import/@impl extraction for ` +
+        "this file. A file node was still created so it stays visible in the graph, but it " +
+        "carries none of its usual edges until the file becomes readable again.",
+    });
+    nodes.push({
+      id: `file:${relPath}`,
+      kind: isTest ? "test" : "file",
+      filePath: relPath,
+      contentHash: hash(""),
+    });
+    return { nodes, edges, warnings };
+  }
+  const content = stripBom(rawContent);
+  const fileHash = hash(content);
 
   nodes.push({
     id: `file:${relPath}`,

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -2101,6 +2101,14 @@ function isModuleFile(filePath: string, ctx: ResolverContext): boolean {
           ));
     }
   } catch {
+    // This catch-all could also swallow an `OxcLoadError`, but that is
+    // unreachable with the current data flow: `isModuleFile` is only called
+    // from `extractImports`, and `extractImports` only runs after that same
+    // file's `safeParseSync` has already succeeded (i.e. `loadOxc` is
+    // confirmed loaded) — and the negative cache never transitions
+    // success-to-failure within a process. If import resolution is ever
+    // parallelized or the parse order changes, this assumption can break;
+    // reconsider re-throwing `OxcLoadError` here in that case (see #263).
     result = false;
   }
   ctx.moduleCheckCache.set(filePath, result);

--- a/src/trace/symbol-table.ts
+++ b/src/trace/symbol-table.ts
@@ -35,16 +35,9 @@
 // attribution rather than guessing (fail-safe, FR-007 / SC-006: REQ
 // reachability is never lost, only symbol PRECISION is).
 
-import { createRequire } from "node:module";
 import { readFileSync } from "node:fs";
 import { relative } from "node:path";
-import { createTSParser, globCodeFiles } from "../parsers/typescript.js";
-
-const requireCjs = createRequire(import.meta.url);
-let oxcModule: typeof import("oxc-parser") | undefined;
-function loadOxc(): typeof import("oxc-parser") {
-  return (oxcModule ??= requireCjs("oxc-parser") as typeof import("oxc-parser"));
-}
+import { createTSParser, globCodeFiles, safeParseSync } from "../parsers/typescript.js";
 
 type OxcProgram = import("oxc-parser").ParseResult["program"];
 type OxcStatement = OxcProgram["body"][number];
@@ -171,12 +164,24 @@ export function buildSymbolNameTable(rootDir: string, includePatterns: string[])
     } catch {
       continue;
     }
-    let parsed: import("oxc-parser").ParseResult | undefined;
-    try {
-      parsed = loadOxc().parseSync(filePath, content);
-    } catch {
-      parsed = undefined;
-    }
+    // issue #269 — this used to call `loadOxc().parseSync(filePath, content)`
+    // directly, via its own COPY of `loadOxc` (bypassing the bracket-depth
+    // guard added for issue #247: a deeply-nested file reaching this call
+    // site natively SIGSEGVs the whole process, taking down every trace
+    // command with it). Routed through the shared `safeParseSync` (the same
+    // choke point `parseTSFile` uses) so this call gets the depth guard for
+    // free and can never drift from it. A `depthExceeded` skip is treated
+    // exactly like any other unparseable file here — `buildSymbolNameTable`
+    // is documented fail-safe (never throws, only loses symbol-name
+    // PRECISION, see this file's header comment), so silently `continue`ing
+    // past a depth-guard-skipped file is consistent with the pre-existing
+    // `catch { continue; }` immediately above for a plain parse exception.
+    // A genuine `OxcLoadError` (issue #263 — the native binding itself is
+    // missing/broken) is deliberately NOT caught by `safeParseSync` and so
+    // propagates uncaught from here too, keeping this call site fail-FAST
+    // for that failure mode, consistent with every other oxc call site in
+    // the codebase.
+    const parsed = safeParseSync(filePath, content).parsed;
     if (!parsed) continue;
 
     for (const stmt of parsed.program.body) {

--- a/templates/skills/_shared/output-schema.md
+++ b/templates/skills/_shared/output-schema.md
@@ -84,7 +84,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -8,6 +8,7 @@ import {
   mkdtempSync,
   rmdirSync,
   rmSync,
+  chmodSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { buildGraph, type BuildWarning } from "../src/graph/builder.js";
@@ -1567,3 +1568,59 @@ describe("buildGraph: negative include patterns (issue #266)", () => {
     expect(implEdges.map((e) => e.target).sort()).toEqual(["REQ-500", "REQ-600"]);
   });
 });
+
+// issue #264 — full `buildGraph` integration. Before this fix, an unreadable
+// file crashed HERE first: the incremental parse-cache path in
+// src/graph/builder.ts reads every code file's content unconditionally (to
+// compute a cache-validity hash) BEFORE any per-file parse ever runs, so an
+// EACCES on that read crashed the whole build even before reaching
+// `parseTSFile`'s own (separately guarded) read. Same
+// permission-error-only-makes-sense-on-POSIX-non-root caveat as
+// tests/typescript.test.ts's equivalent test — see IS_WIN/IS_ROOT there.
+const IS_WIN_264 = process.platform === "win32";
+const IS_ROOT_264 = typeof process.getuid === "function" && process.getuid() === 0;
+
+describe.skipIf(IS_WIN_264 || IS_ROOT_264)(
+  "buildGraph survives an unreadable file in the scan set (issue #264)",
+  () => {
+    let root: string;
+    let unreadablePath: string;
+
+    beforeAll(() => {
+      root = mkdtempSync(join(tmpdir(), "artgraph-builder-unreadable-"));
+      mkdirSync(join(root, "src"), { recursive: true });
+      writeFileSync(join(root, "src/keep.ts"), "export const keep = 1;\n// @impl REQ-264\n");
+      unreadablePath = join(root, "src/broken.ts");
+      writeFileSync(unreadablePath, "export const neverRead = 1;\n");
+      chmodSync(unreadablePath, 0o000);
+    });
+
+    afterAll(() => {
+      chmodSync(unreadablePath, 0o644);
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    const cfg: ArtgraphConfig = {
+      include: ["src/**/*.ts"],
+      specDirs: ["specs"],
+      testPatterns: [],
+      lockFile: ".trace.lock",
+    };
+
+    it("does not throw building the graph", () => {
+      expect(() => buildGraph(root, cfg)).not.toThrow();
+    });
+
+    it("emits an unreadable-file warning and still builds the rest of the graph normally", () => {
+      const { graph, warnings } = buildGraph(root, cfg);
+      const unreadableWarnings = warnings.filter((w) => w.type === "unreadable-file");
+      expect(unreadableWarnings).toHaveLength(1);
+      expect(unreadableWarnings[0].files).toEqual(["src/broken.ts"]);
+
+      expect(graph.nodes.has("file:src/broken.ts")).toBe(true);
+      expect(graph.nodes.has("file:src/keep.ts")).toBe(true);
+      const implEdges = graph.edges.filter((e) => e.kind === "implements");
+      expect(implEdges.map((e) => e.target)).toEqual(["REQ-264"]);
+    });
+  },
+);

--- a/tests/e2e/bin.e2e.test.ts
+++ b/tests/e2e/bin.e2e.test.ts
@@ -10,7 +10,16 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -100,5 +109,56 @@ describe.skipIf(!RUN_PACK)("e2e: npm pack + install", () => {
     const r = spawnSync(binShim, ["--version"], { encoding: "utf-8", timeout: 30000 });
     expect(r.status).toBe(0);
     expect(r.stdout.trim()).toBe(PKG_VERSION);
+  });
+});
+
+// issue #263 — verify the REAL CLI-level error UX for an oxc-parser native
+// binding load failure, spawned as a genuine OS process (the in-process
+// `runCli` harness never reaches `src/cli.ts`'s real-entry-only guard, so it
+// cannot exercise the `OxcLoadError` catch added there). Simulated by
+// temporarily moving this repo's `node_modules/oxc-parser` aside — this
+// suite runs `singleFork`/`fileParallelism:false` (serialized), so no
+// concurrent e2e test can observe the package missing mid-test.
+describe("e2e: oxc-parser native binding load failure (issue #263)", () => {
+  const oxcPath = join(REPO_ROOT, "node_modules", "oxc-parser");
+  const oxcBak = join(REPO_ROOT, "node_modules", "oxc-parser.e2e-bak");
+  let projectDir: string;
+
+  beforeAll(() => {
+    projectDir = mkdtempSync(join(tmpdir(), "artgraph-oxc-load-fail-e2e-"));
+    // Minimal scannable project — content doesn't matter, the load failure
+    // fires before any file-level parsing would happen.
+    mkdirSync(join(projectDir, "src"), { recursive: true });
+    writeFileSync(join(projectDir, "src/a.ts"), "export const a = 1;\n");
+    writeFileSync(
+      join(projectDir, ".artgraph.json"),
+      JSON.stringify({ include: ["src/**/*.ts"], specDirs: [], testPatterns: [] }),
+    );
+    expect(existsSync(oxcPath), "expected node_modules/oxc-parser to exist before this test").toBe(
+      true,
+    );
+    renameSync(oxcPath, oxcBak);
+  });
+
+  afterAll(() => {
+    if (existsSync(oxcBak)) renameSync(oxcBak, oxcPath);
+    if (projectDir) rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it("`scan` exits non-zero with a clean, actionable message — no raw Node stack trace", () => {
+    const r = spawnSync("node", [CLI, "scan"], {
+      cwd: projectDir,
+      encoding: "utf-8",
+      timeout: 15000,
+    });
+    expect(r.status).not.toBe(0);
+    // The crafted diagnostic (cause + fix guidance) must be present…
+    expect(r.stderr).toMatch(/failed to load the oxc-parser native binding/);
+    expect(r.stderr).toMatch(/Reinstall dependencies/i);
+    // …and it must NOT be buried in / followed by a raw Node stack trace —
+    // no `at <fn> (...)` frames and no `node:internal/` frames, the
+    // hallmark of an unhandled-exception dump.
+    expect(r.stderr).not.toMatch(/^\s*at .+\(.+\)/m);
+    expect(r.stderr).not.toMatch(/node:internal\//);
   });
 });

--- a/tests/oxc-load-failure.test.ts
+++ b/tests/oxc-load-failure.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Module } from "node:module";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createTSParser, parseTSFilePaths } from "../src/parsers/typescript.js";
+import { buildSymbolNameTable } from "../src/trace/symbol-table.js";
+
+// issue #263 — before this fix, a broken/missing oxc-parser native binding
+// (the `requireCjs("oxc-parser")` call inside `loadOxc` throwing — e.g. a
+// missing platform-specific optional dependency, corrupted node_modules, or
+// an OS/arch mismatch) was silently swallowed by `safeParseSync`'s
+// catch-all, which exists for an entirely UNRELATED reason (issue #247:
+// `parseSync` itself throwing a catchable exception on some input). The
+// symptom: every file in the scan came back with zero symbols/imports and
+// NO warning anywhere (only the plain-text `extractImplTags` regex scan kept
+// working, so the tool looked superficially alive while silently producing
+// an empty graph), and — since `oxcModule ??= requireCjs(...)` never
+// completes on a throw — the failing native dlopen was re-attempted on
+// EVERY file.
+//
+// These tests simulate that failure by monkey-patching node:module's
+// `Module._load`. `loadOxc` uses `createRequire(import.meta.url)` to obtain
+// a genuine Node CJS `require` function, which resolves through
+// `Module._load` under the hood — unlike a plain ESM import, this is NOT
+// something `vi.mock("oxc-parser", …)` can intercept (verified: Vitest's
+// mock registry only rewrites its own ESM/transform-based module graph, not
+// a raw `Module._load` call reached via `createRequire`), so patching
+// `Module._load` directly is the mechanism that actually reaches this call
+// site.
+//
+// IMPORTANT: `loadOxc`'s failure memoization (the module-scoped
+// `oxcLoadError` variable in src/parsers/typescript.ts) persists for the
+// lifetime of THIS TEST FILE's module instance once poisoned by the first
+// test below — every later call into the TS parser (or anything that calls
+// into it, like `buildSymbolNameTable`) in this same file throws the same
+// cached error, by design (issue #263's whole point: no per-file retry).
+// Vitest isolates module state per test FILE by default, so this cannot leak
+// into other suites; this file is deliberately kept single-purpose (every
+// test here expects the poisoned/throwing state) so that isn't a problem.
+
+function write(rootDir: string, relPath: string, content: string): void {
+  const abs = join(rootDir, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, content);
+}
+
+describe("oxc-parser load failure (issue #263): fail-fast, not silently swallowed", () => {
+  let root: string;
+  let requireAttempts = 0;
+  let originalLoad: (typeof Module)["_load"];
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "artgraph-oxc-load-fail-"));
+    write(root, "src/a.ts", "export const a = 1;\n");
+    write(root, "src/b.ts", "export const b = 2;\n");
+
+    originalLoad = Module._load;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Module as any)._load = function (request: string, ...rest: unknown[]) {
+      if (request === "oxc-parser") {
+        requireAttempts++;
+        throw new Error("simulated missing native binding (ERR_DLOPEN_FAILED)");
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (originalLoad as any).apply(Module, [request, ...rest]);
+    };
+  });
+
+  afterAll(() => {
+    Module._load = originalLoad;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("parseTSFilePaths throws a clear, actionable error instead of silently returning zero symbols", () => {
+    expect(() => parseTSFilePaths(root, [join(root, "src/a.ts")], "symbol")).toThrow(/oxc-parser/i);
+
+    let caught: unknown;
+    try {
+      parseTSFilePaths(root, [join(root, "src/a.ts")], "symbol");
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const message = (caught as Error).message;
+    expect(message).toMatch(/native binding/i);
+    expect(message).toMatch(/reinstall/i);
+    expect(message).toMatch(/node_modules/);
+  });
+
+  it("createTSParser().parse() over multiple files also throws (does not fail-open per file)", () => {
+    expect(() => createTSParser(root, ["src/**/*.ts"], "symbol").parse()).toThrow(/oxc-parser/i);
+  });
+
+  it("buildSymbolNameTable propagates the same fail-fast error (issue #269 alignment — no independent, silently-fail-open loadOxc copy)", () => {
+    expect(() => buildSymbolNameTable(root, ["src/**/*.ts"])).toThrow(/oxc-parser/i);
+  });
+
+  it("never retries the native require after the first failure across every call above (negative cache)", () => {
+    expect(requireAttempts).toBe(1);
+  });
+});

--- a/tests/symbol-table.test.ts
+++ b/tests/symbol-table.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { buildSymbolNameTable } from "../src/trace/symbol-table.js";
+import { MAX_BRACKET_NESTING_DEPTH } from "../src/parsers/typescript.js";
+
+// issue #269 — `buildSymbolNameTable`'s "Source 2" class-member walk used to
+// call `loadOxc().parseSync(filePath, content)` DIRECTLY, via its own copy of
+// `loadOxc`, bypassing the bracket-nesting depth guard added for issue #247
+// (`safeParseSync` in src/parsers/typescript.ts). A file whose bracket
+// nesting is deep enough natively SIGSEGVs oxc-parser's Rust binding — not a
+// catchable JS exception — so this call site could crash the whole process
+// for trace-dependent commands, even though `createTSParser`'s own parse
+// path (Source 1, used earlier in the same function) was already guarded.
+//
+// Fixed by routing through the shared, exported `safeParseSync` instead.
+// This test uses a depth (2,000) that is safely ABOVE
+// MAX_BRACKET_NESTING_DEPTH (so the guard's skip path is exercised) and
+// safely BELOW the empirically observed ~3,500 native crash threshold (so
+// running it in-process here — without the fix — would still be expected to
+// SIGSEGV per issue #247's own canary, not merely misbehave; this pins the
+// SKIP behavior itself rather than re-proving the underlying native crash,
+// which tests/parser-oxc-canary.test.ts already does via subprocess
+// isolation).
+function write(rootDir: string, relPath: string, content: string): void {
+  const abs = join(rootDir, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, content);
+}
+
+const PATHOLOGICAL_DEPTH = 2000;
+
+// Pin the fixture's premise: the depth must sit ABOVE the guard threshold
+// (or this suite silently stops exercising the skip path if the constant is
+// ever raised past it — see the doc comment above for the upper bound too).
+if (PATHOLOGICAL_DEPTH <= MAX_BRACKET_NESTING_DEPTH) {
+  throw new Error(
+    `fixture depth ${PATHOLOGICAL_DEPTH} no longer exceeds MAX_BRACKET_NESTING_DEPTH (${MAX_BRACKET_NESTING_DEPTH}) — bump PATHOLOGICAL_DEPTH`,
+  );
+}
+
+describe("buildSymbolNameTable survives a pathologically deep-bracket-nesting file (issue #269)", () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "artgraph-symtable-269-"));
+    write(
+      root,
+      "src/normal.ts",
+      ["export class Cart {", "  add(): number {", "    return 1;", "  }", "}", ""].join("\n"),
+    );
+    write(
+      root,
+      "src/pathological.ts",
+      [
+        "export class Deep {",
+        "  compute(): number {",
+        `    return ${"(".repeat(PATHOLOGICAL_DEPTH)}1${")".repeat(PATHOLOGICAL_DEPTH)};`,
+        "  }",
+        "}",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("does not crash (does not throw / SIGSEGV) building the table over a set containing a pathological file", () => {
+    expect(() => buildSymbolNameTable(root, ["src/**/*.ts"])).not.toThrow();
+  });
+
+  it("still resolves a normal file's class-member name to the member's own symbol id", () => {
+    const table = buildSymbolNameTable(root, ["src/**/*.ts"]);
+    expect(table.hasFile("src/normal.ts")).toBe(true);
+    expect(table.resolve("src/normal.ts", "add")).toEqual({
+      kind: "symbol",
+      id: "symbol:src/normal.ts#Cart.add",
+    });
+  });
+
+  it("fails safe (file-fallback, never a crash) resolving a name inside the pathological file — its class member was never symbolized", () => {
+    const table = buildSymbolNameTable(root, ["src/**/*.ts"]);
+    expect(table.hasFile("src/pathological.ts")).toBe(true);
+    expect(table.resolve("src/pathological.ts", "compute")).toEqual({
+      kind: "file-fallback",
+      id: "file:src/pathological.ts",
+    });
+  });
+});

--- a/tests/typescript.test.ts
+++ b/tests/typescript.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { createTSParser, globCodeFiles, hash } from "../src/parsers/typescript.js";
 
 const FIXTURE_DIR = resolve(import.meta.dirname, "fixtures");
+
+// Filesystem-permission tests (issue #264) only make sense on POSIX, as a
+// non-root user — root bypasses mode bits entirely, so the chmod-induced
+// EACCES these tests rely on never fires. Same convention as
+// tests/doctor.test.ts / tests/agents/distribute.test.ts.
+const IS_WIN = process.platform === "win32";
+const IS_ROOT = typeof process.getuid === "function" && process.getuid() === 0;
 
 describe("createTSParser", () => {
   const parser = createTSParser(FIXTURE_DIR, ["src/**/*.ts", "tests/**/*.ts"]);
@@ -1762,3 +1769,84 @@ describe("globCodeFiles (issue #266 — negative glob patterns)", () => {
     expect(parsedFiles).toEqual(["src/keep.ts", "src/other/skip.ts"]);
   });
 });
+
+// issue #264 — `parseTSFile`'s `readFileSync` used to be unguarded: a single
+// unreadable file (permission error, verified empirically via chmod 000)
+// crashed the ENTIRE scan with an uncaught exception, asymmetric with
+// `isModuleFile` elsewhere in this module, which already guards its own
+// read. Fixed to warn (`unreadable-file`) and synthesize a bare file node
+// for that ONE file while scanning continues normally for every other file.
+describe.skipIf(IS_WIN || IS_ROOT)(
+  "createTSParser survives an unreadable file in the scan set (issue #264)",
+  () => {
+    let root: string;
+    let unreadablePath: string;
+
+    beforeAll(() => {
+      root = mkdtempSync(join(tmpdir(), "artgraph-unreadable-file-"));
+      mkdirSync(join(root, "src"), { recursive: true });
+      writeFileSync(join(root, "src/normal-target.ts"), "export const helloTarget = 1;\n");
+      writeFileSync(
+        join(root, "src/normal.ts"),
+        [
+          'import { helloTarget } from "./normal-target.js";',
+          "// @impl CANARY-264",
+          "export function normalFn(): number {",
+          "  return helloTarget;",
+          "}",
+          "",
+        ].join("\n"),
+      );
+      unreadablePath = join(root, "src/unreadable.ts");
+      writeFileSync(unreadablePath, "export const neverRead = 1;\n");
+      chmodSync(unreadablePath, 0o000);
+    });
+
+    afterAll(() => {
+      chmodSync(unreadablePath, 0o644);
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    it("does not throw scanning a directory containing an unreadable file", () => {
+      expect(() => createTSParser(root, ["src/**/*.ts"], "symbol").parse()).not.toThrow();
+    });
+
+    it("emits exactly one unreadable-file warning for the unreadable file", () => {
+      const result = createTSParser(root, ["src/**/*.ts"], "symbol").parse();
+      const unreadableWarnings = result.warnings.filter((w) => w.type === "unreadable-file");
+      expect(unreadableWarnings).toHaveLength(1);
+      expect(unreadableWarnings[0].filePath).toBe("src/unreadable.ts");
+      expect(unreadableWarnings[0].symbolId).toBe("file:src/unreadable.ts");
+      expect(unreadableWarnings[0].message).toContain("src/unreadable.ts");
+    });
+
+    it("still creates a bare file node for the unreadable file, with no symbols/imports", () => {
+      const result = createTSParser(root, ["src/**/*.ts"], "symbol").parse();
+      const node = result.nodes.find((n) => n.filePath === "src/unreadable.ts");
+      expect(node?.kind).toBe("file");
+      expect(result.nodes.some((n) => n.id.startsWith("symbol:src/unreadable.ts#"))).toBe(false);
+      expect(result.edges.some((e) => e.source === "file:src/unreadable.ts")).toBe(false);
+    });
+
+    it("keeps extracting the normal file's imports/symbols/@impl tags unaffected", () => {
+      const result = createTSParser(root, ["src/**/*.ts"], "symbol").parse();
+      expect(
+        result.edges.some(
+          (e) =>
+            e.kind === "imports" &&
+            e.source === "file:src/normal.ts" &&
+            e.target === "symbol:src/normal-target.ts#helloTarget",
+        ),
+      ).toBe(true);
+      expect(result.nodes.some((n) => n.id === "symbol:src/normal.ts#normalFn")).toBe(true);
+      expect(
+        result.edges.some(
+          (e) =>
+            e.kind === "implements" &&
+            e.source === "symbol:src/normal.ts#normalFn" &&
+            e.target === "CANARY-264",
+        ),
+      ).toBe(true);
+    });
+  },
+);


### PR DESCRIPTION
## Summary

parser 堅牢性まとめの PR 2/2 (1/2 は #272 の警告可視化基盤 + 負パターン)。「パーサ/環境の失敗がサイレントに握りつぶされる」経路 3 件を塞ぐ。

**#263 (blocker) — oxc ロード失敗の完全サイレント劣化を fail-fast 化** (承認済み方針)

ネイティブバインディング欠落/破損環境では `loadOxc()` の throw を `safeParseSync` が飲み込み、全ファイルで symbol/imports 抽出がゼロになるのに警告ゼロ (@impl regex スキャンだけ生き残り一見動いて見える)。さらにメモ化が代入前 throw で効かず毎ファイル dlopen 再試行。

- `OxcLoadError` (専用エラー型) を新設し、ロード失敗を per-file パース失敗と区別して `safeParseSync` の catch の**外側**で素通し → `buildGraph` / `createTSParser` / `buildSymbolNameTable` まで無捕捉で伝播し fail-fast
- 負キャッシュでロード失敗確定後は dlopen を再試行しない
- `cli.ts` エントリポイントで `OxcLoadError` **のみ**整形メッセージ (原因候補: バインディング欠落・プラットフォーム不一致・node_modules 破損 / 対処法付き) + exit 1。他のエラー型の既定挙動 (stack trace) は不変 — 既存の「全エラー共通で stack を出す」方針への最小限の例外で、承認済みの「明確なエラーメッセージで停止」を満たすためのもの

**#264 — 読み取り不能ファイル 1 個で scan 全体がクラッシュ → 警告 + スキップ継続**

`parseTSFile` の `readFileSync` が無ガード (chmod 000 で実証済み)。調査の過程で、`builder.ts` の parse-cache 有効性判定の `readFileSync` が `parseTSFile` より**先に**同じ理由で落ちることも発見し、あわせてガード (常に cache miss 扱い、警告発行は `parseTSFile` 側に一本化)。`unreadable-file` を `BuildWarning` に追加 — #272 の配線により全コマンドで見える。

**#269 — symbol-table の SIGSEGV ガード適用漏れ**

`symbol-table.ts` が `loadOxc().parseSync` を直接呼び #261 のブラケット深度ガードを経由していなかった (深いネストのファイルで trace 系コマンドがプロセスごと SIGSEGV)。独自 `loadOxc` コピーを削除し、export 化した `safeParseSync` に統一 (深度超過は file-fallback の安全側挙動)。

Closes #263
Closes #264
Closes #269

## Change type

- [x] fix (bug fix)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — 全 suite green (88 files / 2092 passed / 11 skipped — chmod 系は root 環境で意図的スキップ、非 root での実動作は個別検証済み)
- [x] Added tests where needed — oxc require 失敗シミュレーション (fail-fast / 負キャッシュ = dlopen 1 回 / symbol-table への伝播)、chmod 000 読み取り不能ファイル (Windows/root ガード付き)、深ネスト fixture での symbol-table 非クラッシュ + 閾値前提のピン、実バイナリ E2E (oxc パッケージ退避 → 整形エラー・stack なし・exit 1)
- [x] Ran `pnpm -r knip` and `pnpm -r build`
- `artgraph check --diff`: No new issues introduced by this change。`doctor` 54 pass (Skills 配布コピーのドリフトなし — output-schema.md の型 union 同期を含む)

## Breaking change

- [ ] Yes (described below)
- [x] No

挙動変化は「壊れた環境でサイレントに空の結果を返していたものが、明確なエラーで停止する」(#263) と「クラッシュしていたものが警告 + 継続になる」(#264/#269) のみ。健全な環境での出力・lock は不変。

## Notes

- `SCHEMA_VERSION` (parse-cache) は据え置き — pre-fix では読み取り不能ファイル存在時に `writeParseCache` へ到達しないため、古い fragment の誤再利用リスクなし
- vitest capture plugin (`src/vitest/plugin.ts`) の独自 `loadOxc` はスコープ外 (capture 側は #270 の記録名契約と同じ領域のため)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg)_