### PR TITLE
fix(builder,lock,rename,plan-coverage): unreadable spec file を警告 + 継続 で全 CLI 経路をカバー (#277)

### DIFF
--- a/src/commands/presenters/rename.ts
+++ b/src/commands/presenters/rename.ts
@@ -33,6 +33,8 @@ export function printRenameText(result: RenameResult) {
       console.log(
         `WARNING: ${w.filePath} — unrecognized trace schema generation; left unrewritten (re-run the test suite to regenerate this trace)`,
       );
+    } else if (w.type === "unreadable-file") {
+      console.log(`WARNING: ${w.message}`);
     } else {
       console.log(
         `WARNING: ${w.filePath} contains @impl ${w.oldId} — manual assignment to ${w.newIds.join(", ")} needed`,

--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -93,6 +93,13 @@ export function isSilentWarning(type: BuildWarning["type"]): boolean {
   return SILENT_WARNING_TYPES.has(type);
 }
 
+// issue #277 — placeholder hash for a bare doc node synthesized when its
+// source .md is unreadable. Never collides with a real hashContent() output
+// (which is 64-hex sha256), so buildLockFromGraph can safely skip nodes
+// carrying this sentinel and check() will not compare against it. Chosen to
+// include a colon so it is trivially unmistakable for a hash.
+export const UNREADABLE_DOC_CONTENT_HASH = "unreadable-file:no-content";
+
 interface CollectedReq {
   id: string;
   specDir: string;
@@ -223,13 +230,27 @@ export function buildGraph(
             "but it carries none of its usual reqs/tasks/edges until the file becomes readable " +
             "again.",
         });
+        // meta-review (PR #293, issue #277 follow-up) — asymmetry with the
+        // readable path: for a readable doc, `autoNodes: false` only
+        // suppresses nodes whose id equals `expectedAutoDocId` (a doc with
+        // a frontmatter `node_id` override survives). Here the file could
+        // not be read at all, so we cannot know whether it would have
+        // declared a custom `node_id` — there is no frontmatter to parse.
+        // We gate this synthesis unconditionally on `autoNodes`, on the
+        // assumption that the user opted out of ALL auto-generated doc
+        // nodes and would rather see nothing than a possibly-wrong auto id.
+        // The documented cost: a file that WOULD have declared a custom
+        // `node_id` produces ZERO graph node while unreadable — a real
+        // divergence from the readable path, where a custom-`node_id` doc
+        // is immune to `autoNodes: false`. See the "documents the
+        // autoNodes=false asymmetry" test below.
         if (autoNodes) {
           nonReqNodes.push({
             id: `doc:${docRelPath}`,
             kind: "doc",
             filePath: relFile,
             label: `doc:${docRelPath}`,
-            contentHash: hashContent(""),
+            contentHash: UNREADABLE_DOC_CONTENT_HASH,
           });
         }
         continue;

--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -185,7 +185,55 @@ export function buildGraph(
     const specFiles = globSync(resolve(rootDir, specDirName, "**/*.md"));
     for (const file of specFiles) {
       const relFile = relative(rootDir, file);
-      const mdSource = readFileSync(file, "utf-8");
+
+      // issue #277 — `readFileSync` throws on a markdown/spec file that exists
+      // (the glob above already enumerated it) but cannot be READ (chmod 000 /
+      // other permission errors; the same failure mode fixed for the TS side
+      // in issue #264's `parseTSFile`, mirrored here). Pre-fix, this uncaught
+      // throw took down the ENTIRE scan/check/impact command — there is no
+      // per-file isolation in this loop, so a single unreadable .md anywhere
+      // under any specDir made every command that builds the graph fail
+      // outright with a raw stack trace. Fixed fail-SAFE, matching #264's
+      // pattern exactly: warn, synthesize a bare `doc:` node (unless
+      // `docGraph.autoNodes` is off, matching the existing opt-out already
+      // honored below for auto-generated doc nodes) so the file still shows
+      // up in the graph instead of silently vanishing, and skip to the next
+      // file — no cache write, no parse, no edge collection for this file.
+      // Deliberate side-effect: every REQ/task this file would have defined
+      // disappears from the graph until it becomes readable again, so any
+      // `@impl REQ-X` pointing at one of them becomes an orphan-edge warning
+      // in the meantime — this is expected and surfaces the real problem
+      // (the file is unreadable) rather than a confusing crash.
+      let mdSource: string;
+      try {
+        mdSource = readFileSync(file, "utf-8");
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        const docRelPath =
+          specDirName && relFile.startsWith(specDirName + "/")
+            ? relFile.slice(specDirName.length + 1)
+            : relFile;
+        warnings.push({
+          type: "unreadable-file",
+          id: `doc:${docRelPath}`,
+          files: [relFile],
+          message:
+            `could not read "${relFile}" (${message}); skipped req/task/edge extraction for ` +
+            "this file. A bare doc node was still created so it stays visible in the graph, " +
+            "but it carries none of its usual reqs/tasks/edges until the file becomes readable " +
+            "again.",
+        });
+        if (autoNodes) {
+          nonReqNodes.push({
+            id: `doc:${docRelPath}`,
+            kind: "doc",
+            filePath: relFile,
+            label: `doc:${docRelPath}`,
+            contentHash: hashContent(""),
+          });
+        }
+        continue;
+      }
       const mdHash = hashContent(mdSource);
       // Key by specDir too: a file nested under two specDirs is parsed once
       // per dir with a different `specDirPrefix` (and thus a different doc id).

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -2,6 +2,7 @@ import { readFileSync, writeFileSync, existsSync, renameSync, realpathSync } fro
 import { resolve, dirname, basename, relative, isAbsolute } from "node:path";
 import type { LockFile, ArtifactGraph, LockEntry, EdgeProvenance } from "./types.js";
 import { unionDeps, sortUniqueProvenances } from "./graph/canonical.js";
+import { UNREADABLE_DOC_CONTENT_HASH } from "./graph/builder.js";
 
 // Defence-in-depth against symlinked directory components escaping the project
 // root. `loadConfig` validates the lockFile path with string-only resolve/relative,
@@ -293,6 +294,19 @@ export function buildLockFromGraph(graph: ArtifactGraph, prevLock?: LockFile): L
         candidate.lastReconciled = prev.lastReconciled;
       }
       lock[id] = candidate;
+      continue;
+    }
+
+    // meta-review finding #1 (PR #293, issue #277 follow-up) — a bare `doc:`
+    // node synthesized by builder.ts for an unreadable .md carries the
+    // `UNREADABLE_DOC_CONTENT_HASH` sentinel instead of a real content hash.
+    // Locking it here would write that sentinel into `.trace.lock`; the next
+    // time the file becomes readable again with BYTE-IDENTICAL content to
+    // what it had before it went unreadable, `check()` would compare the
+    // real hash against the sentinel and report spurious drift. Skip locking
+    // this node entirely — it reappears in the lock (with a real hash) the
+    // next time the file is actually read successfully.
+    if (node.kind === "doc" && node.contentHash === UNREADABLE_DOC_CONTENT_HASH) {
       continue;
     }
 

--- a/src/plan-coverage/index.ts
+++ b/src/plan-coverage/index.ts
@@ -39,7 +39,7 @@
 // with N typically <= 20 the cost is negligible.
 
 import { existsSync, readFileSync } from "node:fs";
-import { resolve as resolvePath } from "node:path";
+import { resolve as resolvePath, relative as relativePath } from "node:path";
 import { loadConfig } from "../config.js";
 import { scan } from "../scan.js";
 import { readLockWithMeta, warnIfNewerLockSchema } from "../lock.js";
@@ -172,10 +172,39 @@ export interface PlanCoverageRunResult {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function safeRead(path: string | undefined): string | undefined {
+// meta-review (PR #293, issue #277 follow-up) — same unreadable-file crash
+// class as builder.ts's #277 fix and rename-executor.ts's own #277
+// follow-up: `existsSync` only proves the path exists, not that it is a
+// readable regular file (a directory named tasks.md/plan.md/spec.md passes
+// `existsSync` but throws EISDIR on `readFileSync`). Pre-fix, that uncaught
+// throw crashed `runPlanCoverage` outright. Fixed fail-safe: catch the read,
+// push an `unreadable-file` warning onto the SAME `warnings: BuildWarning[]`
+// channel `runPlanCoverage` already threads through from `scan()` (see
+// `PlanCoverageRunResult.warnings`), and return `undefined` exactly like a
+// missing file — callers already treat `safeRead` returning `undefined` as
+// "nothing to read here" (tasks.md's caller falls back to an
+// `emptyExtraction` result; plan.md/spec.md simply contribute nothing to
+// mention detection).
+function safeRead(
+  path: string | undefined,
+  repoRoot: string,
+  warnings: BuildWarning[],
+): string | undefined {
   if (path === undefined || path === "") return undefined;
   if (!existsSync(path)) return undefined;
-  return readFileSync(path, "utf-8");
+  try {
+    return readFileSync(path, "utf-8");
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    const relPath = relativePath(repoRoot, path);
+    warnings.push({
+      type: "unreadable-file",
+      id: `doc:${relPath}`,
+      files: [relPath],
+      message: `could not read "${relPath}" (${message}); skipped for plan-coverage analysis.`,
+    });
+    return undefined;
+  }
 }
 
 function sortStrings(arr: string[]): string[] {
@@ -449,7 +478,7 @@ export function runPlanCoverage(options: PlanCoverageOptions): PlanCoverageRunRe
 
   // Read source texts. tasks.md is the spine; plan.md / spec.md are
   // optional (per FR-015 they only contribute to mention detection).
-  const tasksContent = safeRead(tasksPath);
+  const tasksContent = safeRead(tasksPath, repoRoot, warnings);
   if (tasksContent === undefined) {
     // The CLI layer should have already failed with a clearer error, but
     // be defensive — return an emptyExtraction shaped result so callers
@@ -473,9 +502,9 @@ export function runPlanCoverage(options: PlanCoverageOptions): PlanCoverageRunRe
     };
   }
 
-  const planContent = safeRead(planPath);
+  const planContent = safeRead(planPath, repoRoot, warnings);
   const specPath = resolvePath(specDir, "spec.md");
-  const specContent = safeRead(specPath);
+  const specContent = safeRead(specPath, repoRoot, warnings);
 
   // Stage A/B extraction. tasks.md is the structured source; plan.md
   // contributes additional file seeds when present.

--- a/src/rename-executor.ts
+++ b/src/rename-executor.ts
@@ -51,6 +51,19 @@ export type RenameWarning =
   | {
       type: "unknown-trace-schema";
       filePath: string;
+    }
+  // meta-review (PR #293, issue #277 follow-up) — same unreadable-file
+  // crash class as builder.ts's #277 fix, but for rename/split/merge: a
+  // scanned spec/code/test file that exists (enumerateRewriteFiles already
+  // matched it) but cannot be READ (permission errors, EISDIR, …) used to
+  // throw uncaught here, crashing the whole rename/split/merge command with
+  // no per-file isolation. Fixed fail-safe: warn, skip the file, and keep
+  // rewriting every OTHER file exactly like builder.ts's #277 fix skips
+  // parsing (but keeps scanning) an unreadable .md.
+  | {
+      type: "unreadable-file";
+      filePath: string;
+      message: string;
     };
 
 export interface RenameResult {
@@ -113,6 +126,36 @@ function enumerateRewriteFiles(rootDir: string, config: ArtgraphConfig): string[
     absPaths.add(resolve(file));
   }
   return filterRelevantFiles([...absPaths].map((f) => relative(rootDir, f))).sort();
+}
+
+/**
+ * meta-review (PR #293, issue #277 follow-up) — read a scanned file's
+ * content, catching the EISDIR/EACCES class of errors that a bare
+ * `readFileSync` would otherwise throw uncaught (mirrors builder.ts's
+ * #277 fix for the identical failure mode in `buildGraph`'s markdown loop).
+ * Pre-fix, a single unreadable spec/code/test file anywhere in the scanned
+ * set crashed the whole `rename`/`split`/`merge` command with no per-file
+ * isolation. On failure: push an `unreadable-file` RenameWarning and return
+ * `undefined` so the caller can skip (not rewrite, not throw) this one file
+ * and keep going — matching what already happens for a file `enumerateRewriteFiles`
+ * lists but that no longer `existsSync`s.
+ */
+function tryReadFile(
+  absPath: string,
+  relPath: string,
+  warnings: RenameWarning[],
+): string | undefined {
+  try {
+    return readFileSync(absPath, "utf-8");
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    warnings.push({
+      type: "unreadable-file",
+      filePath: relPath,
+      message: `could not read "${relPath}" (${message}); skipped rewrite for this file.`,
+    });
+    return undefined;
+  }
 }
 
 /**
@@ -228,18 +271,21 @@ export function executeRename(options: RenameOptions & { from: string; to: strin
   const allChanges: RewriteChange[] = [];
   const filesToWrite = new Map<string, string>();
   const scannedFiles = enumerateRewriteFiles(rootDir, config);
+  const readWarnings: RenameWarning[] = [];
 
   for (const relPath of scannedFiles) {
     const absPath = resolve(rootDir, relPath);
     if (!existsSync(absPath)) continue;
 
-    const content = readFileSync(absPath, "utf-8");
+    const content = tryReadFile(absPath, relPath, readWarnings);
+    if (content === undefined) continue;
     const result = rewriteFile(relPath, content, from, to, rewriteOpts);
     if (result.changes.length > 0) {
       allChanges.push(...result.changes);
       filesToWrite.set(absPath, result.content);
     }
   }
+  const unreadableCount = readWarnings.length;
 
   // Safety valve (issue #212): the graph knows `from`, so at least one scanned
   // file must carry a rewritable reference. Zero hits means the enumeration
@@ -265,10 +311,15 @@ export function executeRename(options: RenameOptions & { from: string; to: strin
   const traceRewrite = rewriteTraceShards(rootDir, config, [[from, to]]);
   for (const [absPath, content] of traceRewrite.filesToWrite) filesToWrite.set(absPath, content);
   allChanges.push(...traceRewrite.changes);
-  const warnings: RenameWarning[] = traceRewrite.unknownSchemaShards.map((filePath) => ({
-    type: "unknown-trace-schema" as const,
-    filePath,
-  }));
+  const warnings: RenameWarning[] = [
+    ...readWarnings,
+    ...traceRewrite.unknownSchemaShards.map(
+      (filePath): RenameWarning => ({
+        type: "unknown-trace-schema" as const,
+        filePath,
+      }),
+    ),
+  ];
 
   applyWrites(rootDir, config, filesToWrite, dryRun, force);
 
@@ -276,7 +327,9 @@ export function executeRename(options: RenameOptions & { from: string; to: strin
     operation: "rename",
     from,
     to,
-    filesScanned: scannedFiles.length,
+    // meta-review (PR #293, issue #277 follow-up) — a file that could not be
+    // read is skipped, not scanned, so it is excluded from this count.
+    filesScanned: scannedFiles.length - unreadableCount,
     changes: allChanges,
     lockChanges,
     warnings,
@@ -326,11 +379,16 @@ export function executeSplit(
 
   const implRe = /\/\/[^\S\n]*@impl[^\S\n]+/;
 
+  let unreadableCount = 0;
   for (const relPath of scannedFiles) {
     const absPath = resolve(rootDir, relPath);
     if (!existsSync(absPath)) continue;
 
-    const content = readFileSync(absPath, "utf-8");
+    const content = tryReadFile(absPath, relPath, warnings);
+    if (content === undefined) {
+      unreadableCount++;
+      continue;
+    }
     const ext = extOf(relPath);
 
     if (ext === ".md") {
@@ -387,7 +445,9 @@ export function executeSplit(
     from: splitId,
     sourceIds: [splitId],
     intoIds,
-    filesScanned: scannedFiles.length,
+    // meta-review (PR #293, issue #277 follow-up) — a file that could not be
+    // read is skipped, not scanned, so it is excluded from this count.
+    filesScanned: scannedFiles.length - unreadableCount,
     changes: allChanges,
     lockChanges,
     warnings,
@@ -435,12 +495,14 @@ export function executeMerge(
   const allChanges: RewriteChange[] = [];
   const filesToWrite = new Map<string, string>();
   const scannedFiles = enumerateRewriteFiles(rootDir, config);
+  const readWarnings: RenameWarning[] = [];
 
   for (const relPath of scannedFiles) {
     const absPath = resolve(rootDir, relPath);
     if (!existsSync(absPath)) continue;
 
-    const content = readFileSync(absPath, "utf-8");
+    const content = tryReadFile(absPath, relPath, readWarnings);
+    if (content === undefined) continue;
     const ext = extOf(relPath);
 
     if (ext === ".md") {
@@ -505,10 +567,15 @@ export function executeMerge(
   );
   for (const [absPath, content] of traceRewrite.filesToWrite) filesToWrite.set(absPath, content);
   allChanges.push(...traceRewrite.changes);
-  const warnings: RenameWarning[] = traceRewrite.unknownSchemaShards.map((filePath) => ({
-    type: "unknown-trace-schema" as const,
-    filePath,
-  }));
+  const warnings: RenameWarning[] = [
+    ...readWarnings,
+    ...traceRewrite.unknownSchemaShards.map(
+      (filePath): RenameWarning => ({
+        type: "unknown-trace-schema" as const,
+        filePath,
+      }),
+    ),
+  ];
 
   applyWrites(rootDir, config, filesToWrite, dryRun, force);
 
@@ -517,7 +584,9 @@ export function executeMerge(
     to: intoId,
     sourceIds: mergeIds,
     intoIds: [intoId],
-    filesScanned: scannedFiles.length,
+    // meta-review (PR #293, issue #277 follow-up) — a file that could not be
+    // read is skipped, not scanned, so it is excluded from this count.
+    filesScanned: scannedFiles.length - readWarnings.length,
     changes: allChanges,
     lockChanges,
     warnings,

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -1815,6 +1815,39 @@ describe.skipIf(IS_WIN_277 || IS_ROOT_277)(
       const { graph } = buildGraph(root, cfg);
       expect(graph.edges.some((e) => e.source === "doc:broken.md")).toBe(false);
     });
+
+    // meta-review finding #1 / #3 (PR #293, issue #277 follow-up) — the bare
+    // doc node's placeholder `contentHash` must never be written into
+    // `.trace.lock`, or the file becoming readable again with byte-identical
+    // content would spuriously look like drift (a real hash vs. the
+    // sentinel). Regression test for the `buildLockFromGraph` guard in
+    // src/lock.ts.
+    it("does not write the placeholder hash into the lock (spurious-drift guard, meta-review #1)", () => {
+      const { graph } = buildGraph(root, cfg);
+      const lock = buildLockFromGraph(graph);
+
+      // The bare doc node for the unreadable file is NOT locked.
+      expect(lock["doc:broken.md"]).toBeUndefined();
+
+      // The sibling readable file's req is still locked normally.
+      expect(lock["REQ-2771"]).toBeDefined();
+      expect(lock["REQ-2771"].contentHash).toBeTruthy();
+
+      // Second scan on the now-readable file preserves the lock hash: make
+      // broken.md readable, rebuild, and confirm its REQ locks in cleanly
+      // with a real hash (not the sentinel) — a full round trip through the
+      // "unreadable -> readable" transition never poisons the lock.
+      chmodSync(unreadablePath, 0o644);
+      try {
+        const { graph: graph2 } = buildGraph(root, cfg);
+        const lock2 = buildLockFromGraph(graph2, lock);
+        expect(lock2["doc:broken.md"]).toBeDefined();
+        expect(lock2["doc:broken.md"].contentHash).not.toBe("unreadable-file:no-content");
+        expect(lock2["REQ-2772"]).toBeDefined();
+      } finally {
+        chmodSync(unreadablePath, 0o000);
+      }
+    });
   },
 );
 
@@ -1851,6 +1884,44 @@ describe.skipIf(IS_WIN_277 || IS_ROOT_277)(
       const unreadableWarnings = warnings.filter((w) => w.type === "unreadable-file");
       expect(unreadableWarnings).toHaveLength(1);
       expect(graph.nodes.has("doc:broken.md")).toBe(false);
+    });
+
+    // meta-review finding #2 (PR #293, issue #277 follow-up) — documents the
+    // deliberate asymmetry vs. the READABLE path: a readable doc with an
+    // explicit frontmatter `node_id` survives `autoNodes: false` (only
+    // auto-generated ids are filtered there). An UNREADABLE doc has no
+    // frontmatter to inspect, so builder.ts cannot know whether it would
+    // have declared a custom node_id — it gates synthesis unconditionally
+    // on `autoNodes` instead. Net effect: a readable custom-node_id doc
+    // always shows up in the graph regardless of `autoNodes`, but an
+    // unreadable file NEVER does while `autoNodes: false` is set, even if
+    // it would have declared its own custom node_id. This test locks in
+    // that divergence rather than "fixing" it — see the comment above `if
+    // (autoNodes)` in the catch branch of src/graph/builder.ts.
+    it("readable custom-node_id doc survives autoNodes=false, but an unreadable file never does (documents the asymmetry, meta-review #2)", () => {
+      const customPath = join(root, "specs/custom.md");
+      writeFileSync(
+        customPath,
+        [
+          "---",
+          "artgraph:",
+          '  node_id: "doc:my-custom-id"',
+          "---",
+          "- REQ-2775: custom doc req",
+          "",
+        ].join("\n"),
+      );
+      try {
+        const { graph } = buildGraph(root, cfg);
+        // Readable doc with an explicit node_id survives autoNodes:false.
+        expect(graph.nodes.has("doc:my-custom-id")).toBe(true);
+        // The unreadable file still produces NO doc node at all — even
+        // though it, too, might have declared its own custom node_id we
+        // will never get to see.
+        expect(graph.nodes.has("doc:broken.md")).toBe(false);
+      } finally {
+        rmSync(customPath, { force: true });
+      }
     });
   },
 );

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -1753,3 +1753,104 @@ describe.skipIf(IS_WIN_264 || IS_ROOT_264)(
     });
   },
 );
+
+// issue #277 — the markdown/spec-file counterpart to #264's TS fix. Before
+// this fix, an unreadable `.md` under a specDir crashed the whole
+// scan/check/impact command right here in `buildGraph`'s markdown loop:
+// `readFileSync` on a chmod-000 file throws with no per-file isolation.
+// Same permission-error-only-makes-sense-on-POSIX-non-root caveat as
+// tests/builder.test.ts's #264 test above.
+const IS_WIN_277 = process.platform === "win32";
+const IS_ROOT_277 = typeof process.getuid === "function" && process.getuid() === 0;
+
+describe.skipIf(IS_WIN_277 || IS_ROOT_277)(
+  "buildGraph survives an unreadable .md file in a specDir (issue #277)",
+  () => {
+    let root: string;
+    let unreadablePath: string;
+
+    beforeAll(() => {
+      root = mkdtempSync(join(tmpdir(), "artgraph-builder-unreadable-md-"));
+      mkdirSync(join(root, "specs"), { recursive: true });
+      writeFileSync(join(root, "specs/good.md"), "- REQ-2771: keep me\n");
+      unreadablePath = join(root, "specs/broken.md");
+      writeFileSync(unreadablePath, "- REQ-2772: never read\n");
+      chmodSync(unreadablePath, 0o000);
+    });
+
+    afterAll(() => {
+      chmodSync(unreadablePath, 0o644);
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    const cfg: ArtgraphConfig = {
+      include: ["src/**/*.ts"],
+      specDirs: ["specs"],
+      testPatterns: [],
+      lockFile: ".trace.lock",
+    };
+
+    it("does not throw building the graph", () => {
+      expect(() => buildGraph(root, cfg)).not.toThrow();
+    });
+
+    it("emits exactly one unreadable-file warning for the unreadable .md", () => {
+      const { warnings } = buildGraph(root, cfg);
+      const unreadableWarnings = warnings.filter((w) => w.type === "unreadable-file");
+      expect(unreadableWarnings).toHaveLength(1);
+      expect(unreadableWarnings[0].files).toEqual(["specs/broken.md"]);
+    });
+
+    it("still creates a bare doc node for the unreadable .md", () => {
+      const { graph } = buildGraph(root, cfg);
+      expect(graph.nodes.has("doc:broken.md")).toBe(true);
+    });
+
+    it("still parses sibling .md files normally", () => {
+      const { graph } = buildGraph(root, cfg);
+      expect(graph.nodes.has("REQ-2771")).toBe(true);
+    });
+
+    it("bare doc node has no children edges", () => {
+      const { graph } = buildGraph(root, cfg);
+      expect(graph.edges.some((e) => e.source === "doc:broken.md")).toBe(false);
+    });
+  },
+);
+
+describe.skipIf(IS_WIN_277 || IS_ROOT_277)(
+  "buildGraph respects docGraph.autoNodes=false for an unreadable .md file (issue #277)",
+  () => {
+    let root: string;
+    let unreadablePath: string;
+
+    beforeAll(() => {
+      root = mkdtempSync(join(tmpdir(), "artgraph-builder-unreadable-md-noauto-"));
+      mkdirSync(join(root, "specs"), { recursive: true });
+      writeFileSync(join(root, "specs/good.md"), "- REQ-2773: keep me too\n");
+      unreadablePath = join(root, "specs/broken.md");
+      writeFileSync(unreadablePath, "- REQ-2774: never read\n");
+      chmodSync(unreadablePath, 0o000);
+    });
+
+    afterAll(() => {
+      chmodSync(unreadablePath, 0o644);
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    const cfg: ArtgraphConfig = {
+      include: ["src/**/*.ts"],
+      specDirs: ["specs"],
+      testPatterns: [],
+      lockFile: ".trace.lock",
+      docGraph: { autoNodes: false },
+    };
+
+    it("does not synthesize a bare doc node when autoNodes is false, but still warns", () => {
+      const { graph, warnings } = buildGraph(root, cfg);
+      const unreadableWarnings = warnings.filter((w) => w.type === "unreadable-file");
+      expect(unreadableWarnings).toHaveLength(1);
+      expect(graph.nodes.has("doc:broken.md")).toBe(false);
+    });
+  },
+);

--- a/tests/plan-coverage.test.ts
+++ b/tests/plan-coverage.test.ts
@@ -520,6 +520,101 @@ describe("runPlanCoverage — empty extraction", () => {
 });
 
 // ---------------------------------------------------------------------------
+// meta-review (PR #293, issue #277 follow-up) — `tasks.md` / `plan.md` /
+// `spec.md` existing as a DIRECTORY (not a regular file) passes `existsSync`
+// but throws EISDIR on `readFileSync`. `safeRead` must catch that, push an
+// `unreadable-file` BuildWarning, and let `runPlanCoverage` return a safe
+// result instead of crashing outright.
+// ---------------------------------------------------------------------------
+describe("runPlanCoverage — unreadable tasks.md/plan.md/spec.md (#277 follow-up)", () => {
+  let fx: FixtureRoot;
+  afterEach(() => {
+    if (fx) rmSync(fx.root, { recursive: true, force: true });
+  });
+
+  it("does not throw when tasks.md is a directory, and surfaces an unreadable-file warning", () => {
+    fx = setupFixture();
+    // Replace the tasks.md FILE with a directory of the same name (EISDIR).
+    rmSync(fx.tasksPath, { force: true });
+    mkdirSync(fx.tasksPath);
+
+    let result: ReturnType<typeof runPlanCoverage> | undefined;
+    expect(() => {
+      result = runPlanCoverage({
+        repoRoot: fx.root,
+        specDir: fx.specDir,
+        tasksPath: fx.tasksPath,
+        planPath: fx.planPath,
+        format: "json",
+        gate: false,
+        ignore: [],
+        requireFilesSection: false,
+      });
+    }).not.toThrow();
+
+    expect(result).toBeDefined();
+    // tasks.md unreadable => nothing was extractable => emptyExtraction, same
+    // as a genuinely-missing tasks.md.
+    expect(result!.json.diagnostics.find((d) => d.kind === "emptyExtraction")).toBeDefined();
+    expect(
+      result!.warnings.some(
+        (w) => w.type === "unreadable-file" && w.files.includes("specs/014-test/tasks.md"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not throw when plan.md is a directory, and surfaces an unreadable-file warning", () => {
+    fx = setupFixture();
+    rmSync(fx.planPath, { force: true });
+    mkdirSync(fx.planPath);
+
+    const result = runPlanCoverage({
+      repoRoot: fx.root,
+      specDir: fx.specDir,
+      tasksPath: fx.tasksPath,
+      planPath: fx.planPath,
+      format: "json",
+      gate: false,
+      ignore: [],
+      requireFilesSection: false,
+    });
+
+    // tasks.md is still readable, so its Files: entry still produces impact.
+    expect(result.json.implicitImpacts.length).toBeGreaterThan(0);
+    expect(
+      result.warnings.some(
+        (w) => w.type === "unreadable-file" && w.files.includes("specs/014-test/plan.md"),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not throw when spec.md is a directory, and surfaces an unreadable-file warning", () => {
+    fx = setupFixture();
+    const specMdPath = join(fx.specDir, "spec.md");
+    rmSync(specMdPath, { force: true });
+    mkdirSync(specMdPath);
+
+    const result = runPlanCoverage({
+      repoRoot: fx.root,
+      specDir: fx.specDir,
+      tasksPath: fx.tasksPath,
+      planPath: fx.planPath,
+      format: "json",
+      gate: false,
+      ignore: [],
+      requireFilesSection: false,
+    });
+
+    expect(result.json.implicitImpacts.length).toBeGreaterThan(0);
+    expect(
+      result.warnings.some(
+        (w) => w.type === "unreadable-file" && w.files.includes("specs/014-test/spec.md"),
+      ),
+    ).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Spec Kit standard flat checklist — issues #219 / #220
 // ---------------------------------------------------------------------------
 

--- a/tests/rename-cli.test.ts
+++ b/tests/rename-cli.test.ts
@@ -377,6 +377,98 @@ describe("CLI: rename --merge/--into", () => {
 });
 
 // ---------------------------------------------------------------------------
+// meta-review (PR #293, issue #277 follow-up) — an unreadable file scanned by
+// enumerateRewriteFiles (a directory named `*.md` under `specDirs` passes
+// `existsSync` but throws EISDIR on `readFileSync`) must not crash rename/
+// split/merge outright. It should be skipped with an `unreadable-file`
+// warning while every OTHER scanned file is still rewritten normally.
+// ---------------------------------------------------------------------------
+describe("CLI: rename/split/merge skip unreadable files (#277 follow-up)", () => {
+  /** Create a directory named `broken.md` under `specs/` — EISDIR on read,
+   *  root-safe (no chmod required), and still glob-matched by `specs/**\/*.md`
+   *  since `enumerateRewriteFiles` doesn't pass `nodir` to `globSync`. */
+  function makeUnreadableSpecFile(tmp: string): string {
+    const dirAsFile = resolve(tmp, "specs/broken.md");
+    mkdirSync(dirAsFile);
+    return dirAsFile;
+  }
+
+  it("rename: skips the unreadable file, warns, and still rewrites REQ-001 elsewhere", async () => {
+    const tmp = await prepareTempDir();
+    makeUnreadableSpecFile(tmp);
+
+    const { exitCode, stdout } = await runCli(
+      ["rename", "--from", "REQ-001", "--to", "REQ-100", "--format", "json"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+
+    expect(
+      result.warnings.some(
+        (w: { type: string; filePath: string }) =>
+          w.type === "unreadable-file" && w.filePath === "specs/broken.md",
+      ),
+    ).toBe(true);
+
+    // Normal rewrites on the OTHER scanned files still happened.
+    const spec = readFileSync(resolve(tmp, "specs/feature.md"), "utf-8");
+    expect(spec).toContain("REQ-100: ユーザー認証");
+    const src = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
+    expect(src).toContain("@impl REQ-100");
+  });
+
+  it("split: skips the unreadable file, warns, and still splits REQ-001 elsewhere", async () => {
+    const tmp = await prepareTempDir();
+    makeUnreadableSpecFile(tmp);
+
+    const { exitCode, stdout } = await runCli(
+      ["rename", "--split", "REQ-001", "--into", "REQ-101", "REQ-102", "--format", "json"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+
+    expect(
+      result.warnings.some(
+        (w: { type: string; filePath: string }) =>
+          w.type === "unreadable-file" && w.filePath === "specs/broken.md",
+      ),
+    ).toBe(true);
+
+    const spec = readFileSync(resolve(tmp, "specs/feature.md"), "utf-8");
+    expect(spec).not.toMatch(/^- REQ-001:/m);
+    expect(spec).toContain("REQ-101");
+    expect(spec).toContain("REQ-102");
+  });
+
+  it("merge: skips the unreadable file, warns, and still merges REQ-001/REQ-002 elsewhere", async () => {
+    const tmp = await prepareTempDir();
+    makeUnreadableSpecFile(tmp);
+
+    const { exitCode, stdout } = await runCli(
+      ["rename", "--merge", "REQ-001", "REQ-002", "--into", "REQ-100", "--format", "json"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+
+    expect(
+      result.warnings.some(
+        (w: { type: string; filePath: string }) =>
+          w.type === "unreadable-file" && w.filePath === "specs/broken.md",
+      ),
+    ).toBe(true);
+
+    const src = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
+    expect(src).toContain("@impl REQ-100");
+    const spec = readFileSync(resolve(tmp, "specs/feature.md"), "utf-8");
+    const defLines = spec.split("\n").filter((l) => /^- REQ-100:/.test(l));
+    expect(defLines).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // issue #212 — file enumeration is `.artgraph.json`-pattern based, not
 // git-tracked. Untracked (pre-commit) files must be rewritten like committed
 // ones, a zero-hit scan must fail loudly, and JSON output must expose the


### PR DESCRIPTION
## Summary

Closes #277.

未読の spec `.md` (chmod 000 / EISDIR = ディレクトリを `.md` 名で置いた等) に触れると、`scan` / `check` / `impact` / **`rename` / `plan-coverage`** など graph 構築を含む全 CLI コマンドが未捕捉例外の raw stack trace で落ちていた。

`#264 (PR #276)` が TS 側の同種問題を修正したのと同じパターン (`unreadable-file` 警告 + bare 節点合成 + 継続) を、**問題クラス全体** (builder + rename + plan-coverage) に適用。issue #277 の元スコープは `src/graph/builder.ts` のみだったが、敵対的メタレビューで rename / plan-coverage にも同じ crash 経路残存を確認したため、本 PR でまとめて解消。

## 変更点

### 1. `src/graph/builder.ts` (issue #277 本体)

- markdown 読み込みループの `readFileSync` を try/catch でガード
- 失敗時: `unreadable-file` `BuildWarning` を出力
- `docGraph.autoNodes` を尊重して bare `doc:` node を合成 (autoNodes=false なら省略)
- 該当 file の req/task/edge 収集はスキップ (cache 書き込みもしない)

### 2. `src/lock.ts` + sentinel (メタレビュー Rank 1, BLOCKING BUG)

`buildLockFromGraph` は doc kind を lock 対象とするため、bare doc node の `contentHash: hashContent("")` が `.trace.lock` に書き込まれ、file 復帰後に byte-identical でも偽 drift になっていた (TS side の bare file/test は kind として lock 対象外なので同種問題は起きない、doc だけの非対称)。

- 専用 sentinel `UNREADABLE_DOC_CONTENT_HASH = "unreadable-file:no-content"` を導入
- `buildLockFromGraph` で該当 sentinel の doc node をスキップ

### 3. `autoNodes:false` × custom node_id 非対称の明文化 (メタレビュー Rank 2)

未読 file は frontmatter を読めないため custom `node_id` の有無を判定不能。gating を無条件 `autoNodes` にしている意図と divergence を code comment とテストで明記 (仕様として lock in)。

### 4. `src/rename-executor.ts` + `src/commands/presenters/rename.ts` (メタレビュー Rank 4)

- `tryReadFile()` ヘルパ経由で `executeRename` / `executeSplit` / `executeMerge` 全 3 経路の `readFileSync` をガード
- `RenameWarning` に `unreadable-file` variant を追加、presenter で描画
- unreadable file は `filesScanned` にカウントしない

### 5. `src/plan-coverage/index.ts` (メタレビュー Rank 5)

- `safeRead` を try/catch でガード
- 既存の `BuildWarning[]` チャネルに `unreadable-file` を積む (専用 field 追加不要 — 既存の warnings 経路を再利用)

### Follow-up (scope-out)

- #294: `parsers/markdown.ts` の `parseMarkdown()` エントリ (dead-code) の同種ガード
- #295: `catch (e)` の EACCES/EISDIR vs. EMFILE 混同 (crossbcutting 設計課題)

## Change type

- [x] fix (bug fix)

## Testing

### 新規テスト
- `tests/builder.test.ts`: 3 tests (unreadable .md 継続 / autoNodes=false 抑止 / lock round-trip regression) + 対称性明文化 test
- `tests/rename-cli.test.ts`: 3 tests (rename / split / merge の EISDIR 継続)
- `tests/plan-coverage.test.ts`: 3 tests (tasks.md / plan.md / spec.md 各々の EISDIR 継続)

### CI green
- [x] `pnpm test` — 2155+ passed / 17 skipped / 0 failed
- [x] `pnpm exec tsc --noEmit` — clean
- [x] pre-commit hook (oxlint / oxfmt) — pass

### 実機 E2E 検証 (dist/cli.js on fixed HEAD vs. pre-fix baseline)

Pre-fix (`f377da9`) では `EISDIR: illegal operation on a directory, read` の raw stack で全 3 コマンド crash を再現。Fixed (`d70a405`) で以下シナリオ全 PASS:

| シナリオ | 結果 |
|---|---|
| A: `scan` / `check` / `impact` on EISDIR .md | ✅ exit 0、`unreadable-file` warning、REQ-100 preserved |
| B: `rename --from REQ-200 --to REQ-201` on EISDIR .md | ✅ exit 0、他の md は正しく rewrite、warning 出力 |
| C: `plan-coverage --spec ...` on EISDIR tasks.md | ✅ exit 0、warning 出力 |
| D: 未読 → readable 復帰 round-trip で偽 drift 無し | ✅ `.trace.lock` に sentinel が入らない、復帰後は真の hash で lock 正常化 |

## Breaking change

- [x] No

破壊的変更なし。挙動改善のみ:
- 従来 crash していた入力に対し正常応答 + warning 出力に変わる
- lock file 形式は変わらない (sentinel は lock に載らない設計)
- 既存 pass する入力の挙動は無変化

## Notes

- 元 issue #277 の scope (builder.ts のみ) から拡張したのは敵対的メタレビューで実測発見した 2 経路 (rename / plan-coverage) を潰すため。同じ問題クラスが別コマンドに残ると「scan は復活したのに rename は落ちる」という不整合な UX になるため一気に解消。
- Bare doc node の hash sentinel 化は #264 TS 側先例が「hash("") を sentinel に使うと本物の空 file と衝突する」と警告していたのを doc 側に適用。TS 側は kind として lock 対象外なので現れなかったが、doc 側では顕在化した設計盲点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfhwHk99jzY9ix39SyUuXB