### PR TITLE
feat(lock): .trace.lock に _meta.schemaVersion スタンプを追加 — 新しい lock への書き換えを拒否し読み取りは警告 (#243)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -239,7 +239,7 @@ Typically fired by the `artgraph-plan-coverage` Skill after `/speckit-tasks`
 or after editing `.kiro/specs/<name>/tasks.md`. Manual invocation is fine
 during troubleshooting.
 
-## `artgraph reconcile`
+## `artgraph reconcile` <a id="artgraph-reconcile"></a>
 
 Rebuild `.trace.lock` from the current graph. Run after intentional spec/code/
 test edits when `artgraph check` reports drift you accept.
@@ -249,6 +249,16 @@ artgraph reconcile
 ```
 
 `rename` runs this automatically after a non-preview rename.
+
+**Lock schema version**: `.trace.lock` carries a `_meta.schemaVersion` stamp.
+If the on-disk lock was written by a *newer* artgraph than the one running
+`reconcile` (or `rename`, or `init`'s initial scan), the write is refused with
+a clear error — rebuilding it here would silently discard information the
+newer CLI understood. `--force` overwrites it anyway (a "Downgrading lock
+schema vN -> vM" notice is printed, and newer entries may be lost). If this
+happens because **CI is pinned to an older artgraph version**, update CI's
+artgraph instead of reaching for `--force` there — `--force` on every CI run
+just repeatedly discards whatever the newer local CLI wrote.
 
 ## `artgraph rename`
 
@@ -276,6 +286,12 @@ Notes:
   renamed ID is guaranteed to be re-discoverable by the next scan.
 - After a non-preview run the lock is automatically reconciled, so
   `artgraph check` passes immediately for `rename` and `merge`.
+- **Lock schema version**: like `reconcile`, a non-preview `rename` refuses to
+  touch a `.trace.lock` written by a newer artgraph unless `--force` is given
+  (see the note under [`artgraph reconcile`](#artgraph-reconcile) above).
+  `--dry-run` also warns on a newer-schema lock (it never writes, so it isn't
+  rejected) — the same "update CI's artgraph, don't `--force` it" guidance
+  applies.
 
 ### rename does not reassign `@impl` tags <a id="rename-does-not-reassign-impl-tags"></a>
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -37,11 +37,15 @@ export function registerCheckCommand(program: Command): void {
       }
       const { loadConfig } = await import("../config.js");
       const { scan } = await import("../scan.js");
-      const { readLock } = await import("../lock.js");
+      const { readLockWithMeta, warnIfNewerLockSchema } = await import("../lock.js");
       const { check } = await import("../check.js");
       const config = loadConfig(rootDir);
       const { graph, warnings } = scan(rootDir, config);
-      const lock = readLock(rootDir, config.lockFile);
+      // issue #243 — `check` is read-only w.r.t. the lock: a newer-schema
+      // lock is still readable (unknown fields are simply invisible), so
+      // warn and keep going rather than fail like the write paths do.
+      const { lock, schemaVersion } = readLockWithMeta(rootDir, config.lockFile);
+      warnIfNewerLockSchema(schemaVersion, config.lockFile);
 
       const testResults = await resolveTestResults(config, rootDir);
 

--- a/src/commands/impact.ts
+++ b/src/commands/impact.ts
@@ -105,7 +105,7 @@ export function registerImpactCommand(program: Command): void {
 
       const { loadConfig } = await import("../config.js");
       const { scan } = await import("../scan.js");
-      const { readLock } = await import("../lock.js");
+      const { readLockWithMeta, warnIfNewerLockSchema } = await import("../lock.js");
       const { entryOriginIds, impact, resolveStartIds, resolveOriginReqs } =
         await import("../graph/traverse.js");
       const config = loadConfig(rootDir);
@@ -128,7 +128,10 @@ export function registerImpactCommand(program: Command): void {
       // `check --diff`'s equivalent branch) and to the final output at the
       // bottom of this action.
       const { graph, warnings } = scan(rootDir, config);
-      const lock = readLock(rootDir, config.lockFile);
+      // issue #243 — read-only w.r.t. the lock: warn on a newer schema and
+      // keep going (see commands/check.ts's identical comment).
+      const { lock, schemaVersion } = readLockWithMeta(rootDir, config.lockFile);
+      warnIfNewerLockSchema(schemaVersion, config.lockFile);
 
       // spec 020 (FR-017) — load evidence once, resolve the staleness
       // exclusion set (only when `trace.staleness === "exclude"`) so both the

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -14,7 +14,7 @@ export function registerInitCommand(program: Command): void {
     )
     .option(
       "--force",
-      "Overwrite existing .artgraph.json, distributed Skill files, and integration files. Refuses symlinks even with --force.",
+      "Overwrite existing .artgraph.json, distributed Skill files, and integration files. Also overrides the lock schema-version write guard (downgrades a newer-schema .trace.lock, printing a warning; see `artgraph reconcile`). Refuses symlinks even with --force.",
     )
     .option("--minimal", "Bare config only — opt out of every extra setup stage")
     // Stage opt-outs (in default mode)

--- a/src/commands/reconcile.ts
+++ b/src/commands/reconcile.ts
@@ -7,10 +7,15 @@ export function registerReconcileCommand(program: Command): void {
   program
     .command("reconcile")
     .description("Update the lock file to match current state")
-    .action(async () => {
+    .option(
+      "--force",
+      "Overwrite a lock file written by a newer artgraph (lock schema version newer than this CLI supports)",
+    )
+    .action(async (opts) => {
       const rootDir = process.cwd();
       const { loadConfig } = await import("../config.js");
       const { scan, reconcile } = await import("../scan.js");
+      const { LockSchemaVersionError } = await import("../lock.js");
       const config = loadConfig(rootDir);
       // issue #265 — `warnings` used to be discarded here, so a
       // `pathological-bracket-nesting` / `class-member-collision` build
@@ -18,7 +23,19 @@ export function registerReconcileCommand(program: Command): void {
       // `--format json` mode, so this always prints (mirrors scan/init/check's
       // text-mode behavior).
       const { graph, warnings } = scan(rootDir, config);
-      reconcile(rootDir, config, graph);
+      // issue #243 — a lock schema newer than this CLI understands is a hard
+      // stop (not a silent coarse rebuild): print a clear, actionable error
+      // and exit non-zero instead of letting the exception's raw stack
+      // trace fall through commander's default handling.
+      try {
+        reconcile(rootDir, config, graph, { force: Boolean(opts.force) });
+      } catch (e) {
+        if (e instanceof LockSchemaVersionError) {
+          console.error(`Error: ${e.message}`);
+          process.exit(1);
+        }
+        throw e;
+      }
       console.log(`Lock file updated: ${config.lockFile}`);
       reportGraphWarnings(warnings);
     });

--- a/src/commands/rename.ts
+++ b/src/commands/rename.ts
@@ -14,6 +14,10 @@ export function registerRenameCommand(program: Command): void {
     .option("--merge <ids...>", "Source IDs to merge")
     .option("--into <ids...>", "Target ID(s) for split or merge")
     .option("--dry-run", "Show changes without applying them")
+    .option(
+      "--force",
+      "Overwrite a lock file written by a newer artgraph (lock schema version newer than this CLI supports). Ignored with --dry-run, which never touches the lock.",
+    )
     .addOption(
       new Option("--format <format>", "Output format").choices(["json", "text"]).default("text"),
     )
@@ -21,7 +25,7 @@ export function registerRenameCommand(program: Command): void {
       const rootDir = process.cwd();
       const { executeRename, executeSplit, executeMerge } = await import("../rename-executor.js");
       const format: "json" | "text" = opts.format;
-      const baseOpts = { dryRun: !!opts.dryRun, format, rootDir };
+      const baseOpts = { dryRun: !!opts.dryRun, format, rootDir, force: !!opts.force };
 
       const fail = (msg: string): never => {
         // Honour --format json even on the error path so JSON consumers never

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -41,7 +41,7 @@ export function registerScanCommand(program: Command): void {
       }
 
       if (opts.serve || opts.output) {
-        const { readLock } = await import("../lock.js");
+        const { readLockWithMeta, warnIfNewerLockSchema } = await import("../lock.js");
         const { check } = await import("../check.js");
         const { renderGraphData } = await import("../graph/render.js");
         const { startServer, writeStaticExport } = await import("../graph/serve.js");
@@ -52,7 +52,11 @@ export function registerScanCommand(program: Command): void {
         // swallowing them would hide real repo corruption.
         let checkResult;
         try {
-          const lock = readLock(rootDir, config.lockFile);
+          const { lock, schemaVersion } = readLockWithMeta(rootDir, config.lockFile);
+          // issue #243 — this render path is read-only w.r.t. the lock: warn
+          // on a newer schema and keep going (see commands/check.ts's
+          // identical comment).
+          warnIfNewerLockSchema(schemaVersion, config.lockFile);
           if (Object.keys(lock).length > 0) {
             checkResult = check(result.graph, lock);
           }

--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -224,6 +224,24 @@ export function buildGraph(
         // Kit's SC-NNN Success Criteria are outcome statements, not
         // implementation-trackable requirements).
         if (node.kind === "req" && isIgnoredId(node.id)) continue;
+        // F1 (meta-review, issue #243 follow-up) — `_meta` is the lock file's
+        // reserved top-level stamp key (see lock.ts's `writeLock` /
+        // `readLockWithMeta`). A node whose id is EXACTLY `_meta` — whether
+        // from a user-defined `reqPatterns` match (req/task) or a frontmatter
+        // `artgraph: { node_id: _meta }` (doc, checked here before the
+        // doc/nonReqNodes split below) — would overwrite the stamp on the
+        // next lock write and become invisible on the next read
+        // (`writeLock` now hard-fails on this instead of silently
+        // corrupting the lock, but warning here catches it at scan time,
+        // before a write is ever attempted).
+        if (node.id === "_meta") {
+          warnings.push({
+            type: "reserved-prefix",
+            id: node.id,
+            files: [node.filePath],
+            message: `${node.kind} ID "_meta" collides with the lock file's reserved _meta key; this entry would be lost when the lock is written. Rename it.`,
+          });
+        }
         if (node.kind === "req" || node.kind === "task") {
           // T028: reserved-prefix warning
           if (RESERVED_PREFIXES.some((p) => node.id.startsWith(p))) {

--- a/src/init.ts
+++ b/src/init.ts
@@ -651,7 +651,11 @@ export function runInit(rootDir: string, options: InitOptions = {}): InitResult 
 
   if (stages.scan) {
     const scanResult = scan(abs, config);
-    reconcile(abs, config, scanResult.graph);
+    // issue #243 — `init --force` already means "overwrite existing
+    // conflicting state" (config / Skills / integration files); extending it
+    // to a newer-schema lock keeps that meaning consistent instead of
+    // requiring a second, redundant force flag just for this one stage.
+    reconcile(abs, config, scanResult.graph, { force: options.force ?? false });
     scanSummary = {
       nodeCount: scanResult.nodeCount,
       edgeCount: scanResult.edgeCount,

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -99,12 +99,31 @@ export function readLockWithMeta(rootDir: string, lockPath: string): ReadLockRes
   // a non-object top level would cause cryptic TypeErrors in rename / merge.
   validateLockSchema(parsed);
   const { _meta, ...entries } = parsed as { _meta?: unknown } & Record<string, unknown>;
-  const schemaVersion =
-    _meta &&
-    typeof _meta === "object" &&
-    typeof (_meta as { schemaVersion?: unknown }).schemaVersion === "number"
-      ? (_meta as { schemaVersion: number }).schemaVersion
-      : 0;
+  let schemaVersion = 0;
+  if (_meta !== undefined) {
+    const raw =
+      _meta && typeof _meta === "object" && !Array.isArray(_meta)
+        ? (_meta as { schemaVersion?: unknown }).schemaVersion
+        : undefined;
+    // F2/F3 (meta-review, issue #243 follow-up): `_meta` is present but its
+    // `schemaVersion` cannot be read as a non-negative integer — a string,
+    // an array, `null`, a bare `{}` with no `schemaVersion` field, a
+    // non-integer (1.5), or a negative number. Previously this fell through
+    // to legacy (0) with NO warning, indistinguishable from a genuine
+    // pre-#243 lock that never had a `_meta` key at all — silently hiding a
+    // corrupted or hand-edited stamp. This is a deliberate fail-open: warn
+    // once to stderr, then keep treating the lock as schema v0 (legacy)
+    // rather than blocking every read-only command on a malformed stamp.
+    if (typeof raw === "number" && Number.isInteger(raw) && raw >= 0) {
+      schemaVersion = raw;
+    } else {
+      console.error(
+        `Warning: ${fullPath} has a malformed _meta.schemaVersion (${JSON.stringify(raw)}); ` +
+          `expected a non-negative integer. Treating this lock as schema v0 (legacy).`,
+      );
+      schemaVersion = 0;
+    }
+  }
   return { lock: entries as LockFile, schemaVersion };
 }
 
@@ -126,7 +145,19 @@ export function assertLockSchemaWritable(
   lockFile: string,
   force: boolean,
 ): void {
-  if (schemaVersion <= LOCK_SCHEMA_VERSION || force) return;
+  if (schemaVersion <= LOCK_SCHEMA_VERSION) return;
+  if (force) {
+    // F5 (meta-review) — `--force` on init/reconcile/rename means "downgrade
+    // the lock and accept the loss", not "silently pretend nothing
+    // happened". Without this, the exact PR #242 failure mode (newer
+    // fine-grained entries coarsened/overwritten with no trace) reappears
+    // for anyone who reaches for `--force` without realizing this guard is
+    // what it's overriding.
+    console.error(
+      `Downgrading lock schema v${schemaVersion} -> v${LOCK_SCHEMA_VERSION} (newer entries may be lost): ${lockFile}`,
+    );
+    return;
+  }
   throw new LockSchemaVersionError(
     `${lockFile} was written by a newer version of artgraph (lock schema v${schemaVersion}; ` +
       `this CLI only understands up to v${LOCK_SCHEMA_VERSION}). Rebuilding it with this CLI ` +
@@ -156,13 +187,35 @@ export function writeLock(rootDir: string, lockPath: string, lock: LockFile): vo
   const fullPath = resolve(rootDir, lockPath);
   assertWithinRoot(rootDir, fullPath);
   const tmpPath = resolve(dirname(fullPath), `.${basename(fullPath)}.tmp`);
-  // issue #243 — `_meta` is always stamped fresh on every write, first key
-  // (object spread preserves `lock`'s own key order after it). This is what
-  // makes rename/split/merge's "_meta survives a key-move" requirement a
-  // non-issue: `renameLockKey`/`splitLockKey`/`mergeLockKeys` operate on the
-  // entry-only `LockFile` (no `_meta` key ever reaches them, see `readLock`
-  // above), and the subsequent `reconcile()` → `writeLock()` re-stamps
-  // `_meta` unconditionally regardless of what keys moved.
+  // F1 (meta-review, issue #243 follow-up): `_meta` is the reserved top-level
+  // stamp key stamped below. If `lock` itself already carries a bare `_meta`
+  // entry — from a user-defined `reqPatterns` match, or a markdown
+  // frontmatter `artgraph: { node_id: _meta }` doc id accepted with no
+  // validation (see `src/parsers/markdown.ts`'s `docId`) — the object spread
+  // below would let that entry silently win over the stamp (a later
+  // duplicate key wins, and `lock`'s own `_meta` comes after the stamp
+  // literal in `{ _meta: stamp, ...lock }`). The file on disk would then have
+  // a `_meta` that is actually a `LockEntry`, not `{ schemaVersion }` — the
+  // next `readLockWithMeta` strips it out as "meta", making the real entry
+  // invisible and mis-reporting schemaVersion 0. Fail loudly instead of
+  // silently corrupting the lock; `src/graph/builder.ts` also warns on this
+  // exact-match collision at scan time, before it ever reaches a write.
+  if (Object.prototype.hasOwnProperty.call(lock, "_meta")) {
+    throw new Error(
+      `Refusing to write ${fullPath}: the entry map contains a reserved "_meta" key, which ` +
+        `would silently overwrite the lock schema stamp on write and make the entry invisible ` +
+        `on the next read. This can come from a req/task ID that is literally "_meta" (check a ` +
+        `custom reqPatterns match) or a markdown frontmatter "artgraph: { node_id: _meta }". ` +
+        `Rename the offending ID and re-run.`,
+    );
+  }
+  // issue #243 — `_meta` is stamped fresh on every write. The reader
+  // (`readLockWithMeta`) separates it from the entry map BY NAME (object
+  // destructuring), not by key position, so the key order here is cosmetic
+  // and never load-bearing: `renameLockKey`/`splitLockKey`/`mergeLockKeys`
+  // operate on the entry-only `LockFile` (no `_meta` key ever reaches them,
+  // see `readLock` above), and the subsequent `reconcile()` → `writeLock()`
+  // re-stamps `_meta` unconditionally regardless of what keys moved.
   const stamped = { _meta: { schemaVersion: LOCK_SCHEMA_VERSION }, ...lock };
   writeFileSync(tmpPath, JSON.stringify(stamped, null, 2) + "\n", "utf-8");
   renameSync(tmpPath, fullPath);

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -32,7 +32,32 @@ export class LockSchemaError extends Error {
   }
 }
 
-function validateLockSchema(lock: unknown): asserts lock is LockFile {
+// issue #243 — lock schema version stamp. Mirrors `parse-cache.ts`'s
+// `SCHEMA_VERSION` convention: bump this whenever the on-disk `LockEntry`
+// shape gains/changes a field a strictly-older reader would silently
+// misinterpret (e.g. spec 021's method-grain symbol entries). Before this
+// stamp existed, an OLDER CLI's `reconcile` on a lock a NEWER CLI wrote would
+// rebuild the lock from ITS OWN (coarser) model and silently overwrite the
+// finer-grained entries — no warning, exit 0 (PR #242 review). `_meta` is a
+// reserved top-level key (`{ "_meta": { "schemaVersion": N }, "<nodeId>":
+// {...}, ... }`); a lock predating this field has no `_meta` key at all,
+// which is treated as schemaVersion 0 (legacy) throughout this module.
+export const LOCK_SCHEMA_VERSION = 1;
+
+/**
+ * Thrown by the lock-WRITE guard (`assertLockSchemaWritable`) when the
+ * on-disk lock's `_meta.schemaVersion` is newer than this build understands
+ * and the caller did not pass `force`. Distinct from `LockSchemaError` (shape
+ * corruption) — this is a version mismatch, not malformed JSON.
+ */
+export class LockSchemaVersionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LockSchemaVersionError";
+  }
+}
+
+function validateLockSchema(lock: unknown): asserts lock is Record<string, unknown> {
   if (lock === null || typeof lock !== "object" || Array.isArray(lock)) {
     throw new LockSchemaError(
       `LockFile must be a JSON object at the top level. Delete .trace.lock and run \`artgraph reconcile\` to regenerate.`,
@@ -40,28 +65,106 @@ function validateLockSchema(lock: unknown): asserts lock is LockFile {
   }
 }
 
-export function readLock(rootDir: string, lockPath: string): LockFile {
+export interface ReadLockResult {
+  /** Entry map only — `_meta` is never present as a key here (INV: every
+   * existing consumer that iterates a `LockFile` as an entry map — drift
+   * checks, rename/merge, plan-coverage — must never see `_meta` as a
+   * pseudo-entry). */
+  lock: LockFile;
+  /** `_meta.schemaVersion` from the on-disk file, or `0` when absent (no
+   * lock file at all, or a pre-#243 lock with no `_meta` key). */
+  schemaVersion: number;
+}
+
+/**
+ * Reads the lock file and separates the reserved `_meta` stamp from the
+ * entry map. `readLock` (below) is a thin wrapper that discards
+ * `schemaVersion` for the many existing call sites that only ever consumed
+ * entries; call sites that need to gate on version (write paths via
+ * `assertLockSchemaWritable`, read-only paths via `warnIfNewerLockSchema`)
+ * use this directly instead.
+ */
+export function readLockWithMeta(rootDir: string, lockPath: string): ReadLockResult {
   const fullPath = resolve(rootDir, lockPath);
-  if (!existsSync(fullPath)) return {};
+  if (!existsSync(fullPath)) return { lock: {}, schemaVersion: 0 };
   let parsed: unknown;
   try {
     parsed = JSON.parse(readFileSync(fullPath, "utf-8"));
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     console.error(`Warning: failed to parse ${fullPath}, treating as empty: ${msg}`);
-    return {};
+    return { lock: {}, schemaVersion: 0 };
   }
   // Schema validation is a hard fail (LockSchemaError), not a soft warning:
   // a non-object top level would cause cryptic TypeErrors in rename / merge.
   validateLockSchema(parsed);
-  return parsed;
+  const { _meta, ...entries } = parsed as { _meta?: unknown } & Record<string, unknown>;
+  const schemaVersion =
+    _meta &&
+    typeof _meta === "object" &&
+    typeof (_meta as { schemaVersion?: unknown }).schemaVersion === "number"
+      ? (_meta as { schemaVersion: number }).schemaVersion
+      : 0;
+  return { lock: entries as LockFile, schemaVersion };
+}
+
+export function readLock(rootDir: string, lockPath: string): LockFile {
+  return readLockWithMeta(rootDir, lockPath).lock;
+}
+
+/**
+ * Write-path guard (issue #243): refuse to rebuild/overwrite a lock whose
+ * on-disk `_meta.schemaVersion` is newer than `LOCK_SCHEMA_VERSION`, unless
+ * `force` is set. Callers: `scan.ts#reconcile` (the sole `writeLock` call
+ * site) and `rename-executor.ts` (fail BEFORE any source file is rewritten,
+ * so a rejected rename never leaves spec/code files mutated with no matching
+ * lock update). Read-only commands (check/impact/plan-coverage) must NOT
+ * call this — they call `warnIfNewerLockSchema` instead and keep running.
+ */
+export function assertLockSchemaWritable(
+  schemaVersion: number,
+  lockFile: string,
+  force: boolean,
+): void {
+  if (schemaVersion <= LOCK_SCHEMA_VERSION || force) return;
+  throw new LockSchemaVersionError(
+    `${lockFile} was written by a newer version of artgraph (lock schema v${schemaVersion}; ` +
+      `this CLI only understands up to v${LOCK_SCHEMA_VERSION}). Rebuilding it with this CLI ` +
+      `would silently discard information the newer CLI wrote (e.g. finer-grained entries). ` +
+      `Update artgraph to the version that wrote this lock, or re-run with --force to overwrite ` +
+      `it anyway (accepting that loss).`,
+  );
+}
+
+/**
+ * Read-only-path warning (issue #243): a newer-schema lock is still readable
+ * (unknown fields are simply invisible to this build), so `check` / `impact`
+ * / `plan-coverage` continue rather than fail — but a silent continue would
+ * reproduce the exact PR #242 bug for anyone who doesn't also run a write
+ * command. Warns once to stderr and returns.
+ */
+export function warnIfNewerLockSchema(schemaVersion: number, lockFile: string): void {
+  if (schemaVersion <= LOCK_SCHEMA_VERSION) return;
+  console.error(
+    `WARNING: ${lockFile} was written by a newer version of artgraph (lock schema v${schemaVersion}; ` +
+      `this CLI only understands up to v${LOCK_SCHEMA_VERSION}). Continuing, but newer-format ` +
+      `details may not be reflected below — update artgraph for full fidelity.`,
+  );
 }
 
 export function writeLock(rootDir: string, lockPath: string, lock: LockFile): void {
   const fullPath = resolve(rootDir, lockPath);
   assertWithinRoot(rootDir, fullPath);
   const tmpPath = resolve(dirname(fullPath), `.${basename(fullPath)}.tmp`);
-  writeFileSync(tmpPath, JSON.stringify(lock, null, 2) + "\n", "utf-8");
+  // issue #243 — `_meta` is always stamped fresh on every write, first key
+  // (object spread preserves `lock`'s own key order after it). This is what
+  // makes rename/split/merge's "_meta survives a key-move" requirement a
+  // non-issue: `renameLockKey`/`splitLockKey`/`mergeLockKeys` operate on the
+  // entry-only `LockFile` (no `_meta` key ever reaches them, see `readLock`
+  // above), and the subsequent `reconcile()` → `writeLock()` re-stamps
+  // `_meta` unconditionally regardless of what keys moved.
+  const stamped = { _meta: { schemaVersion: LOCK_SCHEMA_VERSION }, ...lock };
+  writeFileSync(tmpPath, JSON.stringify(stamped, null, 2) + "\n", "utf-8");
   renameSync(tmpPath, fullPath);
 }
 

--- a/src/plan-coverage/index.ts
+++ b/src/plan-coverage/index.ts
@@ -42,7 +42,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import { loadConfig } from "../config.js";
 import { scan } from "../scan.js";
-import { readLock } from "../lock.js";
+import { readLockWithMeta, warnIfNewerLockSchema } from "../lock.js";
 import { entryOriginIds, impact, resolveStartIds, resolveOriginReqs } from "../graph/traverse.js";
 import { extractFiles, type TaskBlock } from "../parsers/sdd-files.js";
 import type { SymbolEntry } from "../types.js";
@@ -442,7 +442,10 @@ export function runPlanCoverage(options: PlanCoverageOptions): PlanCoverageRunRe
   // Load graph + lock once.
   const config = loadConfig(repoRoot);
   const { graph, warnings } = scan(repoRoot, config);
-  const lock = readLock(repoRoot, config.lockFile);
+  // issue #243 — plan-coverage is read-only w.r.t. the lock: warn on a
+  // newer schema and keep going (see commands/check.ts's identical comment).
+  const { lock, schemaVersion } = readLockWithMeta(repoRoot, config.lockFile);
+  warnIfNewerLockSchema(schemaVersion, config.lockFile);
 
   // Read source texts. tasks.md is the spine; plan.md / spec.md are
   // optional (per FR-015 they only contribute to mention detection).

--- a/src/rename-executor.ts
+++ b/src/rename-executor.ts
@@ -16,7 +16,7 @@ import {
 } from "./rename.js";
 import { renameLockKey, splitLockKey, mergeLockKeys } from "./rename-lock.js";
 import type { LockChange } from "./rename-lock.js";
-import { readLock, readLockWithMeta, assertLockSchemaWritable } from "./lock.js";
+import { readLockWithMeta, assertLockSchemaWritable, warnIfNewerLockSchema } from "./lock.js";
 import { scan, reconcile } from "./scan.js";
 import { loadConfig } from "./config.js";
 import { globCodeFiles } from "./parsers/typescript.js";
@@ -253,7 +253,9 @@ export function executeRename(options: RenameOptions & { from: string; to: strin
   }
 
   // Project lock changes (also the source of truth for dry-run reporting).
-  const lockChanges = projectLockChanges(rootDir, config, (lock) => renameLockKey(lock, from, to));
+  const lockChanges = projectLockChanges(rootDir, config, dryRun, (lock) =>
+    renameLockKey(lock, from, to),
+  );
 
   // spec 020 T017 (FR-016) — trace shard REQ ID rewrite, separate from the
   // spec/code/test scan above: shards are not enumerated by
@@ -374,7 +376,7 @@ export function executeSplit(
     );
   }
 
-  const lockChanges = projectLockChanges(rootDir, config, (lock) =>
+  const lockChanges = projectLockChanges(rootDir, config, dryRun, (lock) =>
     splitLockKey(lock, splitId, intoIds),
   );
 
@@ -487,7 +489,7 @@ export function executeMerge(
     );
   }
 
-  const lockChanges = projectLockChanges(rootDir, config, (lock) =>
+  const lockChanges = projectLockChanges(rootDir, config, dryRun, (lock) =>
     mergeLockKeys(lock, mergeIds, intoId),
   );
 
@@ -676,14 +678,27 @@ function mergeMarkdown(
  * Compute the projected lock-key changes for reporting / dry-run. The actual
  * on-disk lock is rebuilt by reconcileAfterWrite, so this only needs the change
  * log, not the resulting lock.
+ *
+ * F4 (meta-review, issue #243 follow-up): reads via `readLockWithMeta` and
+ * warns on a newer-schema lock via `warnIfNewerLockSchema`, but ONLY when
+ * `dryRun` is true. `--dry-run` never calls `assertRenameLockWritable` (it's
+ * exempt from the write guard), so without this it silently produced a
+ * preview from a newer-schema lock while a real apply would warn/reject —
+ * the exact asymmetry the meta-review flagged. For a non-dry-run call,
+ * `assertRenameLockWritable` (invoked earlier in each `execute*` before this
+ * function ever runs) already emitted the equivalent notice — either it
+ * threw, or it printed the `--force` downgrade notice — so warning again
+ * here would just be a duplicate.
  */
 function projectLockChanges(
   rootDir: string,
   config: ArtgraphConfig,
+  dryRun: boolean,
   op: (lock: LockFile) => { changes: LockChange[] },
 ): LockChange[] {
   const lockFilePath = resolve(rootDir, config.lockFile);
   if (!existsSync(lockFilePath)) return [];
-  const lock = readLock(rootDir, config.lockFile);
+  const { lock, schemaVersion } = readLockWithMeta(rootDir, config.lockFile);
+  if (dryRun) warnIfNewerLockSchema(schemaVersion, config.lockFile);
   return op(lock).changes;
 }

--- a/src/rename-executor.ts
+++ b/src/rename-executor.ts
@@ -16,7 +16,7 @@ import {
 } from "./rename.js";
 import { renameLockKey, splitLockKey, mergeLockKeys } from "./rename-lock.js";
 import type { LockChange } from "./rename-lock.js";
-import { readLock } from "./lock.js";
+import { readLock, readLockWithMeta, assertLockSchemaWritable } from "./lock.js";
 import { scan, reconcile } from "./scan.js";
 import { loadConfig } from "./config.js";
 import { globCodeFiles } from "./parsers/typescript.js";
@@ -31,6 +31,11 @@ export interface RenameOptions {
   dryRun: boolean;
   format: "json" | "text";
   rootDir: string;
+  /** issue #243 — overwrite a lock whose `_meta.schemaVersion` is newer than
+   * this CLI's `LOCK_SCHEMA_VERSION` (see `assertLockSchemaWritable`). Only
+   * consulted for a non-dry-run apply — `--dry-run` never touches the lock
+   * file, so it is exempt from the guard. */
+  force?: boolean;
 }
 
 export type RenameWarning =
@@ -130,14 +135,30 @@ function assertRenameableSource(id: string): void {
  * this, `artgraph check` immediately reports drift for every rewritten node
  * (F1). Only runs when a lock file already existed.
  */
-function reconcileAfterWrite(rootDir: string, config: ArtgraphConfig): void {
+function reconcileAfterWrite(rootDir: string, config: ArtgraphConfig, force: boolean): void {
   const lockFilePath = resolve(rootDir, config.lockFile);
   if (!existsSync(lockFilePath)) return;
   // This second scan's `warnings` are discarded outright (see the
   // `buildWarnings` doc on `RenameResult` above — issue #273 tracks properly
   // surfacing them instead of dropping them on the floor).
   const { graph } = scan(rootDir, config);
-  reconcile(rootDir, config, graph);
+  reconcile(rootDir, config, graph, { force });
+}
+
+/**
+ * issue #243 — fail BEFORE any spec/code/test file is rewritten when the
+ * existing lock's schema is newer than this CLI understands and `force` was
+ * not given. Without this early check, `applyWrites` would rewrite every
+ * source file first and only discover the version conflict afterwards (in
+ * `reconcileAfterWrite`), leaving renamed IDs in source files with no
+ * matching lock update — a worse, half-migrated state than refusing upfront.
+ * A no-op when no lock file exists yet (nothing to protect).
+ */
+function assertRenameLockWritable(rootDir: string, config: ArtgraphConfig, force: boolean): void {
+  const lockFilePath = resolve(rootDir, config.lockFile);
+  if (!existsSync(lockFilePath)) return;
+  const { schemaVersion } = readLockWithMeta(rootDir, config.lockFile);
+  assertLockSchemaWritable(schemaVersion, config.lockFile, force);
 }
 
 interface ScanContext {
@@ -169,19 +190,21 @@ function applyWrites(
   config: ArtgraphConfig,
   filesToWrite: Map<string, string>,
   dryRun: boolean,
+  force: boolean,
 ): void {
   if (dryRun) return;
   for (const [absPath, content] of filesToWrite) {
     writeFileSync(absPath, content, "utf-8");
   }
-  reconcileAfterWrite(rootDir, config);
+  reconcileAfterWrite(rootDir, config, force);
 }
 
 // ── executeRename ───────────────────────────────────────────────────
 
 export function executeRename(options: RenameOptions & { from: string; to: string }): RenameResult {
-  const { rootDir, dryRun, from, to } = options;
+  const { rootDir, dryRun, from, to, force = false } = options;
   const { config, existingIds, rewriteOpts, graphWarnings } = loadScanContext(rootDir);
+  if (!dryRun) assertRenameLockWritable(rootDir, config, force);
 
   // Validate
   if (from === to) {
@@ -245,7 +268,7 @@ export function executeRename(options: RenameOptions & { from: string; to: strin
     filePath,
   }));
 
-  applyWrites(rootDir, config, filesToWrite, dryRun);
+  applyWrites(rootDir, config, filesToWrite, dryRun, force);
 
   return {
     operation: "rename",
@@ -265,8 +288,9 @@ export function executeRename(options: RenameOptions & { from: string; to: strin
 export function executeSplit(
   options: RenameOptions & { splitId: string; intoIds: string[] },
 ): RenameResult {
-  const { rootDir, dryRun, splitId, intoIds } = options;
+  const { rootDir, dryRun, splitId, intoIds, force = false } = options;
   const { config, existingIds, rewriteOpts, graphWarnings } = loadScanContext(rootDir);
+  if (!dryRun) assertRenameLockWritable(rootDir, config, force);
 
   // Validate
   assertRenameableSource(splitId);
@@ -354,7 +378,7 @@ export function executeSplit(
     splitLockKey(lock, splitId, intoIds),
   );
 
-  applyWrites(rootDir, config, filesToWrite, dryRun);
+  applyWrites(rootDir, config, filesToWrite, dryRun, force);
 
   return {
     operation: "split",
@@ -375,8 +399,9 @@ export function executeSplit(
 export function executeMerge(
   options: RenameOptions & { mergeIds: string[]; intoId: string },
 ): RenameResult {
-  const { rootDir, dryRun, mergeIds, intoId } = options;
+  const { rootDir, dryRun, mergeIds, intoId, force = false } = options;
   const { config, existingIds, rewriteOpts, graphWarnings } = loadScanContext(rootDir);
+  if (!dryRun) assertRenameLockWritable(rootDir, config, force);
 
   // Validate
   if (mergeIds.length < 1) {
@@ -483,7 +508,7 @@ export function executeMerge(
     filePath,
   }));
 
-  applyWrites(rootDir, config, filesToWrite, dryRun);
+  applyWrites(rootDir, config, filesToWrite, dryRun, force);
 
   return {
     operation: "merge",

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -1,6 +1,11 @@
 import { resolve } from "node:path";
 import { buildGraph, type BuildWarning } from "./graph/builder.js";
-import { writeLock, buildLockFromGraph, readLock } from "./lock.js";
+import {
+  writeLock,
+  buildLockFromGraph,
+  readLockWithMeta,
+  assertLockSchemaWritable,
+} from "./lock.js";
 import type { ArtifactGraph, ArtgraphConfig } from "./types.js";
 
 export interface ScanResult {
@@ -64,12 +69,28 @@ export function scan(rootDir: string, config: ArtgraphConfig): ScanResult {
   };
 }
 
-export function reconcile(rootDir: string, config: ArtgraphConfig, graph: ArtifactGraph): void {
+export interface ReconcileOptions {
+  /** issue #243 — overwrite a lock whose `_meta.schemaVersion` is newer than
+   * this CLI's `LOCK_SCHEMA_VERSION` (see `assertLockSchemaWritable`). */
+  force?: boolean;
+}
+
+export function reconcile(
+  rootDir: string,
+  config: ArtgraphConfig,
+  graph: ArtifactGraph,
+  opts?: ReconcileOptions,
+): void {
   // Pass the previous lock (if any) so structurally-identical entries keep
   // their lastReconciled timestamp. Without this, every `scan` writes new
   // timestamps for every entry and INV-L4 (byte-identical round-trip) is
   // broken in real use even though the test stubs `Date`. Review B1.
-  const prevLock = readLock(rootDir, config.lockFile);
+  const { lock: prevLock, schemaVersion } = readLockWithMeta(rootDir, config.lockFile);
+  // issue #243 — this is THE sole `writeLock` call site in the codebase, so
+  // gating here covers every write path (`reconcile` CLI, `rename-executor`'s
+  // `reconcileAfterWrite`, `init`'s initial scan) without duplicating the
+  // check at each caller.
+  assertLockSchemaWritable(schemaVersion, config.lockFile, opts?.force ?? false);
   const lock = buildLockFromGraph(graph, prevLock);
   writeLock(rootDir, config.lockFile, lock);
 }

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -281,6 +281,59 @@ artgraph:
       rmSync(tmpRoot, { recursive: true, force: true });
     }
   });
+
+  // F1 (meta-review, issue #243 follow-up) — `_meta` exact-match collision
+  // with the lock file's reserved stamp key. Two collision paths:
+  it('F1: warns when a custom reqPatterns match produces a req ID literally "_meta"', () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), "artgraph-meta-collision-req-"));
+    const tmpSpecs = resolve(tmpRoot, "specs");
+    mkdirSync(tmpSpecs, { recursive: true });
+    writeFileSync(
+      resolve(tmpSpecs, "meta-collision.md"),
+      `# Test\n\n- _meta: this list item's ID literally collides with the lock's _meta key\n`,
+    );
+
+    try {
+      const tmpConfig: ArtgraphConfig = {
+        ...config,
+        include: [],
+        testPatterns: [],
+        reqPatterns: { listItem: "^(_meta):\\s" },
+      };
+      const { graph, warnings } = buildGraph(tmpRoot, tmpConfig);
+      expect(graph.nodes.has("_meta")).toBe(true);
+      const metaWarnings = warnings.filter((w) => w.type === "reserved-prefix" && w.id === "_meta");
+      expect(metaWarnings.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('F1: warns when frontmatter `artgraph: { node_id: _meta }` assigns a doc ID literally "_meta"', () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), "artgraph-meta-collision-doc-"));
+    const tmpSpecs = resolve(tmpRoot, "specs");
+    mkdirSync(tmpSpecs, { recursive: true });
+    writeFileSync(
+      resolve(tmpSpecs, "meta-collision-doc.md"),
+      `---
+artgraph:
+  node_id: "_meta"
+---
+# Test
+`,
+    );
+
+    try {
+      const tmpConfig: ArtgraphConfig = { ...config, include: [], testPatterns: [] };
+      const { graph, warnings } = buildGraph(tmpRoot, tmpConfig);
+      expect(graph.nodes.has("_meta")).toBe(true);
+      expect(graph.nodes.get("_meta")?.kind).toBe("doc");
+      const metaWarnings = warnings.filter((w) => w.type === "reserved-prefix" && w.id === "_meta");
+      expect(metaWarnings.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("buildGraph: contains edges with autoNodes=false + explicit node_id", () => {

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -20,6 +20,7 @@ import {
   computeStageGates,
 } from "../src/init.js";
 import { DistributionError } from "../src/agents/distribute.js";
+import { LOCK_SCHEMA_VERSION } from "../src/lock.js";
 import { readSkillSource } from "../src/agents/source.js";
 import { AGENT_DESCRIPTORS } from "../src/agents/descriptors.js";
 
@@ -1168,5 +1169,88 @@ describe("runInit — agents field persistence (#158)", () => {
     writeFileSync(join(tmp, ".artgraph.json"), JSON.stringify({ agents: ["claude"] }));
     runInit(tmp, { force: true, minimal: true, agents: ["claude"] });
     expect(readAgents()).toEqual(["claude"]);
+  });
+});
+
+// F7 (meta-review, issue #243 follow-up) — coverage gap: `init`'s initial
+// scan reconciles the lock via `reconcile(abs, config, scanResult.graph,
+// { force: options.force ?? false })` (src/init.ts), but nothing previously
+// exercised that `options.force` actually reaches `assertLockSchemaWritable`
+// through that path. Pre-seed a `.trace.lock` claiming a newer schema
+// version than this build understands and confirm `init` without `--force`
+// is rejected, while `init --force` proceeds and prints the downgrade notice.
+describe("runInit — --force propagates to the lock schema-version write guard (F7)", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = makeTmpDir();
+  });
+
+  afterEach(() => {
+    cleanup(tmp);
+  });
+
+  function seedFutureLock(): void {
+    writeFileSync(
+      join(tmp, ".trace.lock"),
+      JSON.stringify({ _meta: { schemaVersion: LOCK_SCHEMA_VERSION + 1 } }, null, 2) + "\n",
+    );
+  }
+
+  // Isolate just the config + scan + reconcile stage (skip Skills/integrate/
+  // hooks/agent-context, which are orthogonal to this guard and would need
+  // --agents wired up).
+  const isolatedStages = {
+    noSkills: true,
+    noIntegrate: true,
+    noHooks: true,
+    noAgentContext: true,
+  };
+
+  it("without --force: init's scan/reconcile stage rejects a newer-schema lock", () => {
+    mkdirSync(join(tmp, "src"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+    seedFutureLock();
+
+    expect(() => runInit(tmp, isolatedStages)).toThrow(/newer version of artgraph/i);
+    // Refused write: the lock on disk still claims the future version.
+    const raw = JSON.parse(readFileSync(join(tmp, ".trace.lock"), "utf-8"));
+    expect(raw._meta.schemaVersion).toBe(LOCK_SCHEMA_VERSION + 1);
+  });
+
+  it("with --force: init's scan/reconcile stage downgrades the lock and warns on stderr", () => {
+    mkdirSync(join(tmp, "src"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+    seedFutureLock();
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      expect(() => runInit(tmp, { ...isolatedStages, force: true })).not.toThrow();
+    } finally {
+      spy.mockRestore();
+    }
+    const raw = JSON.parse(readFileSync(join(tmp, ".trace.lock"), "utf-8"));
+    expect(raw._meta.schemaVersion).toBe(LOCK_SCHEMA_VERSION);
+  });
+
+  it("with --force: prints the downgrade notice to stderr", () => {
+    mkdirSync(join(tmp, "src"));
+    writeFileSync(join(tmp, "src", "app.ts"), "export const x = 1;\n");
+    seedFutureLock();
+
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      runInit(tmp, { ...isolatedStages, force: true });
+      const messages = spy.mock.calls.map((c) => String(c[0]));
+      expect(
+        messages.some((m) =>
+          new RegExp(
+            `Downgrading lock schema v${LOCK_SCHEMA_VERSION + 1} -> v${LOCK_SCHEMA_VERSION}`,
+          ).test(m),
+        ),
+      ).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/tests/lock-schema-version.test.ts
+++ b/tests/lock-schema-version.test.ts
@@ -1,0 +1,388 @@
+// issue #243 — lock schema version stamp (`_meta.schemaVersion`).
+//
+// Background: before this fix, an OLDER artgraph's `reconcile` silently
+// rebuilt (and overwrote) a lock a NEWER artgraph had written — no warning,
+// exit 0 — coarsening or dropping information the newer CLI produced (PR #242
+// review). This file pins:
+//   1. `_meta` round-trips through writeLock/readLock and never leaks into
+//      entry-map consumers (readLock, rename-lock operations).
+//   2. A pre-#243 lock with no `_meta` key is treated as schemaVersion 0 and
+//      keeps working exactly as before.
+//   3. Write paths (`reconcile`, `rename`) reject a newer-schema lock with a
+//      clear error + non-zero exit, unless `--force`.
+//   4. Read-only paths (`check`) warn on stderr and continue (exit unaffected
+//      by the version itself).
+//   5. `_meta` survives a rename's key-move (it is always re-stamped by the
+//      `reconcileAfterWrite` that follows every successful rename/split/merge).
+//   6. Lock byte-stability: two `writeLock` calls from the same graph are
+//      byte-identical, `_meta` included.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
+import { mkdtempSync, cpSync, rmSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import {
+  readLock,
+  readLockWithMeta,
+  writeLock,
+  buildLockFromGraph,
+  assertLockSchemaWritable,
+  warnIfNewerLockSchema,
+  LockSchemaVersionError,
+  LOCK_SCHEMA_VERSION,
+} from "../src/lock.js";
+import { reconcile } from "../src/scan.js";
+import type { ArtifactGraph, ArtgraphConfig, GraphNode, LockFile } from "../src/types.js";
+import { runAt } from "./helpers.js";
+
+const RENAME_FIXTURE = resolve(import.meta.dirname, "fixtures/rename");
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+  tempDirs.length = 0;
+});
+
+function node(id: string, kind: GraphNode["kind"]): GraphNode {
+  return { id, kind, filePath: `${id}.md`, contentHash: "abc" };
+}
+
+function graph(nodes: GraphNode[]): ArtifactGraph {
+  const map = new Map<string, GraphNode>();
+  for (const n of nodes) map.set(n.id, n);
+  return { nodes: map, edges: [] };
+}
+
+function mkTmp(prefix: string): string {
+  const dir = mkdtempSync(resolve(tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// 1. writeLock -> readLock round trip: `_meta` separated
+// ---------------------------------------------------------------------------
+
+describe("writeLock/readLock — _meta separation", () => {
+  it("writeLock stamps _meta.schemaVersion = LOCK_SCHEMA_VERSION as the first key", () => {
+    const dir = mkTmp("artgraph-lock-meta-");
+    writeLock(dir, ".trace.lock", { "REQ-1": { contentHash: "x", lastReconciled: "now" } });
+    const raw = JSON.parse(readFileSync(resolve(dir, ".trace.lock"), "utf-8"));
+    expect(Object.keys(raw)[0]).toBe("_meta");
+    expect(raw._meta).toEqual({ schemaVersion: LOCK_SCHEMA_VERSION });
+    expect(raw["REQ-1"]).toEqual({ contentHash: "x", lastReconciled: "now" });
+  });
+
+  it("readLock strips _meta — it never appears as a pseudo-entry", () => {
+    const dir = mkTmp("artgraph-lock-meta-");
+    writeLock(dir, ".trace.lock", { "REQ-1": { contentHash: "x", lastReconciled: "now" } });
+    const lock = readLock(dir, ".trace.lock");
+    expect(Object.keys(lock)).toEqual(["REQ-1"]);
+    expect(Object.prototype.hasOwnProperty.call(lock, "_meta")).toBe(false);
+  });
+
+  it("readLockWithMeta reports the stamped schemaVersion alongside the stripped entries", () => {
+    const dir = mkTmp("artgraph-lock-meta-");
+    writeLock(dir, ".trace.lock", { "REQ-1": { contentHash: "x", lastReconciled: "now" } });
+    const { lock, schemaVersion } = readLockWithMeta(dir, ".trace.lock");
+    expect(schemaVersion).toBe(LOCK_SCHEMA_VERSION);
+    expect(Object.keys(lock)).toEqual(["REQ-1"]);
+  });
+
+  it("_meta never leaks into rename-lock's entry iteration (renameLockKey/splitLockKey/mergeLockKeys consume readLock's output)", async () => {
+    const { renameLockKey } = await import("../src/rename-lock.js");
+    const dir = mkTmp("artgraph-lock-meta-");
+    writeLock(dir, ".trace.lock", {
+      "REQ-1": { contentHash: "x", lastReconciled: "now" },
+      "REQ-2": {
+        contentHash: "y",
+        lastReconciled: "now",
+        dependsOn: [{ id: "REQ-1", provenances: ["frontmatter"] }],
+      },
+    });
+    const lock = readLock(dir, ".trace.lock");
+    const { lock: renamed } = renameLockKey(lock, "REQ-1", "REQ-1-NEW");
+    // A bug that failed to strip `_meta` before readLock returned would make
+    // this loop try to `updateReferences` on `_meta` itself and either crash
+    // or silently corrupt it — asserting the exact key set catches both.
+    expect(Object.keys(renamed).sort()).toEqual(["REQ-1-NEW", "REQ-2"]);
+    expect(renamed["REQ-2"].dependsOn).toEqual([{ id: "REQ-1-NEW", provenances: ["frontmatter"] }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Legacy lock (no `_meta`) — treated as schemaVersion 0
+// ---------------------------------------------------------------------------
+
+describe("legacy lock (no _meta key) — schemaVersion 0", () => {
+  it("readLockWithMeta reports schemaVersion 0 for a pre-#243 lock file", () => {
+    const dir = mkTmp("artgraph-lock-legacy-");
+    writeFileSync(
+      resolve(dir, ".trace.lock"),
+      JSON.stringify({ "REQ-1": { contentHash: "x", lastReconciled: "now" } }, null, 2) + "\n",
+    );
+    const { lock, schemaVersion } = readLockWithMeta(dir, ".trace.lock");
+    expect(schemaVersion).toBe(0);
+    expect(lock).toEqual({ "REQ-1": { contentHash: "x", lastReconciled: "now" } });
+  });
+
+  it("a missing lock file also reports schemaVersion 0", () => {
+    const dir = mkTmp("artgraph-lock-legacy-");
+    const { lock, schemaVersion } = readLockWithMeta(dir, ".trace.lock");
+    expect(schemaVersion).toBe(0);
+    expect(lock).toEqual({});
+  });
+
+  it("reconcile() on a legacy no-_meta lock succeeds and upgrades it with _meta on next write", () => {
+    const dir = mkTmp("artgraph-lock-legacy-");
+    writeFileSync(
+      resolve(dir, ".trace.lock"),
+      JSON.stringify({ "REQ-1": { contentHash: "abc", lastReconciled: "now" } }, null, 2) + "\n",
+    );
+    const config: ArtgraphConfig = {
+      include: [],
+      specDirs: [],
+      testPatterns: [],
+      lockFile: ".trace.lock",
+    };
+    expect(() => reconcile(dir, config, graph([node("REQ-1", "req")]))).not.toThrow();
+    const raw = JSON.parse(readFileSync(resolve(dir, ".trace.lock"), "utf-8"));
+    expect(raw._meta).toEqual({ schemaVersion: LOCK_SCHEMA_VERSION });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. assertLockSchemaWritable / warnIfNewerLockSchema (unit)
+// ---------------------------------------------------------------------------
+
+describe("assertLockSchemaWritable", () => {
+  it("does not throw when schemaVersion <= LOCK_SCHEMA_VERSION", () => {
+    expect(() => assertLockSchemaWritable(0, ".trace.lock", false)).not.toThrow();
+    expect(() => assertLockSchemaWritable(LOCK_SCHEMA_VERSION, ".trace.lock", false)).not.toThrow();
+  });
+
+  it("throws LockSchemaVersionError when schemaVersion > LOCK_SCHEMA_VERSION and force is false", () => {
+    expect(() => assertLockSchemaWritable(LOCK_SCHEMA_VERSION + 1, ".trace.lock", false)).toThrow(
+      LockSchemaVersionError,
+    );
+  });
+
+  it("does not throw when schemaVersion > LOCK_SCHEMA_VERSION and force is true", () => {
+    expect(() =>
+      assertLockSchemaWritable(LOCK_SCHEMA_VERSION + 1, ".trace.lock", true),
+    ).not.toThrow();
+  });
+});
+
+describe("warnIfNewerLockSchema", () => {
+  it("warns to stderr when schemaVersion > LOCK_SCHEMA_VERSION", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnIfNewerLockSchema(LOCK_SCHEMA_VERSION + 1, ".trace.lock");
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toMatch(/^WARNING:/);
+    spy.mockRestore();
+  });
+
+  it("does not warn when schemaVersion <= LOCK_SCHEMA_VERSION", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnIfNewerLockSchema(LOCK_SCHEMA_VERSION, ".trace.lock");
+    warnIfNewerLockSchema(0, ".trace.lock");
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. reconcile() — the sole writeLock call site — rejects / --force overrides
+// ---------------------------------------------------------------------------
+
+describe("reconcile() write-path guard", () => {
+  function futureLockDir(): string {
+    const dir = mkTmp("artgraph-lock-future-");
+    writeFileSync(
+      resolve(dir, ".trace.lock"),
+      JSON.stringify(
+        {
+          _meta: { schemaVersion: LOCK_SCHEMA_VERSION + 1 },
+          "REQ-1": { contentHash: "abc", lastReconciled: "now" },
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    return dir;
+  }
+
+  const config: ArtgraphConfig = {
+    include: [],
+    specDirs: [],
+    testPatterns: [],
+    lockFile: ".trace.lock",
+  };
+
+  it("rejects with LockSchemaVersionError when the on-disk lock is newer and force is not given", () => {
+    const dir = futureLockDir();
+    expect(() => reconcile(dir, config, graph([node("REQ-1", "req")]))).toThrow(
+      LockSchemaVersionError,
+    );
+    // Refusing to write means the on-disk lock is untouched.
+    const raw = JSON.parse(readFileSync(resolve(dir, ".trace.lock"), "utf-8"));
+    expect(raw._meta.schemaVersion).toBe(LOCK_SCHEMA_VERSION + 1);
+  });
+
+  it("--force (opts.force) overwrites the newer lock, downgrading _meta to this build's version", () => {
+    const dir = futureLockDir();
+    expect(() =>
+      reconcile(dir, config, graph([node("REQ-1", "req")]), { force: true }),
+    ).not.toThrow();
+    const raw = JSON.parse(readFileSync(resolve(dir, ".trace.lock"), "utf-8"));
+    expect(raw._meta.schemaVersion).toBe(LOCK_SCHEMA_VERSION);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Lock byte-stability with _meta present
+// ---------------------------------------------------------------------------
+
+describe("lock byte-stability with _meta", () => {
+  it("two writeLock calls from the same buildLockFromGraph output are byte-identical", () => {
+    const g = graph([node("X", "req"), node("Y", "req")]);
+    const now = "2026-07-12T00:00:00.000Z";
+    const real = global.Date;
+    // @ts-expect-error - test stub
+    global.Date = class extends real {
+      constructor(...args: ConstructorParameters<typeof real>) {
+        super(...(args.length === 0 ? [now] : args));
+      }
+      static now() {
+        return real.parse(now);
+      }
+    };
+    let lock1: LockFile;
+    let lock2: LockFile;
+    try {
+      lock1 = buildLockFromGraph(g);
+      lock2 = buildLockFromGraph(g);
+    } finally {
+      global.Date = real;
+    }
+    const dirA = mkTmp("artgraph-lock-stable-a-");
+    const dirB = mkTmp("artgraph-lock-stable-b-");
+    writeLock(dirA, ".trace.lock", lock1);
+    writeLock(dirB, ".trace.lock", lock2);
+    const bufA = readFileSync(resolve(dirA, ".trace.lock"));
+    const bufB = readFileSync(resolve(dirB, ".trace.lock"));
+    expect(Buffer.compare(bufA, bufB)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. CLI-level: reconcile / rename reject a newer lock, check warns
+// ---------------------------------------------------------------------------
+
+function gitCommit(cwd: string, message: string): void {
+  execFileSync("git", ["add", "-A"], { cwd, stdio: "pipe" });
+  execFileSync(
+    "git",
+    ["-c", "user.name=test", "-c", "user.email=test@test.com", "commit", "-m", message],
+    { cwd, stdio: "pipe" },
+  );
+}
+
+async function prepareTempProject(): Promise<string> {
+  const tmp = mkTmp("artgraph-lock-schema-cli-");
+  cpSync(RENAME_FIXTURE, tmp, { recursive: true });
+  execFileSync("git", ["init"], { cwd: tmp, stdio: "pipe" });
+  gitCommit(tmp, "init");
+  // Reconcile once (the fixture's checked-in .trace.lock is a hand-authored
+  // legacy shape) so we start from a real, current-schema lock.
+  await runAt(tmp, ["reconcile"]);
+  gitCommit(tmp, "reconcile");
+  return tmp;
+}
+
+/** Rewrite the temp project's on-disk lock to claim a future schema version. */
+function bumpLockToFutureVersion(tmp: string): void {
+  const lockPath = resolve(tmp, ".trace.lock");
+  const raw = JSON.parse(readFileSync(lockPath, "utf-8"));
+  raw._meta = { schemaVersion: LOCK_SCHEMA_VERSION + 1 };
+  writeFileSync(lockPath, JSON.stringify(raw, null, 2) + "\n");
+}
+
+describe("CLI — reconcile rejects a newer-schema lock, --force overrides", () => {
+  it("`artgraph reconcile` exits non-zero with a clear message on a newer-schema lock", async () => {
+    const tmp = await prepareTempProject();
+    bumpLockToFutureVersion(tmp);
+    const result = await runAt(tmp, ["reconcile"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/newer version of artgraph/i);
+    // Refused write: the lock on disk still claims the future version.
+    const raw = JSON.parse(readFileSync(resolve(tmp, ".trace.lock"), "utf-8"));
+    expect(raw._meta.schemaVersion).toBe(LOCK_SCHEMA_VERSION + 1);
+  });
+
+  it("`artgraph reconcile --force` overwrites the newer-schema lock", async () => {
+    const tmp = await prepareTempProject();
+    bumpLockToFutureVersion(tmp);
+    const result = await runAt(tmp, ["reconcile", "--force"]);
+    expect(result.exitCode).toBe(0);
+    const raw = JSON.parse(readFileSync(resolve(tmp, ".trace.lock"), "utf-8"));
+    expect(raw._meta.schemaVersion).toBe(LOCK_SCHEMA_VERSION);
+  });
+});
+
+describe("CLI — rename rejects a newer-schema lock without mutating source files, --force overrides", () => {
+  it("`artgraph rename --from --to` exits non-zero and leaves source files untouched", async () => {
+    const tmp = await prepareTempProject();
+    const before = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
+    bumpLockToFutureVersion(tmp);
+    const result = await runAt(tmp, ["rename", "--from", "REQ-001", "--to", "REQ-099"]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toMatch(/newer version of artgraph/i);
+    const after = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
+    expect(after).toBe(before);
+  });
+
+  it("`artgraph rename --force` proceeds and re-stamps _meta at this build's version", async () => {
+    const tmp = await prepareTempProject();
+    bumpLockToFutureVersion(tmp);
+    const result = await runAt(tmp, ["rename", "--from", "REQ-001", "--to", "REQ-099", "--force"]);
+    expect(result.exitCode).toBe(0);
+    const after = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
+    expect(after).toMatch(/REQ-099/);
+    const raw = JSON.parse(readFileSync(resolve(tmp, ".trace.lock"), "utf-8"));
+    expect(raw._meta.schemaVersion).toBe(LOCK_SCHEMA_VERSION);
+    // `_meta` survived the rename's key-move (REQ-001 -> REQ-099).
+    expect(raw["REQ-001"]).toBeUndefined();
+    expect(raw["REQ-099"]).toBeDefined();
+  });
+
+  it("`artgraph rename --dry-run` is exempt from the guard (never touches the lock)", async () => {
+    const tmp = await prepareTempProject();
+    bumpLockToFutureVersion(tmp);
+    const result = await runAt(tmp, [
+      "rename",
+      "--from",
+      "REQ-001",
+      "--to",
+      "REQ-099",
+      "--dry-run",
+    ]);
+    expect(result.exitCode).toBe(0);
+    const raw = JSON.parse(readFileSync(resolve(tmp, ".trace.lock"), "utf-8"));
+    expect(raw._meta.schemaVersion).toBe(LOCK_SCHEMA_VERSION + 1);
+  });
+});
+
+describe("CLI — check warns on a newer-schema lock but still completes (read-only path)", () => {
+  it("`artgraph check` warns on stderr and does not fail solely due to the lock schema", async () => {
+    const tmp = await prepareTempProject();
+    bumpLockToFutureVersion(tmp);
+    const result = await runAt(tmp, ["check"]);
+    expect(result.stderr).toMatch(/WARNING:.*newer version of artgraph/i);
+    // The lock is untouched by a read-only command.
+    const raw = JSON.parse(readFileSync(resolve(tmp, ".trace.lock"), "utf-8"));
+    expect(raw._meta.schemaVersion).toBe(LOCK_SCHEMA_VERSION + 1);
+  });
+});

--- a/tests/lock-schema-version.test.ts
+++ b/tests/lock-schema-version.test.ts
@@ -112,6 +112,46 @@ describe("writeLock/readLock — _meta separation", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 1b. writeLock — reserved `_meta` entry key collision guard (F1)
+// ---------------------------------------------------------------------------
+
+describe("writeLock — `_meta` reserved-key collision guard (F1)", () => {
+  it("throws instead of silently letting a bare `_meta` entry overwrite the stamp", () => {
+    const dir = mkTmp("artgraph-lock-meta-collision-");
+    const lock: LockFile = {
+      // A real LockEntry masquerading under the reserved key — this is what
+      // a `reqPatterns` match on the literal id "_meta", or a frontmatter
+      // `node_id: _meta`, would produce via buildLockFromGraph.
+      // @ts-expect-error - deliberately malformed input under test
+      _meta: { contentHash: "x", lastReconciled: "now" },
+      "REQ-1": { contentHash: "y", lastReconciled: "now" },
+    };
+    expect(() => writeLock(dir, ".trace.lock", lock)).toThrow(/reserved "_meta" key/);
+  });
+
+  it('buildLockFromGraph on a graph with a node literally id "_meta" produces an entry map writeLock then rejects', () => {
+    const dir = mkTmp("artgraph-lock-meta-collision-");
+    const g = graph([node("_meta", "req"), node("REQ-1", "req")]);
+    const built = buildLockFromGraph(g);
+    expect(Object.prototype.hasOwnProperty.call(built, "_meta")).toBe(true);
+    expect(() => writeLock(dir, ".trace.lock", built)).toThrow(/reserved "_meta" key/);
+  });
+
+  it("reconcile() surfaces the same rejection end-to-end and does not touch the lock file", () => {
+    const dir = mkTmp("artgraph-lock-meta-collision-");
+    const config: ArtgraphConfig = {
+      include: [],
+      specDirs: [],
+      testPatterns: [],
+      lockFile: ".trace.lock",
+    };
+    expect(() => reconcile(dir, config, graph([node("_meta", "req")]))).toThrow(
+      /reserved "_meta" key/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 2. Legacy lock (no `_meta`) — treated as schemaVersion 0
 // ---------------------------------------------------------------------------
 
@@ -153,6 +193,68 @@ describe("legacy lock (no _meta key) — schemaVersion 0", () => {
 });
 
 // ---------------------------------------------------------------------------
+// 2b. Malformed `_meta.schemaVersion` — warn + fall back to legacy (F2/F3)
+// ---------------------------------------------------------------------------
+
+describe("readLockWithMeta — malformed _meta.schemaVersion warns and falls back to v0 (F2/F3)", () => {
+  function writeRawMeta(dir: string, metaValue: unknown): void {
+    writeFileSync(
+      resolve(dir, ".trace.lock"),
+      JSON.stringify(
+        { _meta: metaValue, "REQ-1": { contentHash: "x", lastReconciled: "now" } },
+        null,
+        2,
+      ) + "\n",
+    );
+  }
+
+  const cases: Array<[label: string, metaValue: unknown]> = [
+    ["schemaVersion is a string", { schemaVersion: "1" }],
+    ["schemaVersion is an array", { schemaVersion: [1] }],
+    ["schemaVersion is null", { schemaVersion: null }],
+    ["_meta is an empty object (no schemaVersion field)", {}],
+    ["_meta is a bare string", "not-an-object"],
+    ["schemaVersion is a non-integer float", { schemaVersion: 1.5 }],
+    ["schemaVersion is negative", { schemaVersion: -1 }],
+  ];
+
+  it.each(cases)("warns to stderr and falls back to schemaVersion 0: %s", (_label, metaValue) => {
+    const dir = mkTmp("artgraph-lock-malformed-meta-");
+    writeRawMeta(dir, metaValue);
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { lock, schemaVersion } = readLockWithMeta(dir, ".trace.lock");
+    expect(schemaVersion).toBe(0);
+    expect(lock).toEqual({ "REQ-1": { contentHash: "x", lastReconciled: "now" } });
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toMatch(/malformed _meta\.schemaVersion/);
+    spy.mockRestore();
+  });
+
+  it("does NOT warn when _meta.schemaVersion is a valid non-negative integer", () => {
+    const dir = mkTmp("artgraph-lock-malformed-meta-");
+    writeRawMeta(dir, { schemaVersion: 0 });
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { schemaVersion } = readLockWithMeta(dir, ".trace.lock");
+    expect(schemaVersion).toBe(0);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("does NOT warn when there is no `_meta` key at all (genuine legacy lock)", () => {
+    const dir = mkTmp("artgraph-lock-malformed-meta-");
+    writeFileSync(
+      resolve(dir, ".trace.lock"),
+      JSON.stringify({ "REQ-1": { contentHash: "x", lastReconciled: "now" } }, null, 2) + "\n",
+    );
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { schemaVersion } = readLockWithMeta(dir, ".trace.lock");
+    expect(schemaVersion).toBe(0);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // 3. assertLockSchemaWritable / warnIfNewerLockSchema (unit)
 // ---------------------------------------------------------------------------
 
@@ -172,6 +274,24 @@ describe("assertLockSchemaWritable", () => {
     expect(() =>
       assertLockSchemaWritable(LOCK_SCHEMA_VERSION + 1, ".trace.lock", true),
     ).not.toThrow();
+  });
+
+  it("F5: prints a downgrade notice to stderr when force overrides a newer schema", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    assertLockSchemaWritable(LOCK_SCHEMA_VERSION + 1, ".trace.lock", true);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toMatch(
+      new RegExp(`Downgrading lock schema v${LOCK_SCHEMA_VERSION + 1} -> v${LOCK_SCHEMA_VERSION}`),
+    );
+    spy.mockRestore();
+  });
+
+  it("F5: does not print a downgrade notice when force is true but schema is not newer", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    assertLockSchemaWritable(LOCK_SCHEMA_VERSION, ".trace.lock", true);
+    assertLockSchemaWritable(0, ".trace.lock", true);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
   });
 });
 
@@ -330,6 +450,18 @@ describe("CLI — reconcile rejects a newer-schema lock, --force overrides", () 
     const raw = JSON.parse(readFileSync(resolve(tmp, ".trace.lock"), "utf-8"));
     expect(raw._meta.schemaVersion).toBe(LOCK_SCHEMA_VERSION);
   });
+
+  // F5 (meta-review) — `--force` must not silently pass; it prints a
+  // downgrade notice so the user sees what they just overrode.
+  it("`artgraph reconcile --force` prints a downgrade notice to stderr", async () => {
+    const tmp = await prepareTempProject();
+    bumpLockToFutureVersion(tmp);
+    const result = await runAt(tmp, ["reconcile", "--force"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toMatch(
+      new RegExp(`Downgrading lock schema v${LOCK_SCHEMA_VERSION + 1} -> v${LOCK_SCHEMA_VERSION}`),
+    );
+  });
 });
 
 describe("CLI — rename rejects a newer-schema lock without mutating source files, --force overrides", () => {
@@ -358,6 +490,18 @@ describe("CLI — rename rejects a newer-schema lock without mutating source fil
     expect(raw["REQ-099"]).toBeDefined();
   });
 
+  // F5 (meta-review) — same downgrade notice as reconcile, since both funnel
+  // through `assertLockSchemaWritable`.
+  it("`artgraph rename --force` prints a downgrade notice to stderr", async () => {
+    const tmp = await prepareTempProject();
+    bumpLockToFutureVersion(tmp);
+    const result = await runAt(tmp, ["rename", "--from", "REQ-001", "--to", "REQ-099", "--force"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toMatch(
+      new RegExp(`Downgrading lock schema v${LOCK_SCHEMA_VERSION + 1} -> v${LOCK_SCHEMA_VERSION}`),
+    );
+  });
+
   it("`artgraph rename --dry-run` is exempt from the guard (never touches the lock)", async () => {
     const tmp = await prepareTempProject();
     bumpLockToFutureVersion(tmp);
@@ -372,6 +516,24 @@ describe("CLI — rename rejects a newer-schema lock without mutating source fil
     expect(result.exitCode).toBe(0);
     const raw = JSON.parse(readFileSync(resolve(tmp, ".trace.lock"), "utf-8"));
     expect(raw._meta.schemaVersion).toBe(LOCK_SCHEMA_VERSION + 1);
+  });
+
+  // F4 (meta-review) — dry-run previously produced a silent preview from a
+  // newer-schema lock while a real apply would warn/reject; it should now
+  // warn just like the read-only `check` path does.
+  it("`artgraph rename --dry-run` warns on stderr about the newer-schema lock", async () => {
+    const tmp = await prepareTempProject();
+    bumpLockToFutureVersion(tmp);
+    const result = await runAt(tmp, [
+      "rename",
+      "--from",
+      "REQ-001",
+      "--to",
+      "REQ-099",
+      "--dry-run",
+    ]);
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toMatch(/WARNING:.*newer version of artgraph/i);
   });
 });
 


### PR DESCRIPTION
## Summary

`.trace.lock` にバージョン情報が皆無のため、新 CLI (spec 021 のメソッド粒度エントリ等) が書いた lock を旧 CLI で `reconcile` すると**無警告・exit 0 で粗い粒度にサイレント巻き戻し**されていた (PR #242 レビューで実測)。artgraph@0.1.0 は npm 公開済みで main には既にメソッド粒度エントリが入っているため、次のリリース以降この事故は現実に起きうる。

npm `lockfileVersion` / Terraform state `version` と同じ定番の世代スタンプで、「サイレントな情報破壊」を「明示的なエラー/警告」に変える。移行ツールは不要。

Closes #243

**実装内容** (承認済み方針: 書き換え系は拒否 + `--force`、読み取り系は警告のみ):

- **`lock.ts`**: `LOCK_SCHEMA_VERSION = 1`、トップレベル `_meta` 予約キー (先頭キー・決定的シリアライズ維持)。`readLockWithMeta` で `_meta` を分離し、既存 `readLock` はエントリのみ返す互換ラッパーとして維持 — rename-lock 等の消費者は無改修で `_meta` がエントリ反復に混入しない。`_meta` なし = version 0 (legacy) として従来どおり動作、次回書き込みで自動付与
- **書き換え系**: `writeLock` の唯一の呼び出し元 `reconcile()` に `assertLockSchemaWritable` を組み込み (scan / rename / init の全書き込み経路を一箇所でカバー)。lock が CLI より新しい場合は `LockSchemaVersionError` (対処法付き) で拒否し exit 1。`reconcile` / `rename` に `--force` を新設、`init` は既存 `--force` を伝播。rename は**ソース書き換え前**の冒頭でガード (拒否が書き換え後に発覚して中途半端な状態が残ることを防ぐ)。`--dry-run` はディスクに書かないため非対象
- **読み取り系** (`check` / `impact` / `plan-coverage` / `scan --serve`): stderr 警告のみで継続
- `rename-lock.ts` は無変更 — `_meta` はエントリとは別チャンネルで管理され、rename/split/merge を素通りして再書き込み時に毎回スタンプされる設計のため「rename 後の `_meta` 維持」が自明に成立

## Change type

- [x] feat (new feature)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — 全 suite green (89 files / 2113 passed)、e2e 119 passed
- [x] Added tests where needed — 21 本新設 (`tests/lock-schema-version.test.ts`): `_meta` 分離ラウンドトリップ / エントリ反復への非混入 (rename-lock 経由含む) / legacy lock の読み書き / 書き換え拒否 + `--force` / rename 拒否時のソース未変更 / `--dry-run` 非対象 / 読み取り警告 + 継続 / lock バイト安定性
- [x] Ran `pnpm -r knip` and `pnpm -r build`
- `artgraph check --diff`: No new issues。`reconcile` 実行で `_meta.schemaVersion: 1` が付与され、再実行で byte-identical を確認

## Breaking change

- [ ] Yes (described below)
- [x] No

`_meta` なしの既存 lock (公開済み v0.1.0 産含む) はそのまま読め、次回書き込みで自動的にスタンプされる。lock ファイルに `_meta` キーが増えるのは additive。既に公開済みの v0.1.0 バイナリ自体は検知コードを持たないため保護されない (本 PR の目的は「検知できないバージョンをこれ以上増やさない」こと)。

## Notes

- 検知の非対称性は意図的: 書き換え = 情報破壊リスクがあるため拒否 / 読み取り = 破壊しないため警告で運用を止めない
- dogfood の `.trace.lock` は本リポジトリでは `.gitignore` 対象 (追跡外) のため、コミットへの同梱は該当なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg)_