### PR TITLE
build(release): sync speckit extension.yml version via release-please extra-files

### DIFF
--- a/.specify/extensions/artgraph/extension.yml
+++ b/.specify/extensions/artgraph/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: artgraph
   name: "artgraph — SDD verification"
-  version: "0.1.0"
+  version: "0.1.0" # x-release-please-version
   description: "Run artgraph scan/reconcile/check at Spec Kit workflow checkpoints."
   author: artgraph
   repository: https://github.com/mori-shin-x/artgraph

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,10 @@
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
       "include-component-in-tag": false,
+      "extra-files": [
+        { "type": "generic", "path": "templates/integrate/speckit/extension.yml" },
+        { "type": "generic", "path": ".specify/extensions/artgraph/extension.yml" }
+      ],
       "bootstrap-sha": "ffe249b7d25f070ad8becf119e40147675c69e38",
       "changelog-sections": [
         { "type": "feat", "section": "Features" },

--- a/templates/integrate/speckit/extension.yml
+++ b/templates/integrate/speckit/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: artgraph
   name: "artgraph — SDD verification"
-  version: "0.1.0"
+  version: "0.1.0" # x-release-please-version
   description: "Run artgraph scan/reconcile/check at Spec Kit workflow checkpoints."
   author: artgraph
   repository: https://github.com/mori-shin-x/artgraph


### PR DESCRIPTION
## Summary

v0.2.0 リリースの publish ブロッカー解消。`prepublishOnly` の `check-versions` (`scripts/check-extension-version.mjs`) は `package.json` と `templates/integrate/speckit/extension.yml` のバージョン一致を強制するが、release-please は extension.yml を bump しない設定だったため、**Release PR #227 をこのままマージすると npm publish が check-versions で必ず失敗する**状態だった。

- `release-please-config.json` に `extra-files` (generic updater) を追加: テンプレート (`templates/integrate/speckit/extension.yml`) と dogfood 配布コピー (`.specify/extensions/artgraph/extension.yml`) の両方
- 両ファイルの `version:` 行に `# x-release-please-version` アノテーションを付与 — 以降のすべての Release PR で package.json と同時に bump される
- `check-versions` の正規表現 (`/^\s*version:\s*["']?([\d.]+)/m`) は末尾コメント付きでもマッチすることを確認済み (`Version sync OK: 0.1.0`)

本PRマージ後、release-please が Release PR #227 を再生成し、extension.yml の 0.2.0 bump が自動で含まれる。

## Change type

- [x] chore / build / ci (toolchain)

## Testing

- [x] Existing tests pass — integrate/speckit + integrate-cli + init (129 tests) green
- [ ] Added tests where needed — 対象外 (リリースツール設定のみ、実行コードの変更なし)
- [x] Ran `pnpm -r build` — `artgraph doctor` 54 pass (配布ドリフトなし)
- `node scripts/check-extension-version.mjs` → `Version sync OK: 0.1.0`、テンプレートと dogfood コピーは byte-identical

## Breaking change

- [ ] Yes (described below)
- [x] No

## Notes

- v0.2.0 リリース手順の詳細はセッション調査レポート参照 (Release PR #227 マージ → Actions で Publish を手動 dispatch)
- 検証は release-please の実走でしか完全確認できないため、本PRマージ後に再生成される Release PR #227 の diff に extension.yml の bump が含まれることを確認するのが最終チェック

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg)_