### PR TITLE
fix(check): fail closed when a downstream baseline failure meets an out-of-graph diff

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -328,10 +328,23 @@ export function registerCheckCommand(program: Command): void {
         // diff (and hence "not tracked") is unverifiable without a base
         // point, so the run falls through to the fail-closed `unavailable`
         // verdict instead of a green early exit.
+        // issue #307 — same rule for a DOWNSTREAM baseline failure (worktree
+        // add / submodules / scan crash → `status:"unavailable"`, no graph):
+        // `baselineStartIds` is then empty not because the changed files
+        // resolved to nothing on the baseline side but because there was no
+        // baseline graph to resolve against. Taking the green early exit
+        // here fails open on exactly the case the baseline union exists for
+        // (a deleted file whose sole `@impl` edge lives only on the baseline
+        // side — spec 017 US2 AS3 / #229). Note `baseline` is only ever
+        // built when `anyBaselineResolvable` said the baseline COULD matter,
+        // so this never blocks the classic "untracked README" exit 0 (there
+        // `baseline` stays undefined and the exit is safe). FR-010:
+        // undeterminable is never a silent pass.
         if (
           currentStartIds.length === 0 &&
           baselineStartIds.length === 0 &&
-          baseUnavailableError === undefined
+          baseUnavailableError === undefined &&
+          baseline?.status !== "unavailable"
         ) {
           // spec 017 (Critical fix D1, issue #182 review) — same E4-style gap
           // as the `diffFiles.length === 0` branch above: `--format json` was

--- a/tests/check-base-ref.test.ts
+++ b/tests/check-base-ref.test.ts
@@ -378,11 +378,11 @@ describe("check --base fail-closed errors (spec 023 US3)", () => {
       { cwd: dir, stdio: "pipe" },
     );
     gitCommitAll(dir, "add submodule");
-    // An in-graph change so the run reaches the unavailable REPORTING path —
-    // a diff touching only non-graph files (.gitmodules, the gitlink) takes
-    // the pre-existing "not tracked" early exit before baselineStatus is
-    // ever surfaced (same shape as on main without --base; noted for
-    // follow-up, out of scope here).
+    // An in-graph change so this test exercises the unavailable REPORTING
+    // path through the normal scope flow. (A diff touching only non-graph
+    // files now ALSO fails closed — issue #307 — pinned by its own tests in
+    // tests/check-baseline-diff.test.ts; this test keeps the in-graph shape
+    // so the two pins stay independent.)
     introduceNewOrphan(dir);
 
     const { stderr, exitCode } = await runAt(dir, ["check", "--diff", "--base", "base", "--gate"]);

--- a/tests/check-baseline-diff.test.ts
+++ b/tests/check-baseline-diff.test.ts
@@ -1054,3 +1054,66 @@ describe("spec 021 (T019, issue #218) — method edit double-drift + baseline un
     expect(json.pass).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// issue #307 — a DOWNSTREAM baseline failure (here: submodules → worktree
+// path unavailable) combined with a diff whose changed files are all outside
+// the current graph used to take the "Changed files are not tracked in the
+// graph." early exit at exit 0: `baselineStartIds` was empty only because
+// there was NO baseline graph to resolve against, not because the baseline
+// side had nothing to say. Fail closed instead (spec 017 FR-010) — with
+// `--gate` the dedicated unavailable exit 1, without it the display-only
+// warning path. The classic safe case (changed files outside the graph AND
+// baseline never attempted) keeps its exit 0.
+// ---------------------------------------------------------------------------
+describe("check --diff: downstream unavailable must not hide behind the not-tracked exit (issue #307)", () => {
+  function repoWithSubmoduleAndOutOfGraphEdit(prefix: string): string {
+    const dir = repo(prefix); // makeRepoWithDebt, tracked via repos[]
+    const subSrc = track(mkdtempSync(join(tmpdir(), `${prefix}subsrc-`)));
+    gitInit(subSrc);
+    writeFileSync(join(subSrc, "lib.txt"), "lib\n");
+    gitCommitAll(subSrc, "lib init");
+    execFileSync(
+      "git",
+      ["-c", "protocol.file.allow=always", "submodule", "add", subSrc, "vendor/lib"],
+      { cwd: dir, stdio: "pipe" },
+    );
+    writeFileSync(join(dir, "README.md"), "# readme\n");
+    gitCommitAll(dir, "add submodule + tracked out-of-graph README");
+    // The unstaged edit to a TRACKED, out-of-graph file makes the diff
+    // non-empty and `anyBaselineResolvable` true (README is in HEAD's tree),
+    // so the baseline IS attempted — and fails on the submodule guard.
+    appendFileSync(join(dir, "README.md"), "\nout-of-graph edit\n");
+    return dir;
+  }
+
+  it("--gate → unavailable exit 1 (was: 'not tracked' exit 0, fail-open)", async () => {
+    const dir = repoWithSubmoduleAndOutOfGraphEdit("artgraph-307-gate-");
+    const { stdout, stderr, exitCode } = await runAt(dir, ["check", "--diff", "--gate"]);
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("could not establish a baseline (git worktree unavailable).");
+    expect(stderr).toContain("gate result is undetermined; not treating as pass.");
+    expect(stdout).not.toContain("Changed files are not tracked in the graph.");
+  });
+
+  it("no --gate, --format json → exit 0 display-only with baselineStatus unavailable", async () => {
+    const dir = repoWithSubmoduleAndOutOfGraphEdit("artgraph-307-nogate-");
+    const { stdout, exitCode } = await runAt(dir, ["check", "--diff", "--format", "json"]);
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(stdout);
+    expect(json.baselineStatus).toBe("unavailable");
+    expect(json.pass).toBe(false);
+    expect(json.baselineError).toContain("submodules are not supported");
+    expect(json.message ?? "").not.toContain("not tracked");
+  });
+
+  it("regression: healthy repo + out-of-graph edit keeps the 'not tracked' exit 0", async () => {
+    const dir = repo("artgraph-307-healthy-");
+    writeFileSync(join(dir, "README.md"), "# readme\n");
+    gitCommitAll(dir, "tracked out-of-graph README");
+    appendFileSync(join(dir, "README.md"), "\nedit\n");
+    const { stdout, exitCode } = await runAt(dir, ["check", "--diff", "--gate"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Changed files are not tracked in the graph.");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #307 (PR #304 のレビュー過程で発見された pre-existing の fail-open corner)。

`computeBaselineIssues` が ref 解決より**下流**で失敗し (submodule / worktree 構築失敗 / scan 例外 → `baselineStatus:"unavailable"`、baseline graph なし)、かつ変更ファイルが全て現在グラフ外の場合、「Changed files are not tracked in the graph.」の early exit が **exit 0** で先に発火し、fail-closed の unavailable 報告 (`--gate` で exit 1) に到達しなかった。`baselineStartIds` が空なのは「baseline 側に何もなかった」からではなく「解決すべき baseline graph が存在しなかった」からであり、削除ファイルの sole `@impl` エッジ (spec 017 US2 AS3 / #229 — baseline 側でのみ解決可能) がこの隙間からゲートを素通りし得た。

対処: early exit の条件に `baseline?.status !== "unavailable"` を追加し、既存の fail-closed unavailable 経路 (`--gate`: 専用 exit 1 / なし: 表示のみ警告 + `pass:false`) へ落とす。

安全な古典ケース — 変更ファイルがグラフ外かつ baseline がそもそも試行されない (`anyBaselineResolvable` false、例: untracked README のみの diff) — は exit 0 のまま (回帰テストで固定)。

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — pre-push フックで全グリーン
- [x] Added tests where needed — `tests/check-baseline-diff.test.ts` に 3 テスト: (a) submodule 下流失敗 × グラフ外 tracked ファイル編集 + `--gate` → exit 1 (「git worktree unavailable」見出し、"not tracked" 非表示)、(b) 同 `--gate` なし `--format json` → exit 0 表示のみ・`baselineStatus:"unavailable"`・`pass:false`、(c) 健全 repo × グラフ外編集 → "not tracked" exit 0 維持
- [x] Ran `pnpm -r knip` and `pnpm -r build`

敵対的レビュー実施済み (Low 超の指摘なし): baseline 5 状態 × startIds × gate/json の全マトリクスを実機検証、pre-fix ビルド (cff0892~1) で failing-mode テスト 2 本の red と実害シナリオ (submodule repo で sole `@impl` ファイルを `rm` → 旧 exit 0 / 新 exit 1) を再現、unborn HEAD ("empty") の FR-014 経路と untracked-only の exit 0 維持、dirty gitlink の新規 fail-closed 化 (意図どおり) を確認。

## Breaking change

- [ ] Yes (described below)
- [x] No

挙動変更は fail-open だった隙間の封鎖のみ。副作用として、submodule repo (baseline 恒常 unavailable) では**グラフ外 tracked ファイルの編集や gitlink の進行でも** `--gate` が exit 1 になる (これまではグラフ内編集のみ exit 1)。submodule は baseline diff 未対応として既に fail-closed が仕様 (spec 017 B9 / spec 023 Out of Scope) であり、この一貫化は意図どおり。untracked 新規ファイルのみの diff は baseline 未試行のため従来どおり exit 0。

## Notes

- 実挙動変更は 1 条件の追加のみ (`src/commands/check.ts`)。エラー見出しは PR #304 F3 で導入済みの stage 別分岐 (「git worktree unavailable」) がそのまま正しく効く
- 発見経緯: PR #304 の F3 テスト作成中にこの経路を踏んだ (該当テストのコメントも本 PR で追随更新)
- レビューの Low 観察 2 件 (対応不要判定・記録): (a) 新 fall-through 経路の `--gate` なし text モードは stdout が空 (stderr の WARNING のみ — contract §4.5 整合)、(b) early exit の JSON が baseline を実際には構築済み ("computed"/"empty") でも `baselineStatus:"skipped"` を返すのは #229 以降の pre-existing な表記ズレ (cosmetic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHmY4p5KJhVs7NARBD8u3a