### PR TITLE
fix(ci): pin scorecard-action to commit SHA, not tag object SHA

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

`.github/workflows/scorecard.yml` was failing on every run (e.g. [run 29492603943](https://github.com/mori-shin-x/artgraph/actions/runs/29492603943)) at the "Run analysis" step. The `ossf/scorecard-action@...` pin for `v2.4.3` resolved to the annotated tag object's SHA (`99c09fe975337306107572b4fdf4db224cf8e2f2`) rather than the commit it points to (`4eaacf0543bb3f2c246792bd56e8cdeffafb205a`). GitHub Actions can still resolve and run the action against a tag object SHA, but Scorecard's result-publishing step verifies server-side that the pinned SHA is a real commit in `ossf/scorecard-action`; since it wasn't, publishing failed with `imposter commit: 99c09fe9... does not belong to ossf/scorecard-action` and the job exited non-zero after retries.

Fix: re-pin to the dereferenced commit SHA for the same `v2.4.3` release.

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [ ] Existing tests pass (`pnpm -r test`)
- [ ] Added tests where needed
- [ ] Ran `pnpm -r knip` and `pnpm -r build`

Not applicable — this is a single-line SHA change to a GitHub Actions workflow file with no code/test surface. Verified the target commit is correct via the GitHub API (tag ref → tag object → underlying commit, commit exists with message "bump docker to ghcr v2.4.3 (#1587)").

## Breaking change

- [ ] Yes (described below)
- [x] No

## Notes

Root-caused via the failing run's job logs (`imposter commit` error from the Scorecard results-publishing API) and cross-checked against the GitHub API for `ossf/scorecard-action`'s `v2.4.3` tag.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SEdsAmoatVw8kaYxUP3F1V)_