### PR TITLE
fix(ci): pin two more actions to commit SHA, not tag object SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -110,7 +110,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -151,7 +151,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: github/codeql-action/init@e8e8e51caba890f74f97e228d00b0b81b666ee4c # v3
+      - uses: github/codeql-action/init@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
         with:
           languages: javascript-typescript
 
-      - uses: github/codeql-action/analyze@e8e8e51caba890f74f97e228d00b0b81b666ee4c # v3
+      - uses: github/codeql-action/analyze@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
         with:
           category: '/language:javascript-typescript'

--- a/.github/workflows/pack-smoke.yml
+++ b/.github/workflows/pack-smoke.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,6 +43,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@e8e8e51caba890f74f97e228d00b0b81b666ee4c # v3
+        uses: github/codeql-action/upload-sarif@411c4c9a36b3fca4d674f06b6396b2c6d23522c6 # v3
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Follow-up to #317 (merged), which fixed `ossf/scorecard-action`'s pin being an annotated-tag-object SHA instead of the commit it points to.

That fix prompted an audit of every full-40-hex-SHA action pin in `.github/workflows/` — verified each one's git object type directly (`git cat-file -t <sha>` against the upstream repo) rather than trusting the `# vX` comment. Two more pins turned out to have the exact same bug:

- `github/codeql-action@e8e8e51c...` (`# v3`) — used by `codeql.yml` (`init`/`analyze`) and `scorecard.yml` (`upload-sarif`). Re-pinned to `411c4c9a36b3fca4d674f06b6396b2c6d23522c6`, the commit the `v3` tag object actually points to.
- `pnpm/action-setup@f40ffcd9...` (`# v4`) — used by `ci.yml` (3 jobs), `pack-smoke.yml`, and `publish.yml`. Re-pinned to `b906affcce14559ad1aafd4ab0e942779e9f58b1`, the commit the `v4` tag object actually points to.

Neither of these had visibly broken a job yet — nothing downstream currently verifies the pin is a real commit the way Scorecard's result-publishing API does for `scorecard-action` — but it's the identical latent bug and would fail the same way (`imposter commit` or equivalent) the moment something starts checking.

All other full-SHA pins in the repo (`actions/checkout`, `actions/upload-artifact`, `actions/setup-node`, `googleapis/release-please-action`, `oven-sh/setup-bun`, `denoland/setup-deno`) were confirmed to already point at real commits.

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [ ] Existing tests pass (`pnpm -r test`)
- [ ] Added tests where needed
- [ ] Ran `pnpm -r knip` and `pnpm -r build`

Not applicable — workflow-file-only SHA changes with no code/test surface. Each replacement SHA was verified with `git cat-file -t <sha>` (confirms `commit`, not `tag`) after fetching it from the relevant upstream repo (`github/codeql-action`, `pnpm/action-setup`).

## Breaking change

- [ ] Yes (described below)
- [x] No

## Notes

This PR carries only the second commit from the original branch (the first, scorecard-action fix, already merged via #317); the branch was reset onto latest `main` before adding this commit.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SEdsAmoatVw8kaYxUP3F1V)_