### PR TITLE
fix(cli): read --version from package.json instead of a hardcoded literal

### DIFF
--- a/src/build-program.ts
+++ b/src/build-program.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import { Command } from "commander";
 import { registerInitCommand } from "./commands/init.js";
 import { registerScanCommand } from "./commands/scan.js";
@@ -10,13 +11,23 @@ import { registerIntegrateCommand } from "./commands/integrate.js";
 import { registerRenameCommand } from "./commands/rename.js";
 import { registerTraceCommand } from "./commands/trace.js";
 
+// `--version` reports package.json's version — the single source of truth.
+// A hardcoded literal here drifts on every release-please bump (the release
+// PR raises package.json but not source literals), which failed the bin
+// e2e's version assertion on the first release branch. Resolved relative to
+// this module so the lookup works both from `dist/` (published layout) and
+// `src/` (tests importing the TS source directly) — package.json sits one
+// level up in both.
+const requireCjs = createRequire(import.meta.url);
+const { version: PKG_VERSION } = requireCjs("../package.json") as { version: string };
+
 // Composition root (issue #162): each command is registered from its own
 // module in `src/commands/`. `buildProgram` wires them onto a fresh
 // commander tree — callers (the CLI entry point, `runCli`) build a new
 // program per invocation so no state leaks between calls.
 export function buildProgram(): Command {
   const program = new Command();
-  program.name("artgraph").description("Typed artifact graph for TS/JS").version("0.1.0");
+  program.name("artgraph").description("Typed artifact graph for TS/JS").version(PKG_VERSION);
 
   registerInitCommand(program);
   registerScanCommand(program);


### PR DESCRIPTION
## Summary

Release PR #227 の CI 失敗の修正。`src/build-program.ts` の `.version("0.1.0")` ハードコードが release-please から見えないため、release ブランチで package.json だけ 0.2.0 に bump され、CLI は 0.1.0 を出力 → bin e2e の version 検証 (`tests/e2e/bin.e2e.test.ts:38,57`) と pack-smoke が失敗していた。

extension.yml (#281) と同類の「3つ目のバージョン同期漏れ」。アノテーションで同期先を増やすのではなく、**起動時に `createRequire` で package.json から version を読む**方式に変更 — 単一情報源になり、このドリフトのクラス自体が再発不能になる。`dist/` (公開レイアウト) と `src/` (テストが TS を直接 import) の両方で `../package.json` が正しく解決される。

## Change type

- [x] fix (bug fix)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — unit 全 suite green (89 files / 2135 passed)
- [x] Added tests where needed — 既存の bin e2e (`--version` = package.json、bin-shim 経由含む) がこの修正の恒久ガードとして機能する (release ブランチで実際に検出した実績)
- [x] Ran `pnpm -r build` — `node dist/cli.js --version` が package.json と一致することを確認
- `ARTGRAPH_E2E_PACK=1` の pack e2e (npm pack → install レイアウト) も 4 passed

## Breaking change

- [ ] Yes (described below)
- [x] No

## Notes

- マージすると release-please が Release PR #227 を再生成する (英訳済み CHANGELOG が一旦日本語に戻るため、再生成後に英訳を再適用する)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg)_