### PR TITLE
fix(check,plan-coverage): reject option-like values on gate-relevant flags

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -3,7 +3,7 @@
 import { Command, InvalidArgumentError, Option } from "commander";
 import type { ArtifactGraph, CheckResult } from "../types.js";
 import type { BaselineIssues } from "../baseline.js";
-import { pathsToEntries, resolveTestResults } from "./shared.js";
+import { nonOptionValue, pathsToEntries, resolveTestResults } from "./shared.js";
 import { printWarnings } from "./presenters/warnings.js";
 import { printCheckText } from "./presenters/check.js";
 
@@ -49,12 +49,23 @@ export function registerCheckCommand(program: Command): void {
         return value;
       }),
     )
-    .option(
-      "--ignore <csv>",
-      "Comma-separated REQ-IDs to drop from newIssues.uncovered (one-shot; not persisted). See issue #178.",
-      "",
+    // issue #306 (F6) — parse-time swallow guard (see `nonOptionValue`):
+    // `--ignore --gate` must be a usage error, never a disarmed gate. An
+    // empty CSV stays legal-by-design (T178-4).
+    .addOption(
+      new Option(
+        "--ignore <csv>",
+        "Comma-separated REQ-IDs to drop from newIssues.uncovered (one-shot; not persisted). See issue #178.",
+      )
+        .default("")
+        .argParser(nonOptionValue("--ignore", { allowEmpty: true })),
     )
-    .option("--format <format>", "Output format: json | text", "text")
+    // issue #306 (F7) — `.choices()` (the doctor/rename/plan-coverage/
+    // integrate convention) rejects both a swallowed flag (`--format --gate`)
+    // and a bogus value (previously a silent fall-through to text), exit 1.
+    .addOption(
+      new Option("--format <format>", "Output format").choices(["json", "text"]).default("text"),
+    )
     .action(async (opts) => {
       const rootDir = process.cwd();
 

--- a/src/commands/plan-coverage.ts
+++ b/src/commands/plan-coverage.ts
@@ -3,7 +3,7 @@
 import { Command, Option } from "commander";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { nonOptionValue, reportGraphWarnings } from "./shared.js";
+import { DASH_PATH_HINT, nonOptionValue, reportGraphWarnings } from "./shared.js";
 
 // spec 014 (FR-013 — FR-020): plan-coverage subcommand. Reads tasks.md /
 // plan.md (and the current spec.md) to detect REQs that are *affected*
@@ -21,28 +21,32 @@ export function registerPlanCoverageCommand(program: Command): void {
     )
     // issue #306 — parse-time swallow guards (see `nonOptionValue` in
     // shared.ts): this command carries `--gate`, so a value-taking option
-    // whose CI variable expands to nothing (`--tasks $PATH --gate` →
-    // `--tasks --gate`) would consume `--gate` as its value and silently
-    // disarm the gate (verified: exit 0 today). Paths/dirs also reject the
+    // whose CI variable expands to nothing (`--ignore $CSV --gate` →
+    // `--ignore --gate`) consumes `--gate` as its value and silently
+    // disarms the gate (verified fail-open: exit 0 with the ignore list
+    // showing "--gate"). The path/dir flags (`--spec`/`--tasks`/`--plan`)
+    // swallow `--gate` the same way but then usually fail on the bogus
+    // path (exit 1) — guarded anyway so the error names the real mistake
+    // instead of "tasks.md not found: --gate". Paths/dirs also reject the
     // empty string (an empty override can only be an unset variable);
     // `--ignore ""` stays legal-by-design, mirroring `check --ignore`.
     .addOption(
       new Option(
         "--spec <dir>",
         "Spec directory (auto-detected via SPECIFY_FEATURE_DIRECTORY or .specify/feature.json)",
-      ).argParser(nonOptionValue("--spec")),
+      ).argParser(nonOptionValue("--spec", { hint: DASH_PATH_HINT })),
     )
     .addOption(
       new Option(
         "--tasks <path>",
         "Override the tasks.md path (default: <spec-dir>/tasks.md)",
-      ).argParser(nonOptionValue("--tasks")),
+      ).argParser(nonOptionValue("--tasks", { hint: DASH_PATH_HINT })),
     )
     .addOption(
       new Option(
         "--plan <path>",
         "Override the plan.md path (default: <spec-dir>/plan.md if present)",
-      ).argParser(nonOptionValue("--plan")),
+      ).argParser(nonOptionValue("--plan", { hint: DASH_PATH_HINT })),
     )
     .addOption(
       new Option("--format <format>", "Output format").choices(["json", "text"]).default("text"),

--- a/src/commands/plan-coverage.ts
+++ b/src/commands/plan-coverage.ts
@@ -3,7 +3,7 @@
 import { Command, Option } from "commander";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { reportGraphWarnings } from "./shared.js";
+import { nonOptionValue, reportGraphWarnings } from "./shared.js";
 
 // spec 014 (FR-013 — FR-020): plan-coverage subcommand. Reads tasks.md /
 // plan.md (and the current spec.md) to detect REQs that are *affected*
@@ -19,17 +19,40 @@ export function registerPlanCoverageCommand(program: Command): void {
     .description(
       "Detect implicit REQ impacts: REQs reached by tasks.md/plan.md `Files:` that are never mentioned in the spec trio.",
     )
-    .option(
-      "--spec <dir>",
-      "Spec directory (auto-detected via SPECIFY_FEATURE_DIRECTORY or .specify/feature.json)",
+    // issue #306 — parse-time swallow guards (see `nonOptionValue` in
+    // shared.ts): this command carries `--gate`, so a value-taking option
+    // whose CI variable expands to nothing (`--tasks $PATH --gate` →
+    // `--tasks --gate`) would consume `--gate` as its value and silently
+    // disarm the gate (verified: exit 0 today). Paths/dirs also reject the
+    // empty string (an empty override can only be an unset variable);
+    // `--ignore ""` stays legal-by-design, mirroring `check --ignore`.
+    .addOption(
+      new Option(
+        "--spec <dir>",
+        "Spec directory (auto-detected via SPECIFY_FEATURE_DIRECTORY or .specify/feature.json)",
+      ).argParser(nonOptionValue("--spec")),
     )
-    .option("--tasks <path>", "Override the tasks.md path (default: <spec-dir>/tasks.md)")
-    .option("--plan <path>", "Override the plan.md path (default: <spec-dir>/plan.md if present)")
+    .addOption(
+      new Option(
+        "--tasks <path>",
+        "Override the tasks.md path (default: <spec-dir>/tasks.md)",
+      ).argParser(nonOptionValue("--tasks")),
+    )
+    .addOption(
+      new Option(
+        "--plan <path>",
+        "Override the plan.md path (default: <spec-dir>/plan.md if present)",
+      ).argParser(nonOptionValue("--plan")),
+    )
     .addOption(
       new Option("--format <format>", "Output format").choices(["json", "text"]).default("text"),
     )
     .option("--gate", "Exit 1 when implicit impacts or diagnostics are non-empty (CI use)")
-    .option("--ignore <csv>", "Comma-separated REQ-IDs to drop from implicit list (one-shot)", "")
+    .addOption(
+      new Option("--ignore <csv>", "Comma-separated REQ-IDs to drop from implicit list (one-shot)")
+        .default("")
+        .argParser(nonOptionValue("--ignore", { allowEmpty: true })),
+    )
     .action(async (opts) => {
       const rootDir = process.cwd();
       const { resolveSpecDir } = await import("../plan-coverage/spec-resolver.js");

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -3,11 +3,40 @@
 // behavior change, only relocation so each command module can import just
 // what it needs instead of everything living in one 2,000-line file.
 
+import { InvalidArgumentError } from "commander";
 import type { ArtgraphConfig, SymbolEntry, TestResultMap } from "../types.js";
 import { parseAgentsList, AgentsParseError } from "../agents/parse-agents.js";
 import { AGENT_IDS, type AgentId } from "../agents/descriptors.js";
 import type { BuildWarning } from "../graph/builder.js";
 import { printWarnings } from "./presenters/warnings.js";
+
+// issue #306 (PR #304 review F6/F7) — commander's required option-args are
+// greedy: a value-taking `--flag` immediately followed by ANOTHER flag
+// consumes that flag as its value (commander Readme, "Options with an
+// expected option-argument are greedy"). On a gate-relevant command the
+// swallowed flag is typically `--gate` itself, so a CI variable expanding to
+// nothing (`--ignore $CSV --gate` → `--ignore --gate`) silently DISARMS the
+// gate and the run exits 0 — fail-open. This parse-time guard mirrors
+// `check --base`'s bespoke validator (spec 023, contracts/cli-check-base.md
+// §1): a value may never start with `-`. `allowEmpty` distinguishes flags
+// whose empty value is legal-by-design (`--ignore ""`, T178-4) from flags
+// where an empty value can only be an unset variable (paths / dirs).
+export function nonOptionValue(
+  flag: string,
+  { allowEmpty = false }: { allowEmpty?: boolean } = {},
+): (value: string) => string {
+  return (value: string): string => {
+    if (!allowEmpty && value === "") {
+      throw new InvalidArgumentError(`${flag} value must not be empty (is a CI variable unset?).`);
+    }
+    if (value.startsWith("-")) {
+      throw new InvalidArgumentError(
+        `${flag} value must not start with "-" (got "${value}" — a missing value swallows the next flag).`,
+      );
+    }
+    return value;
+  };
+}
 
 // spec 016 (R-003) — direct CLI / --diff inputs come in as raw
 // strings (file paths or `path:symbol` declarations). lift each into the

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -23,7 +23,7 @@ import { printWarnings } from "./presenters/warnings.js";
 // where an empty value can only be an unset variable (paths / dirs).
 export function nonOptionValue(
   flag: string,
-  { allowEmpty = false }: { allowEmpty?: boolean } = {},
+  { allowEmpty = false, hint }: { allowEmpty?: boolean; hint?: string } = {},
 ): (value: string) => string {
   return (value: string): string => {
     if (!allowEmpty && value === "") {
@@ -31,12 +31,17 @@ export function nonOptionValue(
     }
     if (value.startsWith("-")) {
       throw new InvalidArgumentError(
-        `${flag} value must not start with "-" (got "${value}" — a missing value swallows the next flag).`,
+        `${flag} value must not start with "-" (got "${value}" — a missing value swallows the next flag${hint ? `; ${hint}` : ""}).`,
       );
     }
     return value;
   };
 }
+
+// The escape hatch for a path that genuinely starts with `-` (mirrors the
+// `check --base` guard documenting its `refs/...` spelling — review F3).
+export const DASH_PATH_HINT =
+  'prefix a relative path with "./" for a name that really starts with "-"';
 
 // spec 016 (R-003) — direct CLI / --diff inputs come in as raw
 // strings (file paths or `path:symbol` declarations). lift each into the

--- a/tests/cli-error-messages.test.ts
+++ b/tests/cli-error-messages.test.ts
@@ -19,7 +19,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { runAt } from "./helpers.js";
+import { gitInit, runAt } from "./helpers.js";
 
 describe("CLI: --agents error UX (spec 013 FR-001 / FR-002 / SC-006 / A1)", () => {
   let initTmp: string;
@@ -139,5 +139,88 @@ describe("CLI: --agents error UX (spec 013 FR-001 / FR-002 / SC-006 / A1)", () =
     expect(stderr).toContain('Did you mean "claude"?');
     expect(stderr).toContain("Also duplicated once case is normalized");
     expect(stderr).toContain('"claude"');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// issue #306 (PR #304 review F6/F7) — value-required options on GATE-relevant
+// commands must reject option-like and (for paths) empty values at parse
+// time. commander's required option-args are greedy, so `--ignore --gate`
+// consumes `--gate` as the CSV and silently DISARMS the gate — the run then
+// exits 0 with the issue printed but not judged (fail-open). Same class as
+// spec 023's `--base --gate` guard (contracts/cli-check-base.md §1).
+// Parse-time errors need no real project fixture — commander rejects the
+// argv before the action ever runs — but we still run inside a tmp dir so a
+// stray `.artgraph.json` in the repo can't leak in.
+// ---------------------------------------------------------------------------
+describe("CLI: gate-relevant option-value swallow guards (issue #306)", () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "artgraph-306-"));
+  });
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("check --diff --ignore --gate → parse error exit 1 (F6: gate must not be swallowed)", async () => {
+    const { exitCode, stderr, stdout } = await runAt(tmp, [
+      "check",
+      "--diff",
+      "--ignore",
+      "--gate",
+    ]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('must not start with "-"');
+    expect(stdout.trim()).toBe("");
+  });
+
+  it('check --diff --ignore "" stays legal (T178-4 contract preserved)', async () => {
+    // Minimal git repo so the action reaches its normal "no changes" exit —
+    // the point is the PARSER accepts the empty CSV (no InvalidArgumentError).
+    gitInit(tmp);
+    const { exitCode, stderr } = await runAt(tmp, ["check", "--diff", "--ignore", ""]);
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain("must not be empty");
+    expect(stderr).not.toContain('must not start with "-"');
+  });
+
+  it("check --diff --format --gate → parse error exit 1 (F7: swallowed flag rejected by choices)", async () => {
+    const { exitCode, stderr } = await runAt(tmp, ["check", "--diff", "--format", "--gate"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Allowed choices are json, text");
+  });
+
+  it("check --format bogus → exit 1 (F7: no more silent fall-through to text)", async () => {
+    const { exitCode, stderr } = await runAt(tmp, ["check", "--format", "bogus"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Allowed choices are json, text");
+  });
+
+  it("plan-coverage --tasks --gate → parse error exit 1 (was: gate silently disarmed, exit 0)", async () => {
+    const { exitCode, stderr } = await runAt(tmp, ["plan-coverage", "--tasks", "--gate"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('must not start with "-"');
+  });
+
+  it('plan-coverage --spec "" --gate → parse error exit 1 (empty path can only be an unset variable)', async () => {
+    const { exitCode, stderr } = await runAt(tmp, ["plan-coverage", "--spec", "", "--gate"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("must not be empty");
+  });
+
+  it('plan-coverage --ignore --gate → parse error exit 1; --ignore "" stays legal', async () => {
+    const swallowed = await runAt(tmp, ["plan-coverage", "--ignore", "--gate"]);
+    expect(swallowed.exitCode).toBe(1);
+    expect(swallowed.stderr).toContain('must not start with "-"');
+
+    const empty = await runAt(tmp, ["plan-coverage", "--ignore", ""]);
+    expect(empty.stderr).not.toContain("must not be empty");
+    expect(empty.stderr).not.toContain('must not start with "-"');
+  });
+
+  it("plan-coverage --plan --gate → parse error exit 1", async () => {
+    const { exitCode, stderr } = await runAt(tmp, ["plan-coverage", "--plan", "--gate"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('must not start with "-"');
   });
 });

--- a/tests/cli-error-messages.test.ts
+++ b/tests/cli-error-messages.test.ts
@@ -196,7 +196,7 @@ describe("CLI: gate-relevant option-value swallow guards (issue #306)", () => {
     expect(stderr).toContain("Allowed choices are json, text");
   });
 
-  it("plan-coverage --tasks --gate → parse error exit 1 (was: gate silently disarmed, exit 0)", async () => {
+  it("plan-coverage --tasks --gate → parse error exit 1 (was: gate swallowed, confusing path error)", async () => {
     const { exitCode, stderr } = await runAt(tmp, ["plan-coverage", "--tasks", "--gate"]);
     expect(exitCode).toBe(1);
     expect(stderr).toContain('must not start with "-"');


### PR DESCRIPTION
## Summary

Closes #306 (PR #304 敵対的レビュー F6/F7 の切り出し)。

commander の値必須 option-arg は貪欲で、直後に別フラグが来るとそれを値として消費する。gate 関連コマンドでは食われるのが典型的に `--gate` 自身であり、CI 変数の空展開でゲートが**無言解除**される (いずれも実証済み):

- `check --diff --ignore --gate` → 新規 issue が**表示された上で**判定されず exit 0 (fail-open)
- `check --diff --format --gate` → 同様 exit 0 (fail-open)
- `plan-coverage --ignore --gate` → gate 解除で exit 0 (fail-open)
- `plan-coverage --tasks/--plan/--spec --gate` → gate は食われるが bogus path でエラー停止 (exit 1) or spec 未検出ガイダンス — fail-open ではないが原因不明のエラーになるためガード対象

対処 (spec 023 の `--base` ガードと同クラス・同 convention):

- `shared.ts` に `nonOptionValue()` argParser factory を追加 — `-` 開始の値を parse 時に `InvalidArgumentError` (exit 1) で拒否。パス/ディレクトリ系は空文字も拒否 (空は未設定 CI 変数でしかあり得ない)。`-` 開始の正当なパスの逃げ道 (`./` prefix) をメッセージに明記
- `check`: `--ignore` をガード (空 CSV は T178-4 どおり合法のまま)、`--format` を `.choices(["json","text"])` へ (doctor/rename/plan-coverage/integrate の既存 convention に整列 — bogus 値の無言 text フォールバックも exit 1 に)
- `plan-coverage`: `--spec` / `--tasks` / `--plan` をガード (空文字も拒否)、`--ignore` をガード (空は合法)

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — pre-push フックで unit/e2e/knip/typecheck 全グリーン
- [x] Added tests where needed — `tests/cli-error-messages.test.ts` に 8 テスト (swallow 3 系統 × check/plan-coverage、`--ignore ""` の合法性維持、`--format bogus` の exit 1 化、空パス拒否)。8 本すべて修正前 (a973ecd) で fail することを敵対的レビューが独立確認済み
- [x] Ran `pnpm -r knip` and `pnpm -r build`

敵対的レビュー実施済み: 修正前ビルドでの fail-open 再現、commander 13.1.0 の `.default("")`×argParser 非干渉・`=`構文の受理、repo 内全利用箇所 (Skills 5 複製 / integrate テンプレ / Stop hook / workflows) の非回帰を実機検証 — Low 超の指摘なし (Low 2 件は反映済み: 057116c)。

## Breaking change

- [ ] Yes (described below)
- [x] No

挙動変更は「これまで誤動作していた入力がエラーになる」方向のみ: (a) `-` 開始の値 → exit 1、(b) `check --format <bogus>` の無言 text フォールバック → exit 1 (兄弟コマンドの既存挙動に整列)。正当な利用 (`--ignore ""`、`--format json`、`--format=json`、Stop hook の `check --gate --diff`) は不変。

## Notes

- 非 gate コマンド (scan/doctor/rename/impact/trace/init) の値必須オプションにも同型の swallow はあるが、`--gate` を持たず fail-open にならない (最悪でも紛らわしいエラー/text フォールバック) ため範囲外とした
- `--gate` を持つコマンドは check / plan-coverage / integrate の 3 つで、integrate の値必須オプションは `.choices()` 済みの `--format` のみ — 本 PR でスコープ完結

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHmY4p5KJhVs7NARBD8u3a