### PR TITLE
fix(observability): unify warning wiring, guard parseMarkdown, branch unreadable-file on errno (#274, #294, #295)

### DIFF
--- a/.agents/skills/_shared/output-schema.md
+++ b/.agents/skills/_shared/output-schema.md
@@ -85,7 +85,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "system-resource-exhausted" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/.claude/skills/_shared/output-schema.md
+++ b/.claude/skills/_shared/output-schema.md
@@ -85,7 +85,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "system-resource-exhausted" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/.cursor/skills/_shared/output-schema.md
+++ b/.cursor/skills/_shared/output-schema.md
@@ -85,7 +85,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "system-resource-exhausted" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/.github/skills/_shared/output-schema.md
+++ b/.github/skills/_shared/output-schema.md
@@ -85,7 +85,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "system-resource-exhausted" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/.kiro/skills/_shared/output-schema.md
+++ b/.kiro/skills/_shared/output-schema.md
@@ -85,7 +85,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "system-resource-exhausted" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -3,8 +3,12 @@
 import { Command, InvalidArgumentError, Option } from "commander";
 import type { ArtifactGraph, CheckResult } from "../types.js";
 import type { BaselineIssues } from "../baseline.js";
-import { nonOptionValue, pathsToEntries, resolveTestResults } from "./shared.js";
-import { printWarnings } from "./presenters/warnings.js";
+import {
+  nonOptionValue,
+  pathsToEntries,
+  resolveTestResults,
+  reportGraphWarnings,
+} from "./shared.js";
 import { printCheckText } from "./presenters/check.js";
 
 export function registerCheckCommand(program: Command): void {
@@ -476,7 +480,7 @@ export function registerCheckCommand(program: Command): void {
         console.log(JSON.stringify({ ...result, warnings }));
       } else {
         printCheckText(result, { diff: !!opts.diff, gate: !!opts.gate });
-        printWarnings(warnings);
+        reportGraphWarnings(warnings);
       }
 
       // spec 017 (contract cli-check-gate §4.4 / §4.5, §3 note) — baseline

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,8 +2,12 @@
 
 import { Command } from "commander";
 import { AGENT_IDS, type AgentId } from "../agents/descriptors.js";
-import { AGENTS_REQUIRED_ERROR, loadIntegrate, parseAgentsFlag } from "./shared.js";
-import { printWarnings } from "./presenters/warnings.js";
+import {
+  AGENTS_REQUIRED_ERROR,
+  loadIntegrate,
+  parseAgentsFlag,
+  reportGraphWarnings,
+} from "./shared.js";
 import { printIntegrateText } from "./presenters/integrate.js";
 
 export function registerInitCommand(program: Command): void {
@@ -141,7 +145,7 @@ export function registerInitCommand(program: Command): void {
             console.log(
               `  req: ${result.scanSummary.reqCount}  doc: ${result.scanSummary.docCount}  file: ${result.scanSummary.fileCount}  test: ${result.scanSummary.testCount}`,
             );
-            printWarnings(result.warnings);
+            reportGraphWarnings(result.warnings);
             console.log(`\nCreated .artgraph.json`);
             console.log(`Created ${result.config.lockFile}`);
           } else {

--- a/src/commands/presenters/warnings.ts
+++ b/src/commands/presenters/warnings.ts
@@ -92,6 +92,17 @@ export function printWarnings(warnings: BuildWarning[]) {
           `WARNING: ${w.message ?? `unreadable-file "${w.id}" in ${w.files.join(", ")}`}`,
         );
         break;
+      // issue #295 — file descriptor exhaustion (EMFILE/ENFILE) hit while
+      // reading a file during the scan. Shown by default (NOT in
+      // SILENT_WARNING_TYPES): this is a system-level problem the user
+      // needs to act on (raise the ulimit), unlike the two silent types
+      // below. `graph/builder.ts` already collapses every occurrence in one
+      // scan down to a single warning, so this case only ever prints once.
+      case "system-resource-exhausted":
+        console.error(
+          `WARNING: ${w.message ?? `system-resource-exhausted "${w.id}" in ${w.files.join(", ")}`}`,
+        );
+        break;
       // issue #287 — the include/testPatterns globs matched a file under
       // node_modules. Shown by default (NOT in SILENT_WARNING_TYPES): the
       // builder-provided message already carries the count and the

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -2,8 +2,7 @@
 
 import { resolve } from "node:path";
 import { Command } from "commander";
-import { resolveTestResults } from "./shared.js";
-import { printWarnings } from "./presenters/warnings.js";
+import { resolveTestResults, reportGraphWarnings } from "./shared.js";
 
 export function registerScanCommand(program: Command): void {
   program
@@ -41,6 +40,18 @@ export function registerScanCommand(program: Command): void {
       }
 
       if (opts.serve || opts.output) {
+        // issue #274(1) — `--serve`/`--output` never called into
+        // `printWarnings`/`reportGraphWarnings` at all: a
+        // `pathological-bracket-nesting` or `class-member-collision` warning
+        // from this same `scan()` call was silently dropped on both of these
+        // paths. Neither branch has a JSON payload (they render HTML), so
+        // print unconditionally — same rationale as `reconcile`'s
+        // no-`--format json`-mode call. Runs before every early
+        // return/`process.exit` below so the warning is never skipped
+        // regardless of which branch (output vs. serve, success vs. error)
+        // is taken.
+        reportGraphWarnings(result.warnings);
+
         const { readLockWithMeta, warnIfNewerLockSchema } = await import("../lock.js");
         const { check } = await import("../check.js");
         const { renderGraphData } = await import("../graph/render.js");
@@ -162,7 +173,7 @@ export function registerScanCommand(program: Command): void {
             `\nTest Results: total=${testResultStats.totalTests} passed=${testResultStats.passedTests} failed=${testResultStats.failedTests}`,
           );
         }
-        printWarnings(result.warnings);
+        reportGraphWarnings(result.warnings);
       }
     });
 }

--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -174,13 +174,21 @@ export function buildGraph(
   const edges: GraphEdge[] = [];
   const warnings: BuildWarning[] = [];
 
-  // issue #295 — `system-resource-exhausted` (EMFILE/ENFILE) is a scan-wide
-  // condition, not a per-file one: both the markdown loop below and the TS
-  // warning-conversion loop further down can independently observe it in
-  // the same `buildGraph()` call. This flag makes the two sites agree on
-  // "has this scan already reported it" so at most one warning of this
-  // type ever lands in `warnings`, regardless of how many files hit it or
-  // which loop (or how many times within a loop) got there first.
+  // issue #295 (PR #334 meta-review LOW-1 wording fix) — `system-resource-
+  // exhausted` (EMFILE/ENFILE) is a scan-wide condition, not a per-file one:
+  // the markdown loop below, the `globCodeFiles` guard, the tsconfig read
+  // guard, and the TS warning-conversion loop further down can each
+  // independently observe it in the same `buildGraph()` call. This flag
+  // makes all of those sites agree on "has this scan already reported it" so
+  // at most one warning of this type ever lands in `warnings`, regardless of
+  // how many files hit it. Which site actually sets the flag is NOT a race:
+  // `buildGraph` runs synchronously, single-threaded, and every guarded site
+  // below executes in a fixed, deterministic order (markdown loop, then the
+  // `globCodeFiles` guard, then the tsconfig read guard, then the TS
+  // warning-conversion loop, which surfaces failures from `parseTSFile`'s own
+  // guarded read) for any given call — which one reports it is fully
+  // determined by which sites this particular scan happens to hit, not by
+  // timing.
   let systemResourceExhaustedReported = false;
 
   // issue #216 — ids with an ignored prefix are excluded at assembly time (no
@@ -535,7 +543,43 @@ export function buildGraph(
   const codePatterns = [...config.include, ...config.testPatterns];
   const tsMode = config.mode ?? "file";
   const codeId = config.reqPatterns?.codeId;
-  const codeFiles = globCodeFiles(rootDir, codePatterns);
+  // Maintenance trap (PR #334 meta-review HIGH-2): this file calls TWO
+  // different glob libraries with OPPOSITE failure semantics. `fast-glob`
+  // (here, and in `globCodeFiles`/`enumerateFiles` in parsers/typescript.ts)
+  // THROWS on a read error (e.g. EMFILE) — guarded below. The markdown loop
+  // above uses the `glob` package's `globSync` (issue #216-era code, line
+  // ~216), which silently swallows read errors and returns an empty match
+  // list instead of throwing — NOT guarded, and deliberately left that way
+  // (pre-existing, tracked separately; see AGENTS.md). Do not assume the two
+  // call sites fail the same way.
+  let codeFiles: string[];
+  try {
+    codeFiles = globCodeFiles(rootDir, codePatterns);
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException)?.code;
+    if (code === "EMFILE" || code === "ENFILE") {
+      if (!systemResourceExhaustedReported) {
+        systemResourceExhaustedReported = true;
+        warnings.push({
+          type: "system-resource-exhausted",
+          id: "glob:code-files",
+          files: [],
+          message:
+            `file descriptor exhaustion (${code}) while globbing code files during this scan; ` +
+            "the process ran out of open file descriptors. Consider raising the OS " +
+            "file-descriptor limit (e.g. `ulimit -n`) and re-running — other file reads " +
+            "in this scan may also be failing the same way. Shown once per scan " +
+            "regardless of how many files were affected.",
+        });
+      }
+      codeFiles = [];
+    } else {
+      // Any other glob failure (e.g. a malformed pattern) is a real problem
+      // the user needs to see, not something to silently paper over with an
+      // empty code-file set — rethrow.
+      throw e;
+    }
+  }
   const relCodeFiles = codeFiles.map((f) => relative(rootDir, f));
 
   // issue #287 — surface configs that still ingest node_modules (pre-#287
@@ -562,9 +606,57 @@ export function buildGraph(
   // change how an UNCHANGED file's import specifier resolves). Any difference
   // invalidates every TS fragment.
   const tsconfigPath = resolve(rootDir, "tsconfig.json");
-  const tsconfigHash = existsSync(tsconfigPath)
-    ? hashContent(readFileSync(tsconfigPath, "utf-8"))
-    : "no-tsconfig";
+  // PR #334 meta-review HIGH-2 — `existsSync` never throws (any error, e.g.
+  // EMFILE, just yields `false`), but the file can still become unreadable
+  // or trip EMFILE/ENFILE on the read itself, in the gap between that check
+  // and this line, or simply because the fd budget is already exhausted by
+  // the time we get here. Pre-fix, an uncaught throw here crashed the WHOLE
+  // build — worse than a missing tsconfig, which `existsSync` returning
+  // `false` already handles fine via the `"no-tsconfig"` sentinel. Fail-safe:
+  // EMFILE/ENFILE report the scan-wide `system-resource-exhausted` type
+  // (deduped via `systemResourceExhaustedReported`, same as every other
+  // guarded read in this module); any other error falls back to the
+  // `"no-tsconfig"` sentinel plus a generic `unreadable-file` warning so the
+  // user knows tsconfig-driven import resolution (jsx/allowJs/
+  // resolveJsonModule) silently did not apply this run.
+  let tsconfigHash: string;
+  if (!existsSync(tsconfigPath)) {
+    tsconfigHash = "no-tsconfig";
+  } else {
+    try {
+      tsconfigHash = hashContent(readFileSync(tsconfigPath, "utf-8"));
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException)?.code;
+      const message = e instanceof Error ? e.message : String(e);
+      if (code === "EMFILE" || code === "ENFILE") {
+        if (!systemResourceExhaustedReported) {
+          systemResourceExhaustedReported = true;
+          warnings.push({
+            type: "system-resource-exhausted",
+            id: "tsconfig.json",
+            files: ["tsconfig.json"],
+            message:
+              `file descriptor exhaustion (${code}) while reading files during this scan; ` +
+              "the process ran out of open file descriptors. Consider raising the OS " +
+              "file-descriptor limit (e.g. `ulimit -n`) and re-running — other file reads " +
+              "in this scan may also be failing the same way. Shown once per scan " +
+              "regardless of how many files were affected.",
+          });
+        }
+      } else {
+        warnings.push({
+          type: "unreadable-file",
+          id: "tsconfig.json",
+          files: ["tsconfig.json"],
+          message:
+            `could not read "tsconfig.json" (${message})${code ? ` [${code}]` : ""}; continuing ` +
+            "as if no tsconfig.json was present. TS import resolution (jsx/allowJs/" +
+            "resolveJsonModule) may differ from a run where it is readable.",
+        });
+      }
+      tsconfigHash = "no-tsconfig";
+    }
+  }
   const tsEnvKey = hashContent(
     JSON.stringify([tsconfigHash, tsMode, codeId ?? null, [...relCodeFiles].sort()]),
   );
@@ -574,6 +666,16 @@ export function buildGraph(
   const fragmentByFile = new Map<string, TsFragment>();
   const missPaths: string[] = [];
   const missHashes = new Map<string, string>();
+  // PR #334 meta-review HIGH-1 — content for every miss path whose read
+  // (below) actually succeeded, handed straight through to `parseTSFilePaths`
+  // so it never re-reads the file. See that function's doc comment for why a
+  // second, independent read here was dangerous (an asymmetric hash-succeeds
+  // / parse-fails race could poison the cache with a broken fragment under a
+  // real, correct hash). A path is deliberately ABSENT from this map when its
+  // own read (below) failed — `parseTSFile`'s guarded read is still the only
+  // thing that attempts (and diagnoses) that file's read, unchanged from
+  // before this fix.
+  const missContents = new Map<string, string>();
   for (let i = 0; i < codeFiles.length; i++) {
     // issue #264 — this read (done purely to compute a cache-validity hash)
     // can throw for exactly the same reason `parseTSFile`'s own read can
@@ -588,9 +690,9 @@ export function buildGraph(
     // `hashContent("")` if that were used as the sentinel instead. The
     // actual "can't read, warn, synthesize a bare node" handling — and the
     // ONLY place the `unreadable-file` warning is emitted from — lives in
-    // `parseTSFile`, which independently attempts (and fails) the same read
-    // for every path in `missPaths`; this catch only needs to avoid crashing
-    // and route the file there, not duplicate that diagnostic.
+    // `parseTSFile`, which independently attempts (and, for this one path,
+    // fails) the same read; this catch only needs to avoid crashing and
+    // route the file there, not duplicate that diagnostic.
     let content: string | undefined;
     try {
       content = readFileSync(codeFiles[i], "utf-8");
@@ -609,10 +711,14 @@ export function buildGraph(
     } else {
       missPaths.push(codeFiles[i]);
       missHashes.set(codeFiles[i], contentHash);
+      // This read succeeded (we're past the `content === undefined` branch
+      // above) — hand it to `parseTSFilePaths` so `parseTSFile` reuses it
+      // instead of reading `codeFiles[i]` a second time (HIGH-1).
+      missContents.set(codeFiles[i], content);
     }
   }
   if (missPaths.length > 0) {
-    const parsed = parseTSFilePaths(rootDir, missPaths, tsMode, codeId);
+    const parsed = parseTSFilePaths(rootDir, missPaths, tsMode, codeId, missContents);
     for (const [abs, frag] of parsed) {
       // Preserve the parser's `starExports` side-channel (specs/018 §3) on the
       // freshly-parsed fragment so the builder's star-expansion pass below

--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -73,6 +73,16 @@ export interface BuildWarning {
     // silent — a scan silently missing a whole file's coverage is exactly
     // the kind of thing the author needs to see.
     | "unreadable-file"
+    // issue #295 — a DIFFERENT unreadable-file failure mode than the one
+    // above: `EMFILE`/`ENFILE` (the process, or the whole system, ran out
+    // of file descriptors) rather than a per-file permission/existence
+    // problem. Unlike `unreadable-file`, this is a scan-wide condition (any
+    // subsequent read may fail the same way), so `buildGraph` emits it at
+    // most ONCE per scan even when both the TS and markdown loops observe
+    // it (see the dedup guard around `warnings.push` below and in the TS
+    // warning-conversion loop). NOT silent — the user needs to act (raise
+    // the ulimit), so it is shown by default like `unreadable-file`.
+    | "system-resource-exhausted"
     // issue #287 — fired when the `include` / `testPatterns` globs matched
     // at least one file under a node_modules directory (any depth).
     // fast-glob does not exclude node_modules by default, so pre-#287
@@ -164,6 +174,15 @@ export function buildGraph(
   const edges: GraphEdge[] = [];
   const warnings: BuildWarning[] = [];
 
+  // issue #295 — `system-resource-exhausted` (EMFILE/ENFILE) is a scan-wide
+  // condition, not a per-file one: both the markdown loop below and the TS
+  // warning-conversion loop further down can independently observe it in
+  // the same `buildGraph()` call. This flag makes the two sites agree on
+  // "has this scan already reported it" so at most one warning of this
+  // type ever lands in `warnings`, regardless of how many files hit it or
+  // which loop (or how many times within a loop) got there first.
+  let systemResourceExhaustedReported = false;
+
   // issue #216 — ids with an ignored prefix are excluded at assembly time (no
   // req node, no edges touching them). Filtering here rather than inside the
   // parsers keeps parse-cache fragments a pure memo of parser output: toggling
@@ -225,16 +244,50 @@ export function buildGraph(
           specDirName && relFile.startsWith(specDirName + "/")
             ? relFile.slice(specDirName.length + 1)
             : relFile;
-        warnings.push({
-          type: "unreadable-file",
-          id: `doc:${docRelPath}`,
-          files: [relFile],
-          message:
-            `could not read "${relFile}" (${message}); skipped req/task/edge extraction for ` +
-            "this file. A bare doc node was still created so it stays visible in the graph, " +
-            "but it carries none of its usual reqs/tasks/edges until the file becomes readable " +
-            "again.",
-        });
+        // issue #295 — same errno branching as the TS side
+        // (`parsers/typescript.ts`'s `parseTSFile`): EACCES/EISDIR/ENOENT
+        // keep the #277 behavior byte-for-byte; EMFILE/ENFILE report the
+        // scan-wide `system-resource-exhausted` type instead, deduped
+        // against the TS loop's own occurrences via
+        // `systemResourceExhaustedReported`; every other code (or none)
+        // keeps the #277 generic message, with the code appended when
+        // present.
+        const code = (e as NodeJS.ErrnoException)?.code;
+        const baseMessage =
+          `could not read "${relFile}" (${message}); skipped req/task/edge extraction for ` +
+          "this file. A bare doc node was still created so it stays visible in the graph, " +
+          "but it carries none of its usual reqs/tasks/edges until the file becomes readable " +
+          "again.";
+        if (code === "EMFILE" || code === "ENFILE") {
+          if (!systemResourceExhaustedReported) {
+            systemResourceExhaustedReported = true;
+            warnings.push({
+              type: "system-resource-exhausted",
+              id: `doc:${docRelPath}`,
+              files: [relFile],
+              message:
+                `file descriptor exhaustion (${code}) while reading files during this scan; ` +
+                "the process ran out of open file descriptors. Consider raising the OS " +
+                "file-descriptor limit (e.g. `ulimit -n`) and re-running — other file reads " +
+                "in this scan may also be failing the same way. Shown once per scan " +
+                "regardless of how many files were affected.",
+            });
+          }
+        } else if (code === "EACCES" || code === "EISDIR" || code === "ENOENT") {
+          warnings.push({
+            type: "unreadable-file",
+            id: `doc:${docRelPath}`,
+            files: [relFile],
+            message: baseMessage,
+          });
+        } else {
+          warnings.push({
+            type: "unreadable-file",
+            id: `doc:${docRelPath}`,
+            files: [relFile],
+            message: code ? `${baseMessage} [${code}]` : baseMessage,
+          });
+        }
         // meta-review (PR #293, issue #277 follow-up) — asymmetry with the
         // readable path: for a readable doc, `autoNodes: false` only
         // suppresses nodes whose id equals `expectedAutoDocId` (a doc with
@@ -598,6 +651,17 @@ export function buildGraph(
     // cross-version fragment that predates the field (SCHEMA_VERSION 6
     // normally cold-invalidates those, but conversion must never crash).
     for (const tw of frag.warnings ?? []) {
+      // issue #295 — `system-resource-exhausted` is scan-wide, not per-file
+      // (see `systemResourceExhaustedReported`'s declaration above): a warm
+      // cache hit can replay one of these per fragment, and the TS side can
+      // hit EMFILE/ENFILE on many files in the same scan, so without this
+      // guard the conversion would emit one `system-resource-exhausted`
+      // warning per affected file/fragment instead of one per scan. Every
+      // other warning type is unaffected and still converts 1:1.
+      if (tw.type === "system-resource-exhausted") {
+        if (systemResourceExhaustedReported) continue;
+        systemResourceExhaustedReported = true;
+      }
       warnings.push({ type: tw.type, id: tw.symbolId, files: [tw.filePath], message: tw.message });
     }
   }

--- a/src/parsers/markdown.ts
+++ b/src/parsers/markdown.ts
@@ -145,6 +145,12 @@ export interface ParsedSpec {
  * — or that want a warning/error surfaced — should check the file with
  * `node:fs` themselves before calling this, or read it and call
  * `parseMarkdownContent` directly (the pattern `buildGraph` uses).
+ *
+ * PR #334 meta-review MEDIUM-2 — note the asymmetry: this empty `ParsedSpec`
+ * carries NO doc node at all, unlike calling `parseMarkdownContent` on a
+ * readable-but-empty file, which always produces exactly one doc node (see
+ * that function — it pushes a doc node unconditionally before any content is
+ * inspected).
  */
 export function parseMarkdown(filePath: string, options?: ParseMarkdownOptions): ParsedSpec {
   let source: string;

--- a/src/parsers/markdown.ts
+++ b/src/parsers/markdown.ts
@@ -125,8 +125,35 @@ export interface ParsedSpec {
   inlineLinks: InlineLinkRef[];
 }
 
+// issue #294 — `parseMarkdown` is the file-path entry point, but nothing in
+// `src/` actually calls it: `buildGraph`'s markdown loop reads the file
+// itself (with its own errno-aware `unreadable-file` / #295
+// `system-resource-exhausted` warning) and calls `parseMarkdownContent`
+// directly. `parseMarkdown` survives as a convenience entry point for tests
+// and ad hoc scripts — a dead-code path in production, per the issue's
+// investigation — so it gets the simplest possible guard rather than a new
+// error type: swallow a failed read and return an empty `ParsedSpec`.
+//
+/**
+ * Read `filePath` and parse it as an artgraph spec/task markdown file.
+ *
+ * A file that cannot be read (missing, permission error, ...) is NOT an
+ * error here: `parseMarkdown` has no warnings channel of its own to report
+ * it through, so it returns an empty `ParsedSpec` (`{ nodes: [], edges: [],
+ * warnings: [], inlineLinks: [] }`) instead of throwing. Callers that need
+ * to distinguish "file exists but is empty" from "file could not be read"
+ * — or that want a warning/error surfaced — should check the file with
+ * `node:fs` themselves before calling this, or read it and call
+ * `parseMarkdownContent` directly (the pattern `buildGraph` uses).
+ */
 export function parseMarkdown(filePath: string, options?: ParseMarkdownOptions): ParsedSpec {
-  return parseMarkdownContent(readFileSync(filePath, "utf-8"), filePath, options);
+  let source: string;
+  try {
+    source = readFileSync(filePath, "utf-8");
+  } catch {
+    return { nodes: [], edges: [], warnings: [], inlineLinks: [] };
+  }
+  return parseMarkdownContent(source, filePath, options);
 }
 
 // Content-level entry point: identical to `parseMarkdown` but takes the file

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -191,8 +191,21 @@ function buildIdMatchers(codeId?: string): IdMatchers {
 // deliberately not handed to the native parser" skip. `symbolId` holds the
 // FILE id (`file:<path>`), same convention as `pathological-bracket-nesting`,
 // since there is no symbol to attribute to (no content was ever read).
+// issue #295 — `EMFILE`/`ENFILE` (process/system file-descriptor exhaustion)
+// is a DIFFERENT failure mode than the permission/existence errors
+// `unreadable-file` covers: it means the process (or the whole system) is
+// out of file descriptors, so LATER reads are likely to fail the same way
+// too, not just this one file. `type` widened here so `parseTSFile`'s catch
+// (below) can emit the dedicated `system-resource-exhausted` variant; the
+// per-scan dedup (only one such warning per `buildGraph()` call, even if
+// both the TS and markdown loops hit it) lives in `graph/builder.ts`, not
+// here — this parser has no visibility into sibling files' outcomes.
 export interface TsParseWarning {
-  type: "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file";
+  type:
+    | "class-member-collision"
+    | "pathological-bracket-nesting"
+    | "unreadable-file"
+    | "system-resource-exhausted";
   // Fully-qualified id the warning is about (`symbol:<path>#<name>`, or
   // `file:<path>` for a file-level warning).
   symbolId: string;
@@ -583,6 +596,22 @@ export function safeParseSync(filePath: string, content: string): SafeParseResul
   }
 }
 
+// issue #295 — shared wording for the `system-resource-exhausted` warning.
+// Only one of these ever survives per scan (deduped in `graph/builder.ts`),
+// so the exact site that first observed EMFILE/ENFILE doesn't matter to the
+// user — the actionable advice (raise the ulimit) is the same either way.
+// `graph/builder.ts`'s markdown loop builds its own copy of this wording
+// (importing from here would be a reverse dependency: builder.ts already
+// imports this module).
+function systemResourceExhaustedMessage(code: string): string {
+  return (
+    `file descriptor exhaustion (${code}) while reading files during this scan; the process ` +
+    "ran out of open file descriptors. Consider raising the OS file-descriptor limit " +
+    "(e.g. `ulimit -n`) and re-running — other file reads in this scan may also be failing " +
+    "the same way. Shown once per scan regardless of how many files were affected."
+  );
+}
+
 function parseTSFile(
   filePath: string,
   rootDir: string,
@@ -618,15 +647,47 @@ function parseTSFile(
     rawContent = readFileSync(filePath, "utf-8");
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
-    warnings.push({
-      type: "unreadable-file",
-      symbolId: `file:${relPath}`,
-      filePath: relPath,
-      message:
-        `could not read "${relPath}" (${message}); skipped symbol/import/@impl extraction for ` +
-        "this file. A file node was still created so it stays visible in the graph, but it " +
-        "carries none of its usual edges until the file becomes readable again.",
-    });
+    // issue #295 — branch on the errno `code` rather than treating every
+    // unreadable file identically:
+    //  - EACCES/EISDIR/ENOENT: the original #264 behavior, unchanged byte
+    //    for byte — a per-file permission/existence problem.
+    //  - EMFILE/ENFILE: the process (or system) ran out of file
+    //    descriptors — a different, scan-wide condition where later reads
+    //    are likely failing the same way. Reported as the dedicated
+    //    `system-resource-exhausted` type; `graph/builder.ts` collapses
+    //    every occurrence across this scan (TS AND markdown loops alike)
+    //    down to a single warning.
+    //  - default (any other code, including `undefined`): keeps the exact
+    //    #264 generic message, with the errno code appended when one is
+    //    present (e.g. ELOOP) so it isn't silently lost — pinned by a
+    //    dedicated test (tests/typescript.test.ts).
+    const code = (e as NodeJS.ErrnoException)?.code;
+    const baseMessage =
+      `could not read "${relPath}" (${message}); skipped symbol/import/@impl extraction for ` +
+      "this file. A file node was still created so it stays visible in the graph, but it " +
+      "carries none of its usual edges until the file becomes readable again.";
+    if (code === "EMFILE" || code === "ENFILE") {
+      warnings.push({
+        type: "system-resource-exhausted",
+        symbolId: `file:${relPath}`,
+        filePath: relPath,
+        message: systemResourceExhaustedMessage(code),
+      });
+    } else if (code === "EACCES" || code === "EISDIR" || code === "ENOENT") {
+      warnings.push({
+        type: "unreadable-file",
+        symbolId: `file:${relPath}`,
+        filePath: relPath,
+        message: baseMessage,
+      });
+    } else {
+      warnings.push({
+        type: "unreadable-file",
+        symbolId: `file:${relPath}`,
+        filePath: relPath,
+        message: code ? `${baseMessage} [${code}]` : baseMessage,
+      });
+    }
     nodes.push({
       id: `file:${relPath}`,
       kind: isTest ? "test" : "file",

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -312,17 +312,42 @@ export function globCodeFiles(rootDir: string, patterns: string[]): string[] {
 // changed files). Import resolution consults the real file system, so targets
 // outside `filePaths` still resolve the same way they do in a full scan.
 // Returns a fragment per input path.
+//
+// PR #334 meta-review HIGH-1 — `contents` lets a caller that already read (and
+// hashed) a file's text hand it straight through instead of paying a SECOND
+// `readFileSync` here. `builder.ts`'s incremental parse-cache path does
+// exactly this: it reads every code file once to compute the cache-validity
+// hash, then (on a miss) used to call this function, which called
+// `parseTSFile`, which read the SAME file again to actually parse it. Two
+// reads of one file are two independent chances to fail, and — critically —
+// they can fail ASYMMETRICALLY: the first (hashing) read succeeds, producing
+// a real content hash, while the second (parsing) read fails (EMFILE because
+// fd pressure got worse between the two reads; EACCES if permissions changed
+// mid-scan). Pre-fix, that asymmetry let a broken, empty fragment (bare file
+// node, no symbols/edges, plus an `unreadable-file`/`system-resource-
+// exhausted` warning) get persisted to the parse cache keyed under the FIRST
+// read's real, correct hash — so a later warm run, even after the
+// environment recovered, would hash-match the poisoned entry and replay the
+// broken fragment FOREVER without ever attempting to reparse (see
+// tests/ts-double-read-regression.test.ts). Passing `contents` collapses the
+// two reads into one for every file the caller already has content for, so
+// this asymmetric failure mode cannot occur at all for those files. A path
+// missing from `contents` (or when the map itself is omitted) falls back to
+// `parseTSFile`'s own guarded read — this keeps every OTHER caller (direct
+// `parseTSFilePaths` callers in tests, `createTSParser`'s per-file loop via
+// `parseTSFile` itself) working exactly as before.
 export function parseTSFilePaths(
   rootDir: string,
   filePaths: string[],
   mode: "file" | "symbol" = "file",
   codeId?: string,
+  contents?: Map<string, string>,
 ): Map<string, ParsedTS> {
   const matchers = buildIdMatchers(codeId);
   const ctx = createResolverContext(rootDir);
   const out = new Map<string, ParsedTS>();
   for (const filePath of filePaths) {
-    out.set(filePath, parseTSFile(filePath, rootDir, mode, matchers, ctx));
+    out.set(filePath, parseTSFile(filePath, rootDir, mode, matchers, ctx, contents?.get(filePath)));
   }
   return out;
 }
@@ -618,6 +643,17 @@ function parseTSFile(
   mode: "file" | "symbol",
   matchers: IdMatchers,
   ctx: ResolverContext,
+  // PR #334 meta-review HIGH-1 — when the caller already read this file (the
+  // parse-cache path in `graph/builder.ts` reads every code file once to
+  // compute a cache-validity hash), it passes that exact text through here
+  // instead of letting this function read the file a SECOND time. See
+  // `parseTSFilePaths`'s doc comment for why a second, independent read is
+  // dangerous (asymmetric read failure can poison the parse cache with a
+  // broken fragment under a real, correct content hash). `undefined` (every
+  // call site that doesn't already have the content — `createTSParser`'s
+  // per-file loop, and direct `parseTSFile`/`parseTSFilePaths` callers in
+  // tests) falls through to the guarded read below exactly as before.
+  precheckedContent?: string,
 ): ParsedTS {
   const nodes: GraphNode[] = [];
   const edges: GraphEdge[] = [];
@@ -642,59 +678,66 @@ function parseTSFile(
   // none of extractSymbols / extractImports / extractImplTags can run
   // without content, so this file contributes no symbols, imports, or
   // impl/verifies edges until it becomes readable again.
+  //
+  // This guarded read only runs when `precheckedContent` is undefined — see
+  // that parameter's doc comment above.
   let rawContent: string;
-  try {
-    rawContent = readFileSync(filePath, "utf-8");
-  } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    // issue #295 — branch on the errno `code` rather than treating every
-    // unreadable file identically:
-    //  - EACCES/EISDIR/ENOENT: the original #264 behavior, unchanged byte
-    //    for byte — a per-file permission/existence problem.
-    //  - EMFILE/ENFILE: the process (or system) ran out of file
-    //    descriptors — a different, scan-wide condition where later reads
-    //    are likely failing the same way. Reported as the dedicated
-    //    `system-resource-exhausted` type; `graph/builder.ts` collapses
-    //    every occurrence across this scan (TS AND markdown loops alike)
-    //    down to a single warning.
-    //  - default (any other code, including `undefined`): keeps the exact
-    //    #264 generic message, with the errno code appended when one is
-    //    present (e.g. ELOOP) so it isn't silently lost — pinned by a
-    //    dedicated test (tests/typescript.test.ts).
-    const code = (e as NodeJS.ErrnoException)?.code;
-    const baseMessage =
-      `could not read "${relPath}" (${message}); skipped symbol/import/@impl extraction for ` +
-      "this file. A file node was still created so it stays visible in the graph, but it " +
-      "carries none of its usual edges until the file becomes readable again.";
-    if (code === "EMFILE" || code === "ENFILE") {
-      warnings.push({
-        type: "system-resource-exhausted",
-        symbolId: `file:${relPath}`,
+  if (precheckedContent !== undefined) {
+    rawContent = precheckedContent;
+  } else {
+    try {
+      rawContent = readFileSync(filePath, "utf-8");
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      // issue #295 — branch on the errno `code` rather than treating every
+      // unreadable file identically:
+      //  - EACCES/EISDIR/ENOENT: the original #264 behavior, unchanged byte
+      //    for byte — a per-file permission/existence problem.
+      //  - EMFILE/ENFILE: the process (or system) ran out of file
+      //    descriptors — a different, scan-wide condition where later reads
+      //    are likely failing the same way. Reported as the dedicated
+      //    `system-resource-exhausted` type; `graph/builder.ts` collapses
+      //    every occurrence across this scan (TS AND markdown loops alike)
+      //    down to a single warning.
+      //  - default (any other code, including `undefined`): keeps the exact
+      //    #264 generic message, with the errno code appended when one is
+      //    present (e.g. ELOOP) so it isn't silently lost — pinned by a
+      //    dedicated test (tests/typescript.test.ts).
+      const code = (e as NodeJS.ErrnoException)?.code;
+      const baseMessage =
+        `could not read "${relPath}" (${message}); skipped symbol/import/@impl extraction for ` +
+        "this file. A file node was still created so it stays visible in the graph, but it " +
+        "carries none of its usual edges until the file becomes readable again.";
+      if (code === "EMFILE" || code === "ENFILE") {
+        warnings.push({
+          type: "system-resource-exhausted",
+          symbolId: `file:${relPath}`,
+          filePath: relPath,
+          message: systemResourceExhaustedMessage(code),
+        });
+      } else if (code === "EACCES" || code === "EISDIR" || code === "ENOENT") {
+        warnings.push({
+          type: "unreadable-file",
+          symbolId: `file:${relPath}`,
+          filePath: relPath,
+          message: baseMessage,
+        });
+      } else {
+        warnings.push({
+          type: "unreadable-file",
+          symbolId: `file:${relPath}`,
+          filePath: relPath,
+          message: code ? `${baseMessage} [${code}]` : baseMessage,
+        });
+      }
+      nodes.push({
+        id: `file:${relPath}`,
+        kind: isTest ? "test" : "file",
         filePath: relPath,
-        message: systemResourceExhaustedMessage(code),
+        contentHash: hash(""),
       });
-    } else if (code === "EACCES" || code === "EISDIR" || code === "ENOENT") {
-      warnings.push({
-        type: "unreadable-file",
-        symbolId: `file:${relPath}`,
-        filePath: relPath,
-        message: baseMessage,
-      });
-    } else {
-      warnings.push({
-        type: "unreadable-file",
-        symbolId: `file:${relPath}`,
-        filePath: relPath,
-        message: code ? `${baseMessage} [${code}]` : baseMessage,
-      });
+      return { nodes, edges, warnings };
     }
-    nodes.push({
-      id: `file:${relPath}`,
-      kind: isTest ? "test" : "file",
-      filePath: relPath,
-      contentHash: hash(""),
-    });
-    return { nodes, edges, warnings };
   }
   const content = stripBom(rawContent);
   const fileHash = hash(content);

--- a/templates/skills/_shared/output-schema.md
+++ b/templates/skills/_shared/output-schema.md
@@ -85,7 +85,7 @@ The CLI prints `JSON.stringify({ ...CheckResult, warnings })` (see `src/cli.ts`)
 ```
 (other fields such as `drifted` / `orphans` / `coverage` are still populated with the full scoped listing — omitted above for brevity. `baselineError` is absent/undefined for every `baselineStatus` other than `"unavailable"`.)
 
-`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
+`warnings[].type` is one of: `"duplicate-id" | "ambiguous-id" | "orphan-doc" | "orphan-edge" | "invalid-relation" | "reserved-prefix" | "unresolved-link" | "out-of-scope-link" | "invalid-annotation-id" | "empty-annotation" | "self-reference-annotation" | "phantom-import-repaired" | "dangling-import" | "class-member-collision" | "pathological-bracket-nesting" | "unreadable-file" | "system-resource-exhausted" | "node-modules-in-scan"`. This list may grow in future releases — a consumer should ignore any `type` value it does not recognize rather than treat it as an error.
 
 ## artgraph impact
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -463,6 +463,37 @@ describe("CLI: scan graph payload", () => {
       rmSync(outDir, { recursive: true, force: true });
     }
   });
+
+  // issue #274(2) — `scan --serve`/`--output` never called into
+  // `printWarnings`/`reportGraphWarnings` at all, so a build warning (here:
+  // orphan-doc, same fixture shape as "CLI: warning output" below) was
+  // silently dropped on this path even though the identical fixture through
+  // plain `scan` (no --serve/--output) surfaces it on stderr.
+  it("--output surfaces build warnings on stderr (issue #274)", async () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), "artgraph-output-warn-"));
+    const outDir = mkdtempSync(join(tmpdir(), "artgraph-output-warn-out-"));
+    try {
+      mkdirSync(join(tmpRoot, "specs"), { recursive: true });
+      mkdirSync(join(tmpRoot, "src"), { recursive: true });
+      writeFileSync(join(tmpRoot, "src", "app.ts"), "export const x = 1;\n");
+      writeFileSync(
+        join(tmpRoot, ".artgraph.json"),
+        JSON.stringify({ include: ["src/**/*.ts"], specDirs: ["specs"] }),
+      );
+      writeFileSync(
+        join(tmpRoot, "specs", "orphan.md"),
+        `---\nartgraph:\n  node_id: "orphan-src"\n  derives_from:\n    - nonexistent-target\n---\n# Orphan\n`,
+      );
+
+      const proc = await runAt(tmpRoot, ["scan", "--output", outDir]);
+      expect(proc.exitCode).toBe(0);
+      expect(proc.stderr).toContain("orphan-doc");
+      expect(proc.stderr).toContain("nonexistent-target");
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+      rmSync(outDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1028,6 +1028,21 @@ artgraph:
   });
 });
 
+// issue #294 — `parseMarkdown`'s `readFileSync` used to be unguarded: a
+// nonexistent (or otherwise unreadable) path threw straight out of the
+// function. `parseMarkdown` has no warnings channel to report the failure
+// through (unlike `buildGraph`'s markdown loop, which synthesizes a bare
+// doc node + `unreadable-file` warning — issue #277), so the fix returns an
+// empty `ParsedSpec` instead.
+describe("parseMarkdown — unreadable path (issue #294)", () => {
+  it("returns an empty ParsedSpec instead of throwing for a nonexistent path", () => {
+    const missingPath = resolve(FIXTURE_DIR, "specs/does-not-exist-294.md");
+    expect(() => parseMarkdown(missingPath)).not.toThrow();
+    const result = parseMarkdown(missingPath);
+    expect(result).toEqual({ nodes: [], edges: [], warnings: [], inlineLinks: [] });
+  });
+});
+
 // ---------------------------------------------------------------------------
 // req→req annotation helpers (specs/010-req-req-dependency)
 // ---------------------------------------------------------------------------

--- a/tests/resource-guard-tsconfig-glob.test.ts
+++ b/tests/resource-guard-tsconfig-glob.test.ts
@@ -1,0 +1,212 @@
+// PR #334 meta-review HIGH-2 — two more scan-wide "ran out of file
+// descriptors" hazards graph/builder.ts did NOT guard before this fix:
+//
+//  1. The tsconfig.json read (builder.ts, just after `globCodeFiles`) used a
+//     bare `readFileSync` guarded only by `existsSync` (which never throws,
+//     but doesn't protect the read itself from EMFILE/ENFILE, or from any
+//     other errno). An uncaught throw here crashed the WHOLE build — worse
+//     than simply treating the repo as tsconfig-less, which the code already
+//     does when the file is absent.
+//  2. `globCodeFiles` (builder.ts) wraps `fast-glob`, which — unlike the
+//     `glob` package the markdown loop uses — THROWS on a read error instead
+//     of silently returning an empty match list. An uncaught throw here
+//     likewise crashed the whole build before a single TS file was even
+//     enumerated.
+//
+// Both are now guarded: EMFILE/ENFILE report the scan-wide
+// `system-resource-exhausted` type (deduped against every other site that
+// can report it, per the flag documented in graph/builder.ts) and the build
+// continues — tsconfig-driven import resolution falls back to "no tsconfig"
+// and the code-file set falls back to empty (spec/doc nodes are unaffected;
+// the graph is simply empty on the code side for this one run). Any OTHER
+// glob failure (a real bug, not resource exhaustion) still propagates instead
+// of being silently swallowed.
+//
+// Scope note: `tsconfig.json` is ALSO read from a second, independent site —
+// `src/parsers/typescript.ts`'s `createResolverContext` /
+// `readTsconfigResolveOptions`, which the actual TS parser consults for
+// jsx/allowJs/resolveJsonModule. That read is unguarded too, but it is OUT OF
+// SCOPE for this fix (only builder.ts:565-566's cache-hash read was in
+// scope) — a separate, pre-existing gap, not something this PR introduces or
+// claims to close. The `tsconfig.json` failure mock below therefore only
+// fails the FIRST readFileSync call for that path (builder.ts's own read,
+// which always runs before `parseTSFilePaths`/`createResolverContext` in
+// `buildGraph`'s call order) and lets every later call through untouched, so
+// these tests exercise builder.ts's new guard in isolation without tripping
+// over that unrelated, unguarded second site.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fsFailureControl = vi.hoisted(() => ({
+  // path suffix -> errno code to simulate for the FIRST readFileSync call
+  // matching that suffix only (see the scope note above for why this is
+  // call-count-limited rather than unconditional).
+  failures: new Map<string, string>(),
+  calls: new Map<string, number>(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: (
+      ...args: Parameters<typeof actual.readFileSync>
+    ): ReturnType<typeof actual.readFileSync> => {
+      const path = String(args[0] ?? "");
+      for (const [suffix, code] of fsFailureControl.failures) {
+        if (path.endsWith(suffix)) {
+          const n = (fsFailureControl.calls.get(suffix) ?? 0) + 1;
+          fsFailureControl.calls.set(suffix, n);
+          if (n === 1) {
+            const err = new Error(`simulated ${code} reading ${path}`) as NodeJS.ErrnoException;
+            err.code = code;
+            throw err;
+          }
+          break;
+        }
+      }
+      return actual.readFileSync(...args);
+    },
+  };
+});
+
+const globControl = vi.hoisted(() => ({
+  // when set, every fastGlob.sync() call throws an error with this code
+  failCode: undefined as string | undefined,
+}));
+
+vi.mock("fast-glob", async (importOriginal) => {
+  const actual = await importOriginal<{ default: typeof import("fast-glob") }>();
+  const realDefault = actual.default as unknown as {
+    sync: (...args: unknown[]) => string[];
+  } & ((...args: unknown[]) => unknown);
+  const wrapped = Object.assign(
+    (...args: unknown[]) => (realDefault as (...a: unknown[]) => unknown)(...args),
+    realDefault,
+    {
+      sync: (...args: unknown[]) => {
+        if (globControl.failCode) {
+          const err = new Error(
+            `simulated ${globControl.failCode} in fast-glob.sync`,
+          ) as NodeJS.ErrnoException;
+          err.code = globControl.failCode;
+          throw err;
+        }
+        return realDefault.sync(...args);
+      },
+    },
+  );
+  return { default: wrapped };
+});
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildGraph } from "../src/graph/builder.js";
+import type { ArtgraphConfig } from "../src/types.js";
+
+function makeFixture(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(root, "specs"), { recursive: true });
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(join(root, "specs", "spec.md"), "# Spec\n\n- REQ-4101: needs coverage\n");
+  writeFileSync(join(root, "src", "a.ts"), "export const a = 1;\n// @impl REQ-4101\n");
+  writeFileSync(join(root, "tsconfig.json"), JSON.stringify({ compilerOptions: { jsx: "react" } }));
+  writeFileSync(
+    join(root, ".artgraph.json"),
+    JSON.stringify({ include: ["src/**/*.ts"], specDirs: ["specs"] }),
+  );
+  return root;
+}
+
+const cfg: ArtgraphConfig = {
+  include: ["src/**/*.ts"],
+  specDirs: ["specs"],
+  testPatterns: [],
+  lockFile: ".trace.lock",
+};
+
+afterEach(() => {
+  fsFailureControl.failures.clear();
+  fsFailureControl.calls.clear();
+  globControl.failCode = undefined;
+});
+
+describe("buildGraph: tsconfig.json read guard (PR #334 HIGH-2)", () => {
+  it("EMFILE reading tsconfig.json does not crash the build and reports system-resource-exhausted once", () => {
+    const root = makeFixture("artgraph-tsconfig-emfile-");
+    try {
+      fsFailureControl.failures.set("tsconfig.json", "EMFILE");
+
+      const { graph, warnings } = buildGraph(root, cfg);
+
+      const exhausted = warnings.filter((w) => w.type === "system-resource-exhausted");
+      expect(exhausted).toHaveLength(1);
+      expect(exhausted[0]!.message).toMatch(/EMFILE/);
+      expect(warnings.some((w) => w.type === "unreadable-file")).toBe(false);
+
+      // The rest of the scan is unaffected: tsconfig.json simply falls back
+      // to "not present" for import-resolution purposes, code files still
+      // parse and their edges still land.
+      expect(graph.nodes.has("file:src/a.ts")).toBe(true);
+      expect(graph.nodes.has("REQ-4101")).toBe(true);
+      const implEdge = graph.edges.find(
+        (e) => e.source === "file:src/a.ts" && e.target === "REQ-4101" && e.kind === "implements",
+      );
+      expect(implEdge).toBeDefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("a non-resource read error on tsconfig.json falls back to no-tsconfig with a generic warning, not a crash", () => {
+    const root = makeFixture("artgraph-tsconfig-eacces-");
+    try {
+      fsFailureControl.failures.set("tsconfig.json", "EACCES");
+
+      const { warnings } = buildGraph(root, cfg);
+
+      expect(warnings.some((w) => w.type === "system-resource-exhausted")).toBe(false);
+      const unreadable = warnings.filter(
+        (w) => w.type === "unreadable-file" && w.id === "tsconfig.json",
+      );
+      expect(unreadable).toHaveLength(1);
+      expect(unreadable[0]!.message).toMatch(/tsconfig\.json/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("buildGraph: fast-glob (globCodeFiles) resource-exhaustion guard (PR #334 HIGH-2)", () => {
+  it("EMFILE from fast-glob.sync does not crash the build, warns once, and the graph is empty on the code side", () => {
+    const root = makeFixture("artgraph-fastglob-emfile-");
+    try {
+      globControl.failCode = "EMFILE";
+
+      const { graph, warnings } = buildGraph(root, cfg);
+
+      const exhausted = warnings.filter((w) => w.type === "system-resource-exhausted");
+      expect(exhausted).toHaveLength(1);
+      expect(exhausted[0]!.message).toMatch(/EMFILE/);
+
+      // No TS file was enumerated at all — but the doc/spec side of the
+      // graph, which never depends on globCodeFiles, is unaffected.
+      expect(graph.nodes.has("file:src/a.ts")).toBe(false);
+      expect(graph.nodes.has("REQ-4101")).toBe(true);
+      expect(graph.edges.some((e) => e.kind === "implements")).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("a non-resource fast-glob failure is NOT swallowed — it propagates", () => {
+    const root = makeFixture("artgraph-fastglob-other-");
+    try {
+      globControl.failCode = "EPERM";
+
+      expect(() => buildGraph(root, cfg)).toThrow(/EPERM/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/system-resource-exhausted.test.ts
+++ b/tests/system-resource-exhausted.test.ts
@@ -1,0 +1,242 @@
+// issue #295 — `EMFILE`/`ENFILE` (file descriptor exhaustion) is a
+// scan-wide condition, distinct from the per-file `unreadable-file` warning
+// issue #264/#277 already cover (EACCES/EISDIR/ENOENT). This file pins:
+//
+//  1. EMFILE hit by BOTH the markdown loop and the TS loop in the same
+//     `buildGraph()` call still produces exactly ONE `system-resource-exhausted`
+//     warning (builder-level dedup).
+//  2. That warning appears in `scan --format json`'s `warnings[]` array
+//     (the field it rides through end to end).
+//  3. `scan`'s default text output prints it (NOT silent, unlike
+//     `phantom-import-repaired`/`dangling-import`).
+//  4. The "default" errno branch (anything other than
+//     EACCES/EISDIR/ENOENT/EMFILE/ENFILE, e.g. EPERM) keeps the pre-#295
+//     generic `unreadable-file` behavior, with the code appended.
+//  5. EACCES keeps the pre-#295 `unreadable-file` message byte-for-byte
+//     (no code appended) — the real permission-error tests in
+//     tests/builder.test.ts / tests/typescript.test.ts already cover this
+//     via actual chmod(0); this file adds a deterministic, cross-platform
+//     (no chmod) confirmation of the same branch via a mocked errno.
+//
+// vitest ESM: `vi.spyOn(fs, "readFileSync")` fails with "Cannot redefine
+// property" because node:fs's exports are non-configurable (same
+// constraint documented in tests/hooks-merge.test.ts for renameSync). This
+// file mocks the module instead, with a flag-gated, path-suffix-guarded
+// pass-through so only paths this file explicitly registers are affected —
+// every other read (including this test file's own fixture setup) uses the
+// real readFileSync.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fsFailureControl = vi.hoisted(() => ({
+  // path suffix -> errno code to simulate for that one readFileSync call.
+  failures: new Map<string, string>(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: (
+      ...args: Parameters<typeof actual.readFileSync>
+    ): ReturnType<typeof actual.readFileSync> => {
+      const path = String(args[0] ?? "");
+      for (const [suffix, code] of fsFailureControl.failures) {
+        if (path.endsWith(suffix)) {
+          const err = new Error(`simulated ${code} reading ${path}`) as NodeJS.ErrnoException;
+          err.code = code;
+          throw err;
+        }
+      }
+      return actual.readFileSync(...args);
+    },
+  };
+});
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildGraph } from "../src/graph/builder.js";
+import type { ArtgraphConfig } from "../src/types.js";
+import { runAt } from "./helpers.js";
+
+function makeFixture(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(root, "specs"), { recursive: true });
+  mkdirSync(join(root, "src"), { recursive: true });
+  writeFileSync(join(root, "specs", "good.md"), "# Good\n\n- REQ-2951: stays readable\n");
+  writeFileSync(join(root, "specs", "broken.md"), "- REQ-2952: never actually read\n");
+  writeFileSync(join(root, "src", "keep.ts"), "export const keep = 1;\n// @impl REQ-2951\n");
+  writeFileSync(join(root, "src", "broken.ts"), "export const neverRead = 1;\n");
+  writeFileSync(
+    join(root, ".artgraph.json"),
+    JSON.stringify({ include: ["src/**/*.ts"], specDirs: ["specs"] }),
+  );
+  return root;
+}
+
+const cfg: ArtgraphConfig = {
+  include: ["src/**/*.ts"],
+  specDirs: ["specs"],
+  testPatterns: [],
+  lockFile: ".trace.lock",
+};
+
+afterEach(() => {
+  fsFailureControl.failures.clear();
+});
+
+describe("buildGraph: EMFILE/ENFILE dedup across markdown + TS loops (issue #295)", () => {
+  it("emits exactly one system-resource-exhausted warning when both loops hit EMFILE", () => {
+    const root = makeFixture("artgraph-emfile-dedup-");
+    try {
+      fsFailureControl.failures.set("specs/broken.md", "EMFILE");
+      fsFailureControl.failures.set("src/broken.ts", "EMFILE");
+
+      const { graph, warnings } = buildGraph(root, cfg);
+
+      const exhausted = warnings.filter((w) => w.type === "system-resource-exhausted");
+      expect(exhausted).toHaveLength(1);
+      expect(exhausted[0]!.message).toMatch(/EMFILE/);
+
+      // Neither failing file crashed the build, and neither one is
+      // misreported as a plain `unreadable-file` — the scan continues for
+      // both loops (graph semantics unchanged, per the issue's design).
+      expect(warnings.some((w) => w.type === "unreadable-file")).toBe(false);
+      expect(graph.nodes.has("file:src/keep.ts")).toBe(true);
+      expect(graph.nodes.has("REQ-2951")).toBe(true);
+      expect(graph.nodes.has("file:src/broken.ts")).toBe(true);
+      expect(graph.nodes.has("doc:broken.md")).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("emits exactly one warning even with ENFILE and EMFILE mixed across loops", () => {
+    const root = makeFixture("artgraph-enfile-mix-");
+    try {
+      fsFailureControl.failures.set("specs/broken.md", "ENFILE");
+      fsFailureControl.failures.set("src/broken.ts", "EMFILE");
+
+      const { warnings } = buildGraph(root, cfg);
+      const exhausted = warnings.filter((w) => w.type === "system-resource-exhausted");
+      expect(exhausted).toHaveLength(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("scan --format json / text surface system-resource-exhausted (issue #295)", () => {
+  it("scan --format json includes system-resource-exhausted in warnings[]", async () => {
+    const root = makeFixture("artgraph-emfile-json-");
+    try {
+      fsFailureControl.failures.set("src/broken.ts", "EMFILE");
+
+      const { stdout, exitCode } = await runAt(root, ["scan", "--format", "json"]);
+      expect(exitCode).toBe(0);
+      const result = JSON.parse(stdout);
+      expect(
+        result.warnings.some((w: { type: string }) => w.type === "system-resource-exhausted"),
+      ).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("scan (text) prints the warning to stderr — not silent", async () => {
+    const root = makeFixture("artgraph-emfile-text-");
+    try {
+      fsFailureControl.failures.set("src/broken.ts", "EMFILE");
+
+      const { stderr, exitCode } = await runAt(root, ["scan"]);
+      expect(exitCode).toBe(0);
+      expect(stderr).toContain("WARNING:");
+      expect(stderr).toMatch(/EMFILE/);
+      expect(stderr).toMatch(/ulimit/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("errno branch coverage: EACCES unchanged, default (EPERM) pinned (issue #295)", () => {
+  it("EACCES keeps the pre-#295 unreadable-file message byte-for-byte (TS side)", () => {
+    const root = makeFixture("artgraph-eacces-ts-");
+    try {
+      fsFailureControl.failures.set("src/broken.ts", "EACCES");
+
+      const { warnings } = buildGraph(root, cfg);
+      const unreadable = warnings.filter((w) => w.type === "unreadable-file");
+      expect(unreadable).toHaveLength(1);
+      expect(unreadable[0]!.files).toEqual(["src/broken.ts"]);
+      expect(unreadable[0]!.message).toBe(
+        `could not read "src/broken.ts" (simulated EACCES reading ${join(root, "src", "broken.ts")}); ` +
+          "skipped symbol/import/@impl extraction for this file. A file node was still created so " +
+          "it stays visible in the graph, but it carries none of its usual edges until the file " +
+          "becomes readable again.",
+      );
+      // The default branch's "append code" behavior must NOT leak into the
+      // EACCES branch.
+      expect(unreadable[0]!.message).not.toContain("[EACCES]");
+      expect(warnings.some((w) => w.type === "system-resource-exhausted")).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("EACCES keeps the pre-#295 unreadable-file message byte-for-byte (markdown side)", () => {
+    const root = makeFixture("artgraph-eacces-md-");
+    try {
+      fsFailureControl.failures.set("specs/broken.md", "EACCES");
+
+      const { warnings } = buildGraph(root, cfg);
+      const unreadable = warnings.filter((w) => w.type === "unreadable-file");
+      expect(unreadable).toHaveLength(1);
+      expect(unreadable[0]!.files).toEqual(["specs/broken.md"]);
+      expect(unreadable[0]!.message).not.toContain("[EACCES]");
+      expect(warnings.some((w) => w.type === "system-resource-exhausted")).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  // Step 0-pre required item — pin the "default" bucket (any errno NOT in
+  // {EACCES, EISDIR, ENOENT, EMFILE, ENFILE}, and code === undefined) to the
+  // SAME `unreadable-file` type and generic message the pre-#295 code
+  // always produced, with the errno code appended when one is present.
+  // EPERM stands in for the "some other real errno" case (ELOOP is the
+  // issue's own example).
+  it("default branch (EPERM) stays unreadable-file with the generic message + appended code (TS side)", () => {
+    const root = makeFixture("artgraph-eperm-ts-");
+    try {
+      fsFailureControl.failures.set("src/broken.ts", "EPERM");
+
+      const { warnings } = buildGraph(root, cfg);
+      const unreadable = warnings.filter((w) => w.type === "unreadable-file");
+      expect(unreadable).toHaveLength(1);
+      expect(unreadable[0]!.message).toContain(
+        "skipped symbol/import/@impl extraction for this file",
+      );
+      expect(unreadable[0]!.message).toContain("[EPERM]");
+      expect(warnings.some((w) => w.type === "system-resource-exhausted")).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("default branch (EPERM) stays unreadable-file with the generic message + appended code (markdown side)", () => {
+    const root = makeFixture("artgraph-eperm-md-");
+    try {
+      fsFailureControl.failures.set("specs/broken.md", "EPERM");
+
+      const { warnings } = buildGraph(root, cfg);
+      const unreadable = warnings.filter((w) => w.type === "unreadable-file");
+      expect(unreadable).toHaveLength(1);
+      expect(unreadable[0]!.message).toContain("skipped req/task/edge extraction for this file");
+      expect(unreadable[0]!.message).toContain("[EPERM]");
+      expect(warnings.some((w) => w.type === "system-resource-exhausted")).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/ts-double-read-regression.test.ts
+++ b/tests/ts-double-read-regression.test.ts
@@ -1,0 +1,212 @@
+// PR #334 meta-review HIGH-1 — regression test for the asymmetric-read /
+// parse-cache-poisoning bug.
+//
+// Before this fix, graph/builder.ts's incremental TS parse-cache path read
+// every code file TWICE: once (in builder.ts, `buildGraph`) purely to
+// compute a cache-validity content hash, and a second time INSIDE
+// `parseTSFile` (src/parsers/typescript.ts) to actually parse it. When the
+// FIRST (hashing) read succeeded but the SECOND (parsing) read failed —
+// EMFILE because file-descriptor pressure got worse between the two reads,
+// or EACCES if permissions changed mid-scan — a broken fragment (a bare
+// `file:` node, empty edges/symbols, plus an `unreadable-file`/
+// `system-resource-exhausted` warning) was persisted to the parse cache
+// keyed under the FIRST read's real, correct content hash. A later warm run
+// — even long after the environment fully recovered — would hash-match
+// that poisoned entry and reuse the broken, edge-less fragment WITHOUT ever
+// attempting to reparse, reproducing the corruption forever.
+//
+// The fix threads the content builder.ts already read straight through to
+// `parseTSFilePaths`/`parseTSFile` (the new `contents`/`precheckedContent`
+// parameters), so there is only ever ONE read per file on this path — the
+// asymmetric failure window this test simulates cannot occur post-fix.
+//
+// vitest ESM: mock node:fs the same way tests/system-resource-exhausted.test.ts
+// does, but COUNT calls per path so only the FIRST readFileSync for the
+// target file succeeds; every call after that fails with the configured
+// errno. Pre-fix, that second call is exactly the one `parseTSFile` used to
+// make. Post-fix it should never happen at all.
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const fsFailureControl = vi.hoisted(() => ({
+  // path suffix -> rule
+  rules: new Map<string, { code: string; succeedFirstNCalls: number }>(),
+  calls: new Map<string, number>(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: (
+      ...args: Parameters<typeof actual.readFileSync>
+    ): ReturnType<typeof actual.readFileSync> => {
+      const path = String(args[0] ?? "");
+      for (const [suffix, rule] of fsFailureControl.rules) {
+        if (path.endsWith(suffix)) {
+          const n = (fsFailureControl.calls.get(suffix) ?? 0) + 1;
+          fsFailureControl.calls.set(suffix, n);
+          if (n > rule.succeedFirstNCalls) {
+            const err = new Error(
+              `simulated ${rule.code} reading ${path}`,
+            ) as NodeJS.ErrnoException;
+            err.code = rule.code;
+            throw err;
+          }
+          break;
+        }
+      }
+      return actual.readFileSync(...args);
+    },
+  };
+});
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync as realReadFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { buildGraph } from "../src/graph/builder.js";
+import { hashContent } from "../src/parse-cache.js";
+import type { ArtgraphConfig } from "../src/types.js";
+
+const TARGET_CONTENT = "export const target = 1;\n// @impl REQ-4001\n";
+
+function makeFixture(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  mkdirSync(join(root, "specs"), { recursive: true });
+  mkdirSync(join(root, "src"), { recursive: true });
+  // The parse cache only activates when node_modules exists — opt in
+  // explicitly, this test's whole point is about what gets PERSISTED.
+  mkdirSync(join(root, "node_modules"), { recursive: true });
+  writeFileSync(join(root, "specs", "spec.md"), "# Spec\n\n- REQ-4001: needs coverage\n");
+  writeFileSync(join(root, "src", "target.ts"), TARGET_CONTENT);
+  writeFileSync(
+    join(root, ".artgraph.json"),
+    JSON.stringify({ include: ["src/**/*.ts"], specDirs: ["specs"] }),
+  );
+  return root;
+}
+
+const cfg: ArtgraphConfig = {
+  include: ["src/**/*.ts"],
+  specDirs: ["specs"],
+  testPatterns: [],
+  lockFile: ".trace.lock",
+};
+
+function readCacheTsFragment(root: string): {
+  contentHash: string;
+  nodes: unknown[];
+  edges: { source: string; target: string; kind: string }[];
+} {
+  const cacheRaw = realReadFileSync(
+    join(root, "node_modules", ".cache", "artgraph", "parse-cache.json"),
+    "utf-8",
+  );
+  const cache = JSON.parse(cacheRaw);
+  return cache.ts["src/target.ts"];
+}
+
+function implEdge(edges: { source: string; target: string; kind: string }[]) {
+  return edges.find(
+    (e) => e.source === "file:src/target.ts" && e.target === "REQ-4001" && e.kind === "implements",
+  );
+}
+
+afterEach(() => {
+  fsFailureControl.rules.clear();
+  fsFailureControl.calls.clear();
+});
+
+describe.each(["EMFILE", "EACCES"])(
+  "buildGraph: precheck-succeeds/parse-fails asymmetry no longer poisons the TS parse cache (%s)",
+  (code) => {
+    it(`produces correct edges and never persists a broken fragment under the real hash (${code})`, () => {
+      const root = makeFixture(`artgraph-double-read-${code.toLowerCase()}-`);
+      try {
+        // Only the FIRST readFileSync call for src/target.ts succeeds. Any
+        // further read of this path — pre-fix, `parseTSFile`'s own second
+        // read — fails with `code`.
+        fsFailureControl.rules.set("src/target.ts", { code, succeedFirstNCalls: 1 });
+
+        const { graph, warnings } = buildGraph(root, cfg);
+
+        // No failure should be observable at all — the fix removes the
+        // second read this scenario is modeling.
+        expect(warnings.some((w) => w.type === "unreadable-file")).toBe(false);
+        expect(warnings.some((w) => w.type === "system-resource-exhausted")).toBe(false);
+        expect(implEdge(graph.edges)).toBeDefined();
+
+        // The persisted fragment must carry the REAL content hash (not the
+        // "unreadable-file:cannot-hash" sentinel) paired with the correct,
+        // non-empty edges. Pre-fix, this exact real hash could be persisted
+        // alongside a BROKEN (empty-edges) fragment — the corruption this
+        // test guards against.
+        const frag = readCacheTsFragment(root);
+        expect(frag).toBeDefined();
+        expect(frag.contentHash).toBe(hashContent(TARGET_CONTENT));
+        expect(frag.contentHash).not.toBe("unreadable-file:cannot-hash");
+        expect(implEdge(frag.edges)).toBeDefined();
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it(`a warm run after the environment recovers still reports the correct edges, not a poisoned empty fragment (${code})`, () => {
+      const root = makeFixture(`artgraph-double-read-warm-${code.toLowerCase()}-`);
+      try {
+        fsFailureControl.rules.set("src/target.ts", { code, succeedFirstNCalls: 1 });
+        buildGraph(root, cfg); // run 1 — see the sibling test above for what this pins
+
+        // "Recovery": by run 2 the simulated failure is gone (fd budget
+        // freed / permissions restored). This is the exact scenario the
+        // meta-review flags: pre-fix, a poisoned cache entry (real hash +
+        // broken, empty fragment) would hash-match THIS warm run and get
+        // reused verbatim — no reparse attempted — so the broken result
+        // would replay forever even after recovery.
+        fsFailureControl.rules.clear();
+        fsFailureControl.calls.clear();
+
+        const { graph, warnings } = buildGraph(root, cfg);
+        expect(warnings.some((w) => w.type === "unreadable-file")).toBe(false);
+        expect(warnings.some((w) => w.type === "system-resource-exhausted")).toBe(false);
+        expect(implEdge(graph.edges)).toBeDefined();
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+  },
+);
+
+describe("buildGraph: symmetric failure (both attempts would fail) keeps self-repairing via the sentinel hash, unchanged", () => {
+  it("stays unreadable while the file stays unreadable, then repairs on the first run after it becomes readable", () => {
+    const root = makeFixture("artgraph-double-read-symmetric-");
+    try {
+      // Every read of src/target.ts fails — the pre-existing #264 "both
+      // attempts fail" behavior. This fix must not change it: with no
+      // successful precheck read, `missContents` never gets an entry for
+      // this path, so `parseTSFile` still makes (and fails) its own guarded
+      // read, exactly as before this fix.
+      fsFailureControl.rules.set("src/target.ts", { code: "EACCES", succeedFirstNCalls: 0 });
+
+      const first = buildGraph(root, cfg);
+      expect(first.warnings.some((w) => w.type === "unreadable-file")).toBe(true);
+      expect(implEdge(first.graph.edges)).toBeUndefined();
+
+      const frag = readCacheTsFragment(root);
+      expect(frag.contentHash).toBe("unreadable-file:cannot-hash");
+
+      fsFailureControl.rules.clear();
+      fsFailureControl.calls.clear();
+      const second = buildGraph(root, cfg);
+      expect(second.warnings.some((w) => w.type === "unreadable-file")).toBe(false);
+      expect(implEdge(second.graph.edges)).toBeDefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

警告配線シリーズ **PR-A** (バンドル構成はユーザー承認済み: PR-A = #274+#294+#295 / PR-B = #273+#279 は後続 / #189 は 2/3 実装済み確認によりクローズ・残部を #333 へ切り出し)。

Closes #274, Closes #294, Closes #295.

### #274 — 警告出力配線の統一

- `scan --serve` / `--output` 分岐が `printWarnings` に一切到達せず buildGraph 警告が silent drop されていた漏れを修正 (early return / `process.exit` の前に必ず報告)
- `scan` / `check` / `init` の `printWarnings` 直呼びを、他 5 コマンドが既に使う `reportGraphWarnings` に統一 — **純リファクタで既存経路の出力は byte-identical** (既存テストの厳密な stdout/stderr assertion が無変更で green なことで担保)

### #294 — `parseMarkdown()` の readFileSync ガード

dead-code 経路 (blast radius 0) だが、将来の consumer が #277 の crash class を復活させないよう `parseMarkdownContent` 委譲 + try/catch (失敗時は空 `ParsedSpec`、JSDoc に契約明記)。

### #295 — unreadable-file ガードの errno 分岐

`parseTSFile` と builder の markdown loop の 2 サイト (issue 明記の範囲) で `ErrnoException.code` を分岐:

- **EACCES / EISDIR / ENOENT**: per-file `unreadable-file` 警告を byte-for-byte 維持
- **EMFILE / ENFILE**: 新 warning type **`system-resource-exhausted`** を **scan 全体で最大 1 回** 発行 (TS/markdown 両ループ横断の dedupe フラグ、ループは中断しない = graph 構築セマンティクス不変、`SILENT_WARNING_TYPES` 非登録 = 常時表示、ulimit 引き上げの actionable なメッセージ)
- **default (列挙外 code / code なし)**: 現行の汎用メッセージ + code 追記 — **列挙外 errno が silent skip に劣化しない**ことをテストで pin (Step 0-pre M4 の必須要件)

rename-executor / plan-coverage の同種 read ガード 2 サイトは #295 の明記スコープ外として非対称を許容 (対象ファイル数が少なく EMFILE 到達が実質不可能なため。Step 0-pre M5 の判断)。

## Change type

- [x] fix (bug fix)
- [ ] feat / refactor / docs / chore / test

## Testing

- [x] Existing tests pass (`pnpm -r test`) — 95 files, 2280 passed / 19 skipped (scan/check/init の厳密出力 assertion 無変更 = #274 の byte-identical 担保)
- [x] Added tests where needed — `tests/system-resource-exhausted.test.ts` (8 tests: EMFILE の両ループ横断 dedupe / ENFILE 混在 / json 出力 / text 非silent / EACCES 不変 pin ×2 / **EPERM default 分岐 pin ×2**)、`tests/cli.test.ts` (`--output` 分岐の警告出力)、`tests/markdown.test.ts` (unreadable → 空 ParsedSpec)
- [x] Ran `pnpm -r knip` and `pnpm -r build` — clean、`tsc --noEmit` clean、`node dist/cli.js check --diff` exit 0

## Breaking change

- [ ] Yes (described below)
- [x] No

`BuildWarning["type"]` union への加算 (`system-resource-exhausted`) のみ。`_shared/output-schema.md` の型 union 文書を 6 ファイル (canonical + 5 配布先) 同期済み (既存の doc-sync テストが強制)。

## Notes

- Step 0-pre (13 チェック + 新チェック 5/6) が事前検出したもの: #189 の 2/3 実装済み事実 (→ issue クローズ + #333 切り出し)、`--verbose` フラグの不在、default 分岐の必須 pin テスト、EMFILE 集約の「TS/markdown 別ループで合計 2 回出る」リスク (→ builder 全体 1 フラグで設計)
- PR-B (#273 rename 警告経路 + #279 エラー envelope 統一) は本 PR merge 後に着手予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BREZStzmU62xFvKSydGKZV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BREZStzmU62xFvKSydGKZV)_