### PR TITLE
fix(release): switch to per-component release branches to fix auto-tagging

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,5 +28,5 @@
     }
   },
   "pull-request-title-pattern": "chore(release): release ${version}",
-  "separate-pull-requests": false
+  "separate-pull-requests": true
 }


### PR DESCRIPTION
## Summary

`release-please` の自動PR作成が止まっていた件を調査したところ、v0.1.0〜v0.2.1の全リリースで、GitHub Release/タグが `release-please` 自身によって自動作成されたことが一度もなく、毎回手動対応していたことが判明しました（実行ログ上はジョブが green で終わるため気づきにくい）。

原因は `release-please` の `buildRelease()`（`src/strategies/base.ts`）内の以下のチェックです:

```typescript
if (pullRequestBody.releaseData.length === 1 && !pullRequestBody.releaseData[0].component) {
  const branchComponent = await this.getBranchComponent();
  if (this.normalizeComponent(branchName.component) !== this.normalizeComponent(branchComponent)) {
    this.logger.warn(`PR component: ${branchName.component} does not match configured component: ${branchComponent}`);
    return; // ← release オブジェクトの構築自体を打ち切る
  }
}
```

- `separate-pull-requests: false`（単一の統合リリースPR方式）だと、ブランチ名は常に `release-please--branches--main` で、component情報を一切含まない → `branchName.component` は `undefined`
- `getBranchComponent()` は `package-name: "artgraph"`（またはpackage.jsonの`name`フィールド）から常に `"artgraph"` を返す
- `undefined !== "artgraph"` で不一致となり、`buildRelease()` が即座に `return` — 何も作成されない

`include-component-in-tag: false` はタグ名からcomponentを除く設定であり、このブランチ名照合チェックには一切効きません。

## Change type

- [x] fix (bug fix)
- [ ] feat (new feature)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — 設定ファイルのみの変更のため影響なし
- [ ] Added tests where needed — 設定変更のため対象外
- [x] Ran `pnpm -r knip` and `pnpm -r build` — 影響なし

実地検証はマージ後、次回の release-please 実行（このPRのマージ自体がトリガーになります）でブランチ名が `release-please--branches--main--components--artgraph` になり、GitHub Release/タグが自動生成されることを確認する形になります。

`.github/workflows/pack-smoke.yml` のリリースPR検出は `startsWith(github.head_ref, 'release-please--branches--')` の前方一致なので、この変更後も引き続き正しく動作します（確認済み）。

## Breaking change

- [ ] Yes (described below)
- [x] No

`separate-pull-requests: true` に変更しますが、このリポジトリはパッケージが1つ（`.`）のみなので、実際に作られるPRは引き続き1本だけです。ブランチ名・PRタイトルの命名規則が変わるのみで、タグ形式（`v0.3.0`等）・CHANGELOG生成・manifestのバージョン管理には影響しません。

## Notes

- 既存のオープン中リリースPR（旧ブランチ形式）は、このPRマージ後にrelease-pleaseが新しいcomponent付きブランチで再作成する見込みです。挙動を確認の上、必要なら旧PRをクローズします。


---
_Generated by [Claude Code](https://claude.ai/code/session_012qWw3p9udJo6RaXEskykq3)_