### PR TITLE
fix(init): exclude node_modules from default include patterns (#287)

### DIFF
--- a/.agents/skills/_shared/output-schema.md
+++ b/.agents/skills/_shared/output-schema.md
@@ -84,7 +84,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/.artgraph.json
+++ b/.artgraph.json
@@ -1,7 +1,8 @@
 {
   "include": [
     "src/**/*.ts",
-    "src/**/*.tsx"
+    "src/**/*.tsx",
+    "!**/node_modules/**"
   ],
   "specDirs": [
     "specs",

--- a/.claude/skills/_shared/output-schema.md
+++ b/.claude/skills/_shared/output-schema.md
@@ -84,7 +84,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/.cursor/skills/_shared/output-schema.md
+++ b/.cursor/skills/_shared/output-schema.md
@@ -84,7 +84,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/.github/skills/_shared/output-schema.md
+++ b/.github/skills/_shared/output-schema.md
@@ -84,7 +84,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/.kiro/skills/_shared/output-schema.md
+++ b/.kiro/skills/_shared/output-schema.md
@@ -84,7 +84,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,11 +10,11 @@ how edge provenance is surfaced.
 
 Both are lists of [fast-glob](https://github.com/mrmlnc/fast-glob) patterns
 resolved relative to the repo root (defaults: `include: ["src/**/*.ts",
-"src/**/*.tsx"]`). A leading `!` marks a pattern as an exclusion (e.g.
-`"!src/generated/**"`), matching fast-glob's own negative-pattern
-convention; excluded files are dropped from both scanning and `artgraph
-rename`'s rewrite scope. A list made up entirely of exclusions matches zero
-files.
+"src/**/*.tsx", "!**/node_modules/**"]`). A leading `!` marks a pattern as
+an exclusion (e.g. `"!src/generated/**"`), matching fast-glob's own
+negative-pattern convention; excluded files are dropped from both scanning
+and `artgraph rename`'s rewrite scope. A list made up entirely of
+exclusions matches zero files.
 
 **Put exclusions in `include`, not `testPatterns`.** A negative pattern on
 `testPatterns` narrows the scanned file set the same way it does on
@@ -24,6 +24,18 @@ symbol names, never `testPatterns`. A negative pattern that only lives in
 `testPatterns` therefore drifts from what trace evaluation sees, and can
 surface a suggested `@impl` / drift candidate that points at a symbol with
 no corresponding node in the graph. See issue #275.
+
+**node_modules is excluded by default (issue #287).** `artgraph init`
+generates configs whose `include` ends with `"!**/node_modules/**"` (as
+shown above), because fast-glob does not exclude node_modules on its own —
+without the negation, a broad pattern like `"**/*.ts"` (the config `init`
+produces when no `src/` directory is detected) would ingest thousands of
+vendored `.ts` files into the graph on the very first scan. Projects
+created before this version can add `"!**/node_modules/**"` to their own
+`include` to opt in. `artgraph scan` emits a `node-modules-in-scan` warning
+whenever the matched file set still contains files under a node_modules
+directory, so a missing exclusion is caught rather than silently producing
+a bloated graph.
 
 Degenerate patterns behave as inert rather than as errors: a doubled
 negation (`"!!foo/**"`), a bare `"!"`, and an empty string (`""`) are all

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,16 @@ whenever the matched file set still contains files under a node_modules
 directory, so a missing exclusion is caught rather than silently producing
 a bloated graph.
 
+Configs that omit `include` entirely pick up the new default automatically
+on upgrade, with no action needed — but any previously-scanned files under a
+node_modules path silently leave the graph on the next scan, since they are
+now excluded rather than detected, so no `node-modules-in-scan` warning
+fires for them. Only configs with an explicit `include` need the manual
+opt-in described above. A config that deliberately includes node_modules —
+for checked-in vendored code, say — will instead see the
+`node-modules-in-scan` warning on every run; it is informational only and
+never affects exit codes.
+
 Degenerate patterns behave as inert rather than as errors: a doubled
 negation (`"!!foo/**"`), a bare `"!"`, and an empty string (`""`) are all
 accepted without complaint and simply do not produce a working exclusion.

--- a/src/commands/presenters/warnings.ts
+++ b/src/commands/presenters/warnings.ts
@@ -92,6 +92,14 @@ export function printWarnings(warnings: BuildWarning[]) {
           `WARNING: ${w.message ?? `unreadable-file "${w.id}" in ${w.files.join(", ")}`}`,
         );
         break;
+      // issue #287 — the include/testPatterns globs matched a file under
+      // node_modules. Shown by default (NOT in SILENT_WARNING_TYPES): the
+      // builder-provided message already carries the count and the
+      // `!**/node_modules/**` config fix, so print it verbatim with the
+      // file list as fallback.
+      case "node-modules-in-scan":
+        console.error(`WARNING: ${w.message ?? `node-modules-in-scan (${w.files.join(", ")})`}`);
+        break;
       // Filtered above via `isSilentWarning`, but the switch still needs
       // cases so the exhaustiveness check below stays happy.
       case "phantom-import-repaired":

--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -67,7 +67,15 @@ export interface BuildWarning {
     // and a bare file node is still synthesized (see `parseTSFile`). NOT
     // silent — a scan silently missing a whole file's coverage is exactly
     // the kind of thing the author needs to see.
-    | "unreadable-file";
+    | "unreadable-file"
+    // issue #287 — fired when the `include` / `testPatterns` globs matched
+    // at least one file under a node_modules directory (any depth).
+    // fast-glob does not exclude node_modules by default, so pre-#287
+    // configs (which lack a `"!**/node_modules/**"` entry in `include`)
+    // silently ingest vendored files into the graph. NOT silent — shown by
+    // default, to guide the user toward adding the exclusion. Non-fatal:
+    // does not affect exit codes.
+    | "node-modules-in-scan";
   id: string;
   files: string[];
   message?: string;
@@ -402,6 +410,23 @@ export function buildGraph(
   const codeId = config.reqPatterns?.codeId;
   const codeFiles = globCodeFiles(rootDir, codePatterns);
   const relCodeFiles = codeFiles.map((f) => relative(rootDir, f));
+
+  // issue #287 — surface configs that still ingest node_modules (pre-#287
+  // configs lack the `"!**/node_modules/**"` negation added to
+  // DEFAULT_CONFIG.include). Segment-based check (split on both path
+  // separators) rather than a substring test, so a file literally named
+  // `node_modules.ts` doesn't false-positive and Windows backslash paths
+  // still match. `files` is capped at 5 entries to keep `scan --format
+  // json` output bounded on repos with thousands of vendored files.
+  const nodeModulesFiles = relCodeFiles.filter((f) => f.split(/[\\/]/).includes("node_modules"));
+  if (nodeModulesFiles.length > 0) {
+    warnings.push({
+      type: "node-modules-in-scan",
+      id: "node_modules",
+      files: nodeModulesFiles.slice(0, 5),
+      message: `${nodeModulesFiles.length} scanned file(s) are under node_modules/ — add "!**/node_modules/**" to "include" in .artgraph.json to exclude them`,
+    });
+  }
 
   // TS fragments are only reusable while the import-resolution environment is
   // unchanged: tsconfig content (the parser's specifier resolver reads jsx /

--- a/src/init.ts
+++ b/src/init.ts
@@ -177,7 +177,12 @@ export function detectProject(rootDir: string): DetectionResult {
 }
 
 export function generateConfig(detection: DetectionResult): ArtgraphConfig {
-  const include = detection.hasSrc ? [...DEFAULT_CONFIG.include] : ["**/*.ts", "**/*.tsx"];
+  // issue #287 — no `src/` dir means the whole repo tree is scanned, so the
+  // node_modules exclusion matters even more here than in the hasSrc branch
+  // (which inherits it from DEFAULT_CONFIG.include).
+  const include = detection.hasSrc
+    ? [...DEFAULT_CONFIG.include]
+    : ["**/*.ts", "**/*.tsx", "!**/node_modules/**"];
 
   // "specs" and "docs" are always siblings, never parent/child, so this can't
   // produce the parent+child specDirs shape loadConfig's validateSpecDirs

--- a/src/types.ts
+++ b/src/types.ts
@@ -664,7 +664,14 @@ export interface ArtgraphConfig {
 }
 
 export const DEFAULT_CONFIG: ArtgraphConfig = {
-  include: ["src/**/*.ts", "src/**/*.tsx"],
+  // issue #287 — the trailing negative pattern excludes node_modules at any
+  // depth (including nested ones, e.g. `packages/*/node_modules` in a
+  // monorepo): fast-glob does not exclude node_modules by default, so
+  // without this a fresh `artgraph scan` would ingest thousands of vendored
+  // .ts files into the graph. Per issue #275 the exclusion deliberately
+  // lives in `include`, not `testPatterns` — see the `testPatterns` doc
+  // comment above for why.
+  include: ["src/**/*.ts", "src/**/*.tsx", "!**/node_modules/**"],
   specDirs: ["specs", "docs"],
   testPatterns: ["**/*.test.ts", "**/*.spec.ts", "**/*.test.tsx"],
   lockFile: ".trace.lock",

--- a/templates/skills/_shared/output-schema.md
+++ b/templates/skills/_shared/output-schema.md
@@ -84,7 +84,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -1622,6 +1622,82 @@ describe("buildGraph: negative include patterns (issue #266)", () => {
   });
 });
 
+// issue #287 — `buildGraph` integration test: a config whose `include`
+// still matches files under node_modules (e.g. a pre-#287 config that
+// predates the `"!**/node_modules/**"` default) should surface a
+// `node-modules-in-scan` warning, while a config carrying the negation
+// should scan cleanly and not false-positive on a file that merely has
+// "node_modules" as a substring of its own name.
+describe("buildGraph: node_modules scan warning (issue #287)", () => {
+  let root: string;
+
+  const write = (relPath: string, content: string): void => {
+    const abs = join(root, relPath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  };
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "artgraph-t287-builder-"));
+    // 6 files across two "packages" so the warning's `files` cap (5) is
+    // actually exercised.
+    write("node_modules/pkgA/a.ts", "export const a = 1;\n");
+    write("node_modules/pkgA/b.ts", "export const b = 1;\n");
+    write("node_modules/pkgA/c.ts", "export const c = 1;\n");
+    write("node_modules/pkgB/d.ts", "export const d = 1;\n");
+    write("node_modules/pkgB/e.ts", "export const e = 1;\n");
+    write("node_modules/pkgB/f.ts", "export const f = 1;\n");
+    // Segment-check regression fixture: this file's name merely CONTAINS
+    // "node_modules" as a substring — it must never be treated as if it
+    // were under a node_modules/ directory.
+    write("node_modules.ts", "export const notNodeModules = 1;\n");
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("warns when include has no node_modules exclusion, capping files at 5", () => {
+    const cfg: ArtgraphConfig = {
+      include: ["**/*.ts"],
+      specDirs: [],
+      testPatterns: [],
+      lockFile: ".trace.lock",
+    };
+    const { warnings } = buildGraph(root, cfg);
+    const nmWarnings = warnings.filter((w) => w.type === "node-modules-in-scan");
+    expect(nmWarnings).toHaveLength(1);
+    expect(nmWarnings[0].message).toContain("6");
+    expect(nmWarnings[0].message).toContain("!**/node_modules/**");
+    expect(nmWarnings[0].files.length).toBeLessThanOrEqual(5);
+  });
+
+  it("does not warn and excludes node_modules files when include carries the negation", () => {
+    const cfg: ArtgraphConfig = {
+      include: ["**/*.ts", "!**/node_modules/**"],
+      specDirs: [],
+      testPatterns: [],
+      lockFile: ".trace.lock",
+    };
+    const { graph, warnings } = buildGraph(root, cfg);
+    expect(warnings.some((w) => w.type === "node-modules-in-scan")).toBe(false);
+    expect(graph.nodes.has("file:node_modules/pkgA/a.ts")).toBe(false);
+    expect(graph.nodes.has("file:node_modules/pkgB/f.ts")).toBe(false);
+  });
+
+  it("includes a root file literally named node_modules.ts without warning (segment check, not substring)", () => {
+    const cfg: ArtgraphConfig = {
+      include: ["**/*.ts", "!**/node_modules/**"],
+      specDirs: [],
+      testPatterns: [],
+      lockFile: ".trace.lock",
+    };
+    const { graph, warnings } = buildGraph(root, cfg);
+    expect(graph.nodes.has("file:node_modules.ts")).toBe(true);
+    expect(warnings.some((w) => w.type === "node-modules-in-scan")).toBe(false);
+  });
+});
+
 // issue #264 — full `buildGraph` integration. Before this fix, an unreadable
 // file crashed HERE first: the incremental parse-cache path in
 // src/graph/builder.ts reads every code file's content unconditionally (to

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -17,7 +17,9 @@ describe("loadConfig", () => {
   it("should return default config when no file exists", () => {
     const config = loadConfig(TMP_DIR);
     expect(config.reqPatterns).toBeUndefined();
-    expect(config.include).toEqual(["src/**/*.ts", "src/**/*.tsx"]);
+    // issue #287 — DEFAULT_CONFIG.include now ends with a node_modules
+    // exclusion.
+    expect(config.include).toEqual(["src/**/*.ts", "src/**/*.tsx", "!**/node_modules/**"]);
   });
 
   it("should load reqPatterns from config file", () => {

--- a/tests/init.test.ts
+++ b/tests/init.test.ts
@@ -115,6 +115,18 @@ describe("generateConfig", () => {
     expect(config.include).not.toContain("src/**/*.ts");
   });
 
+  // issue #287 — both branches must exclude node_modules by default, since
+  // fast-glob does not do so on its own.
+  it("excludes node_modules by default when hasSrc is true", () => {
+    const config = generateConfig({ hasSrc: true, hasSpecs: false, hasDocs: false, sddTools: [] });
+    expect(config.include).toContain("!**/node_modules/**");
+  });
+
+  it("excludes node_modules by default when hasSrc is false", () => {
+    const config = generateConfig({ hasSrc: false, hasSpecs: false, hasDocs: false, sddTools: [] });
+    expect(config.include).toContain("!**/node_modules/**");
+  });
+
   it("includes both specs and docs in specDirs when both exist", () => {
     const config = generateConfig({ hasSrc: true, hasSpecs: true, hasDocs: true, sddTools: [] });
     expect(config.specDirs).toEqual(["specs", "docs"]);
@@ -201,6 +213,25 @@ describe("runInit", () => {
     const config = JSON.parse(readFileSync(join(tmp, ".artgraph.json"), "utf-8"));
     expect(config.include).toContain("**/*.ts");
     expect(config.include).not.toContain("src/**/*.ts");
+  });
+
+  // issue #287 regression: a project without src/ used to generate an
+  // `include` with no node_modules exclusion, so the first scan ingested
+  // vendored .ts files from node_modules into the graph.
+  it("excludes node_modules from the scan when src/ does not exist", () => {
+    writeFileSync(join(tmp, "app.ts"), "export const x = 1;\n");
+    mkdirSync(join(tmp, "node_modules", "somepkg"), { recursive: true });
+    writeFileSync(join(tmp, "node_modules", "somepkg", "index.ts"), "export const y = 1;\n");
+    writeFileSync(
+      join(tmp, "node_modules", "somepkg", "foo.test.ts"),
+      "import { describe, it } from 'vitest';\ndescribe('foo', () => { it('works', () => {}); });\n",
+    );
+
+    const result = runInit(tmp);
+
+    expect(result.scanSummary).toBeDefined();
+    expect(result.scanSummary!.fileCount).toBe(1);
+    expect(result.warnings.some((w) => w.type === "node-modules-in-scan")).toBe(false);
   });
 
   it("includes both specs and docs when both directories exist", () => {


### PR DESCRIPTION
## Summary

Closes #287.

A fresh `artgraph init` on a project without `src/` generated `"include": ["**/*.ts", "**/*.tsx"]` with no node_modules exclusion, so the very first scan ingested every vendored `.ts` file into the graph (995 files / 9480 nodes in the reported repro). fast-glob does not exclude node_modules on its own.

Changes:

- **`DEFAULT_CONFIG.include`** (src/types.ts) and **`generateConfig`'s no-`src/` branch** (src/init.ts) now end with `"!**/node_modules/**"`, using the negative-pattern support from #266. The pattern matches node_modules at any depth (monorepo `packages/*/node_modules` included). Per the #275 policy the exclusion lives in `include`, not `testPatterns` — and since `buildGraph` combines both lists into one glob call, the single negation also stops the default `testPatterns` (`**/*.test.ts` etc.) from matching vendored test files.
- **New non-fatal `node-modules-in-scan` warning** (src/graph/builder.ts + presenter): fires when the matched file set still contains ≥1 file under a node_modules directory, guiding pre-existing configs (which lack the negation and are deliberately not rewritten — `init --force` preserves user `include`) to add the exclusion. Path-segment check, so a file literally named `node_modules.ts` doesn't false-positive; `files` capped at 5 entries to keep `scan --format json` bounded.
- **Dogfooding**: this repo's own `.artgraph.json` now carries the negation too (scan output verified byte-identical before/after — it matches zero current files, but keeps `testPatterns`' `**/*.test.ts` from ever ingesting vendored test files a future direct dependency might ship).
- **Docs**: `docs/configuration.md` documents the new default, the warning, the automatic-upgrade behavior for omit-`include` configs, and the intentional-vendoring case; the six `_shared/output-schema.md` copies gained the new warning type in the `warnings[].type` union (kept byte-identical, enforced by `tests/skills-templates.test.ts`).

## Change type

- [x] fix (bug fix)
- [ ] feat (new feature)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — unit: 89 files / 2141 passed, e2e: 119 passed, typecheck + knip green (pre-push hook run)
- [x] Added tests where needed
- [x] Ran `pnpm -r knip` and `pnpm -r build`

New tests:
- `generateConfig` asserts `"!**/node_modules/**"` in both the hasSrc=true and hasSrc=false branches (tests/init.test.ts)
- Issue-repro regression: `runInit` on a tmp project without `src/` containing `node_modules/somepkg/{index.ts,foo.test.ts}` → `fileCount === 1`, no warning (tests/init.test.ts)
- `buildGraph` warning behavior: fires with count + fix hint and caps `files` at 5 on a no-negation config; silent with the negation; no false-positive on a root file named `node_modules.ts` (tests/builder.test.ts)
- `loadConfig` default assertion updated (tests/config.test.ts)

End-to-end verification against the issue's own repro (npm-pack'd tarball installed into a fresh npm project with `typescript` + `vitest`, 862 vendored `.ts` files under node_modules):
- post-fix `init` (no `src/`) generates `["**/*.ts", "**/*.tsx", "!**/node_modules/**"]`; `scan` reports `file: 1` (only `app.ts`), empty stderr
- with the negation manually stripped (pre-fix config), `scan` ingests 863 files and stderr shows `WARNING: 862 scanned file(s) are under node_modules/ — add "!**/node_modules/**" to "include" in .artgraph.json to exclude them`

## Breaking change

- [ ] Yes (described below)
- [x] No

Edge note (from adversarial review, judged pathological but recorded for the changelog): a config that *omits* `include` entirely (falls back to `DEFAULT_CONFIG`) *and* carries `@impl`-tagged `.ts` files under a `src/**/node_modules/**` path would see those files silently leave the graph on the next scan after upgrading — the files are excluded rather than detected, so the new warning cannot fire for them, and a `check --gate` relying on that coverage could flip. Configs with an explicit `include` — everything `init` has ever generated — are untouched; they get the new warning instead. Documented in docs/configuration.md.

## Notes

Design decisions (confirmed with the maintainer):
- Warning threshold is "≥1 matched file" rather than the issue's proposed percentage — there is no legitimate case for scanning node_modules unintentionally, and a simple threshold can't miss.
- The `.gitignore`-respecting option from the issue was deliberately not pursued (no native fast-glob support; nested/negated .gitignore semantics are costly to replicate). Can be split into a follow-up issue if desired.

Adversarial review + meta-review outcomes (all dispositions applied in the second commit):
- `node-modules-in-scan` has no suppression knob: intentional-vendoring configs see it on every run. Judged consistent with the existing non-silent warning types (`unreadable-file` etc.), stderr-only, never affects exit codes; documented rather than adding a config knob. A follow-up issue is warranted only if a real user hits it.
- Pre-existing, out of scope: `check --diff`'s text-mode "No changes detected" short-circuits skip `printWarnings` while the JSON path includes `warnings` — affects all warning types and predates this PR; candidate for its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xnq2nc9Bwm6wjgKp23g5wB