### PR TITLE
fix(test): handle npm 12's object-keyed npm pack --dry-run --json shape

### DIFF
--- a/tests/packaging.test.ts
+++ b/tests/packaging.test.ts
@@ -24,12 +24,23 @@ function listAllTemplateFiles(): string[] {
   return out;
 }
 
+// `npm pack --dry-run --json`'s top-level shape changed between major npm
+// versions: npm <=11 prints an array (`[{ id, files, ... }]`), npm >=12
+// prints an object keyed by package name (`{ "artgraph": { id, files, ... } }`,
+// presumably to disambiguate multi-workspace packs). `publish.yml` runs
+// `npm install -g npm@latest` right before `prepublishOnly` (Trusted
+// Publishing's OIDC exchange needs npm >=11.5.1), so this suite is the
+// FIRST place in CI that ever exercises a non-bundled npm version — every
+// other job keeps whatever npm ships with the pinned Node version. Handle
+// both shapes rather than pinning to whichever one happens to be current.
 function getPackedFiles(): string[] {
   const raw = execSync("npm pack --dry-run --json", {
     cwd: REPO_ROOT,
     encoding: "utf8",
   });
-  return JSON.parse(raw)[0].files.map((f: { path: string }) => f.path);
+  const parsed: unknown = JSON.parse(raw);
+  const entry = Array.isArray(parsed) ? parsed[0] : Object.values(parsed as object)[0];
+  return (entry as { files: { path: string }[] }).files.map((f) => f.path);
 }
 
 describe("npm packaging", () => {


### PR DESCRIPTION
## Summary

npm publish 実行時に `prepublishOnly` の `test:unit` 段階で発覚した publish ブロッカーの修正。**npm へは何もアップロードされていない**(prepublishOnly のライフサイクルスクリプト失敗時、npm publish はアップロード前に中断する)。

`npm pack --dry-run --json` の出力形式が npm メジャーバージョン間で変わっていた:
- npm ≤11(バンドル版、通常の CI ジョブすべて): トップレベル**配列** `[{ id, files, ... }]`
- npm ≥12: トップレベルの**パッケージ名キー付きオブジェクト** `{ "artgraph": { id, files, ... } }`(マルチワークスペース pack の曖昧さ回避のためと推測)

`tests/packaging.test.ts` の `getPackedFiles()` は配列形状のみ対応していたため、`publish.yml` が Trusted Publishing の OIDC 交換要件(npm >=11.5.1)のために実行する `npm install -g npm@latest` の直後、`JSON.parse(raw)[0].files` が `undefined.files` で例外。**このスイートは CI 内で唯一 bundled 以外の npm バージョンを踏む場所**だったため、通常の CI ジョブでは一切気づけず、今回の実 publish 初回実行で初めて顕在化した。

Closes: v0.2.0 publish 実行時の CI 失敗(ワークフロー実行 [29187698949](https://github.com/mori-shin-x/artgraph/actions/runs/29187698949))

## Change type

- [x] fix (bug fix)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — 全 suite green(89 files / 2135 passed)
- [x] Added tests where needed — 既存テストの修正のみ(新規テストは不要、両形状を実データで検証)
- [x] Ran `pnpm -r knip` and `pnpm -r build`
- ローカル npm(10.9.7、配列形状)で `pnpm exec vitest run tests/packaging.test.ts` green
- `npx npm@latest pack --dry-run --json`(12.0.1、オブジェクト形状)の実出力を保存し、修正後のパースロジックで `dist/cli.js` / `templates/agent-context/agents-md-snippet.md` を正しく抽出できることを直接検証

## Breaking change

- [ ] Yes (described below)
- [x] No

テストツール内部のみの変更で、パッケージの挙動・出力には影響しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKdi5mSGNQ831f3zyAu5Gg)_