### PR TITLE
fix(rename,cli): carry warnings across rename throw paths; unify fatal-error envelopes (#273, #279)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,11 +22,15 @@ across every command that has a `--format` option:
 This applies uniformly to: a command's own usage/validation errors, a
 rejected `LockSchemaVersionError` (a `.trace.lock` written by a newer
 artgraph), `rename`'s validation/safety-valve failures (`RenameValidationError`,
-issue #273), and `OxcLoadError` (oxc-parser's native binding missing/broken,
-issue #263) — every command whose action reaches `scan()`/`buildGraph()`
-(`scan`, `check`, `impact`, `plan-coverage`, `reconcile`, `trace status`,
-`trace report`, `rename`) surfaces `OxcLoadError` through this same
-stderr/exit-1 contract instead of a raw, format-blind stack trace.
+issue #273), a malformed `.artgraph.json` (`loadConfig()`'s `Failed to parse
+...`, issue #336), an `AgentsParseError` from `--agents=<list>` (issue #336),
+and `OxcLoadError` (oxc-parser's native binding missing/broken, issue #263) —
+every command whose action reaches `loadConfig()` and/or `scan()`/
+`buildGraph()` (`scan`, `check`, `impact`, `plan-coverage`, `reconcile`,
+`trace status`, `trace report`, `rename`, `init`, `doctor`) surfaces every
+one of these through this same stderr/exit-1 contract instead of a raw,
+format-blind stack trace (`commands/shared.ts#withFatalErrors`, issue #336 —
+a superset of the original issue #279 `OxcLoadError`-only guard).
 
 **Declared exceptions to this contract** (deliberately not touched by this
 section, or by issue #279):
@@ -475,6 +479,32 @@ Notes:
   `--dry-run` also warns on a newer-schema lock (it never writes, so it isn't
   rejected) — the same "update CI's artgraph, don't `--force` it" guidance
   applies.
+- **`postWriteWarnings` (issue #273-2)**: after a non-preview run whose
+  post-write scan found a `.trace.lock` to reconcile against, the JSON result
+  carries `postWriteWarnings` — the SET DIFFERENCE of that post-write scan's
+  `buildGraph()` warnings against the pre-write scan's `buildWarnings`
+  (structurally keyed by type+id+sorted-files+message; `system-resource-exhausted`
+  keys on type alone — issue #336 F3/F4). It is therefore only ever NEW
+  warnings this specific run's post-write scan produced that the pre-write
+  scan did not already have — a pre-existing, rename-unrelated warning never
+  reappears here. `postWriteWarnings` is `undefined` (omitted from the JSON
+  payload) when no post-write scan ran at all — either `--dry-run` (which
+  never writes or reconciles) or no `.trace.lock` file existed to reconcile
+  against — versus `[]` when the post-write scan DID run and found nothing
+  new. Callers must not conflate the two: `undefined` is "no data", `[]` is a
+  real, positive "ran and found nothing new" signal. A non-empty
+  `postWriteWarnings` is a signal to INVESTIGATE, not necessarily proof the
+  rename itself is the cause — the underlying condition (e.g. an
+  environment-wide `system-resource-exhausted`) can coincide with, rather
+  than be caused by, this rename.
+- **Fatal-error envelope's optional `warnings` field**: when a non-preview
+  rename fails validation (`RenameValidationError`, issue #273) AFTER the
+  pre-write scan already ran, the `--format json` error envelope described in
+  ["Fatal errors"](#fatal-errors-stdoutstderr-contract-issue-279) above gains
+  an optional `warnings` field carrying that pre-write scan's `BuildWarning[]`
+  (e.g. `{"error": "...", "warnings": [...]}`) — omitted entirely when there
+  are none, never an empty array. Text mode prints the same warnings via
+  `printWarnings` (stderr) before the `Error: ...` line instead.
 
 ### rename does not reassign `@impl` tags <a id="rename-does-not-reassign-impl-tags"></a>
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,11 +4,55 @@ Full CLI reference. For the summary table and the agent-native workflow, see
 the top-level [README](../README.md). Run `artgraph --help` for the
 authoritative flag list.
 
+## Fatal errors: stdout/stderr contract (issue #279)
+
+This is the contract every command's **fatal** errors (a thrown exception
+that aborts the command outright — usage errors, environment failures like a
+broken oxc-parser native binding, unrecoverable validation failures) follow,
+across every command that has a `--format` option:
+
+- **text** (default, and every command with no `--format` at all, e.g.
+  `reconcile`): a human-readable message on **stderr**, exit `1`.
+- **json** (`--format json`): a `{"error": "<message>"}` envelope on
+  **stderr**, exit `1`. Never mixed into stdout — a `--format json`
+  consumer piping stdout to `jq` never has to guard against invalid JSON or
+  a truncated/partial payload, and stdout is reserved exclusively for a
+  **successful** result's structured payload.
+
+This applies uniformly to: a command's own usage/validation errors, a
+rejected `LockSchemaVersionError` (a `.trace.lock` written by a newer
+artgraph), `rename`'s validation/safety-valve failures (`RenameValidationError`,
+issue #273), and `OxcLoadError` (oxc-parser's native binding missing/broken,
+issue #263) — every command whose action reaches `scan()`/`buildGraph()`
+(`scan`, `check`, `impact`, `plan-coverage`, `reconcile`, `trace status`,
+`trace report`, `rename`) surfaces `OxcLoadError` through this same
+stderr/exit-1 contract instead of a raw, format-blind stack trace.
+
+**Declared exceptions to this contract** (deliberately not touched by this
+section, or by issue #279):
+
+- **`impact --diff --base <ref>`'s environment errors** (unresolvable ref,
+  uncomputable merge-base) already have their own stricter contract — **zero
+  bytes of stdout**, even under `--format json` — documented under
+  [`impact --diff --base <ref>`](#impact---diff---base-ref--commit-range-selection-in-ci-spec-024)
+  below. That contract predates this section and is unchanged; it is
+  stricter than (a subset of) the general rule above, not a conflict with
+  it.
+- **`rename`'s text-mode success path splits its two warning kinds across
+  streams**: `RenameWarning`s (`manual-assignment-needed`,
+  `unknown-trace-schema`, `unreadable-file`) print to **stdout** as part of
+  the rename summary, while `BuildWarning`s (`buildWarnings`,
+  `postWriteWarnings`) print to **stderr** via `printWarnings`. This is an
+  existing, current-behavior split (Step 0-pre M3), documented here as-is —
+  changing it is out of this section's scope; file a separate issue if it
+  should be unified.
+
 ## `artgraph init`
 
 Full agent-native setup in one command: `.artgraph.json` config + initial scan
-+ cross-agent Skills distribution + Stop hook + `AGENTS.md` snippet +
-auto-integrate of detected SDD tools.
+
+- cross-agent Skills distribution + Stop hook + `AGENTS.md` snippet +
+  auto-integrate of detected SDD tools.
 
 ```bash
 artgraph init --agents=claude              # required for the Skills / agent-context stages
@@ -122,11 +166,11 @@ additional findings — the same "declared vs. exercised" cross-check as
 trace-absent project none of this appears; output is byte-identical to
 before the feature shipped.
 
-| Finding | Text heading | `--format json` field | Meaning |
-| --- | --- | --- | --- |
-| Unexercised claim | `UNEXERCISED CLAIM:` | `unexercisedClaims` | `@impl REQ-001` exists but REQ-001's tagged green tests never execute that symbol |
-| Suggested impl | `SUGGESTED IMPL:` | `suggestedImpls` | No `@impl`, but the symbol is exercised exclusively by one REQ's tests |
-| Stale evidence | `STALE EVIDENCE:` | `staleEvidence` | The symbol's content hash changed since its trace evidence was captured (`{ reqId, symbols[], tracedAt }`) |
+| Finding           | Text heading         | `--format json` field | Meaning                                                                                                    |
+| ----------------- | -------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Unexercised claim | `UNEXERCISED CLAIM:` | `unexercisedClaims`   | `@impl REQ-001` exists but REQ-001's tagged green tests never execute that symbol                          |
+| Suggested impl    | `SUGGESTED IMPL:`    | `suggestedImpls`      | No `@impl`, but the symbol is exercised exclusively by one REQ's tests                                     |
+| Stale evidence    | `STALE EVIDENCE:`    | `staleEvidence`       | The symbol's content hash changed since its trace evidence was captured (`{ reqId, symbols[], tracedAt }`) |
 
 `trace.staleness` (`.artgraph.json`, default `"warn"`) controls how stale
 evidence is treated: `"warn"` reports it only; `"exclude"` drops stale
@@ -207,7 +251,15 @@ artgraph impact --diff --tests --format json
 ```
 
 ```json
-{ "testsToRun": [{ "testFile": "tests/billing.test.ts", "testName": "[REQ-003] charge bills a positive amount", "reqId": "REQ-003" }] }
+{
+  "testsToRun": [
+    {
+      "testFile": "tests/billing.test.ts",
+      "testName": "[REQ-003] charge bills a positive amount",
+      "reqId": "REQ-003"
+    }
+  ]
+}
 ```
 
 When the graph has any `exercises` edges at all, `impact`'s regular JSON
@@ -220,7 +272,7 @@ reached via a static path (`@impl` / `imports`) or via `exercises` evidence
 `--tests` is passed → exit `1` with the same runner-setup guidance as
 `artgraph trace report` (below).
 
-### `impact --diff --base <ref>` — commit-range selection in CI (spec 024)
+### `impact --diff --base <ref>` — commit-range selection in CI (spec 024) <a id="impact---diff---base-ref--commit-range-selection-in-ci-spec-024"></a>
 
 In CI the checked-out working tree matches the commit exactly, so plain
 `impact --diff --tests` sees an empty diff and returns "No changes detected"
@@ -247,13 +299,13 @@ artgraph impact --diff --base "origin/${{ github.base_ref }}" --tests --format j
   stdout, even under `--format json`** — an environment failure is not a
   verdict, and an empty-`testsToRun` payload would misread as "nothing to
   run". There is no fallback to a working-tree-only diff.
-- **Selection limits (declared)** — startIds resolve against the *current*
+- **Selection limits (declared)** — startIds resolve against the _current_
   graph only: a file **deleted** by a commit in the range, or a changed file
   the graph does not track, contributes no start ids — silently, exactly
   like graph-external files always have under `--diff`. `impact` takes no
   baseline worktree and no rename map (a base-range rename is folded to its
   new path, which is the correct current-graph input). A file **renamed**
-  in the range is in the same boat with respect to *stale evidence*: its
+  in the range is in the same boat with respect to _stale evidence_: its
   start ids resolve under the new path, but trace shards cached from the
   base branch record evidence under the old path, so the `--tests` join
   misses and its tests silently drop from the selection.
@@ -261,7 +313,7 @@ artgraph impact --diff --base "origin/${{ github.base_ref }}" --tests --format j
   or graph-untracked changed files contribute nothing to the selection.
   Treat `impact --tests` as an **optimization** — fall back to
   the full suite on exit `1` or whenever unsure. The correctness gate
-  remains `check --diff --base --gate` (which *does* resolve deletions
+  remains `check --diff --base --gate` (which _does_ resolve deletions
   against the baseline and fails the PR on the resulting uncovered REQs).
   Also filter the selected test files for existence before handing them to
   the runner — a PR that deletes a test file can yield a selection of
@@ -269,15 +321,15 @@ artgraph impact --diff --base "origin/${{ github.base_ref }}" --tests --format j
   legitimate PR).
 - **`trace.staleness: "exclude"` interaction** — in CI the trace shards
   necessarily predate the change (e.g. cached from the base branch), so the
-  changed code's evidence is stale *by construction* and `"exclude"` drops
+  changed code's evidence is stale _by construction_ and `"exclude"` drops
   exactly the tests most related to the change. Combining `--tests`,
   `--base` and `staleness: "exclude"` emits a non-fatal stderr warning; use
   `staleness: "warn"` for CI test selection, or fall back to the full suite.
 
-| exit code | meaning | CI consumer action |
-| --- | --- | --- |
-| `0` | valid selection — including the legitimate "No changes detected" empty merged diff | use `testsToRun` (treat an empty selection with suspicion — see the consumer rule) |
-| `1` | usage error, unresolvable ref / merge-base, or no changed path resolved in the graph | **fall back to the full suite** |
+| exit code | meaning                                                                              | CI consumer action                                                                 |
+| --------- | ------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------- |
+| `0`       | valid selection — including the legitimate "No changes detected" empty merged diff   | use `testsToRun` (treat an empty selection with suspicion — see the consumer rule) |
+| `1`       | usage error, unresolvable ref / merge-base, or no changed path resolved in the graph | **fall back to the full suite**                                                    |
 
 ## `artgraph trace` <a id="artgraph-trace"></a>
 
@@ -303,7 +355,14 @@ Reports how much evidence is on disk and how fresh it is.
   "shardCount": 4,
   "testCount": 12,
   "skippedCount": 1,
-  "diagnostics": { "dangling": 0, "corrupted": 0, "offGraph": 0, "unknownSchema": 0, "skipped": 1, "stale": 2 },
+  "diagnostics": {
+    "dangling": 0,
+    "corrupted": 0,
+    "offGraph": 0,
+    "unknownSchema": 0,
+    "skipped": 1,
+    "stale": 2
+  },
   "staleRate": 0.15
 }
 ```
@@ -315,11 +374,18 @@ touched by either an `@impl` claim or exercises evidence into four buckets:
 
 ```json
 {
-  "corroborated":      [{ "reqId": "REQ-001", "node": "symbol:src/auth.ts#signIn" }],
+  "corroborated": [{ "reqId": "REQ-001", "node": "symbol:src/auth.ts#signIn" }],
   "unexercisedClaims": [{ "reqId": "REQ-001", "node": "symbol:src/legacy.ts#oldSignIn" }],
-  "suggestedImpls":    [{ "reqId": "REQ-002", "node": "symbol:src/auth.ts#resetPassword" }],
-  "infrastructure":    [{ "node": "symbol:src/util.ts#validateEmail", "reqCount": 3 }],
-  "diagnostics":       { "dangling": 0, "corrupted": 0, "offGraph": 0, "unknownSchema": 0, "skipped": 1, "stale": 0 }
+  "suggestedImpls": [{ "reqId": "REQ-002", "node": "symbol:src/auth.ts#resetPassword" }],
+  "infrastructure": [{ "node": "symbol:src/util.ts#validateEmail", "reqCount": 3 }],
+  "diagnostics": {
+    "dangling": 0,
+    "corrupted": 0,
+    "offGraph": 0,
+    "unknownSchema": 0,
+    "skipped": 1,
+    "stale": 0
+  }
 }
 ```
 
@@ -368,7 +434,7 @@ artgraph reconcile
 `rename` runs this automatically after a non-preview rename.
 
 **Lock schema version**: `.trace.lock` carries a `_meta.schemaVersion` stamp.
-If the on-disk lock was written by a *newer* artgraph than the one running
+If the on-disk lock was written by a _newer_ artgraph than the one running
 `reconcile` (or `rename`, or `init`'s initial scan), the write is refused with
 a clear error — rebuilding it here would silently discard information the
 newer CLI understood. `--force` overwrites it anyway (a "Downgrading lock

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -8,6 +8,7 @@ import {
   pathsToEntries,
   resolveTestResults,
   reportGraphWarnings,
+  withOxcLoadErrorFatal,
 } from "./shared.js";
 import { printCheckText } from "./presenters/check.js";
 
@@ -108,7 +109,16 @@ export function registerCheckCommand(program: Command): void {
       const { readLockWithMeta, warnIfNewerLockSchema } = await import("../lock.js");
       const { check } = await import("../check.js");
       const config = loadConfig(rootDir);
-      const { graph, warnings } = scan(rootDir, config);
+      // issue #279 — format-aware `OxcLoadError` handling (issue #263): this
+      // action had no catch of its own before, so the error used to
+      // propagate uncaught to cli.ts's format-blind top-level catch. The
+      // baseline-worktree scan for `--diff --base` (further below) is a
+      // DIFFERENT code path — `baseline.ts` already contains its own scan
+      // failures into a display-only "unavailable" baseline status, so an
+      // OxcLoadError there never reaches this catch or cli.ts's.
+      const { graph, warnings } = await withOxcLoadErrorFatal(opts.format, () =>
+        scan(rootDir, config),
+      );
       // issue #243 — `check` is read-only w.r.t. the lock: a newer-schema
       // lock is still readable (unknown fields are simply invisible), so
       // warn and keep going rather than fail like the write paths do.

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -8,7 +8,7 @@ import {
   pathsToEntries,
   resolveTestResults,
   reportGraphWarnings,
-  withOxcLoadErrorFatal,
+  withFatalErrors,
 } from "./shared.js";
 import { printCheckText } from "./presenters/check.js";
 
@@ -108,17 +108,22 @@ export function registerCheckCommand(program: Command): void {
       const { scan } = await import("../scan.js");
       const { readLockWithMeta, warnIfNewerLockSchema } = await import("../lock.js");
       const { check } = await import("../check.js");
-      const config = loadConfig(rootDir);
-      // issue #279 — format-aware `OxcLoadError` handling (issue #263): this
-      // action had no catch of its own before, so the error used to
-      // propagate uncaught to cli.ts's format-blind top-level catch. The
-      // baseline-worktree scan for `--diff --base` (further below) is a
-      // DIFFERENT code path — `baseline.ts` already contains its own scan
-      // failures into a display-only "unavailable" baseline status, so an
-      // OxcLoadError there never reaches this catch or cli.ts's.
-      const { graph, warnings } = await withOxcLoadErrorFatal(opts.format, () =>
-        scan(rootDir, config),
-      );
+      // issue #279 / issue #336 (meta-review F1) — format-aware fatal-error
+      // handling for both `loadConfig()` and `scan()`: pre-#336, only the
+      // `scan()` call was guarded (against `OxcLoadError` only), so a
+      // malformed `.artgraph.json` (`loadConfig()`'s `Failed to parse ...`)
+      // propagated uncaught to cli.ts's format-blind top-level catch — a raw
+      // Node stack trace regardless of `--format`. Both calls now route
+      // through `withFatalErrors`, which also catches every OTHER thrown
+      // `Error`, not just `OxcLoadError` (mirrors rename.ts's
+      // `loadScanContext`, the reference implementation for "loadConfig
+      // inside the guarded region"). The baseline-worktree scan for
+      // `--diff --base` (further below) is a DIFFERENT code path —
+      // `baseline.ts` already contains its own scan failures into a
+      // display-only "unavailable" baseline status, so a fatal error there
+      // never reaches this catch or cli.ts's.
+      const config = await withFatalErrors(opts.format, () => loadConfig(rootDir));
+      const { graph, warnings } = await withFatalErrors(opts.format, () => scan(rootDir, config));
       // issue #243 — `check` is read-only w.r.t. the lock: a newer-schema
       // lock is still readable (unknown fields are simply invisible), so
       // warn and keep going rather than fail like the write paths do.

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2,7 +2,11 @@
 
 import { Command, Option } from "commander";
 import type { AgentId } from "../agents/descriptors.js";
-import { parseAgentsFlag } from "./shared.js";
+import { parseAgentsFlag, printFatalCatchAll, printOxcLoadError } from "./shared.js";
+// See commands/shared.ts's `withFatalErrors` doc comment for why this static
+// import is free (cli.ts's own top-level catch already pays it
+// unconditionally on every real CLI invocation).
+import { OxcLoadError } from "../parsers/typescript.js";
 
 // spec 013 T028 — `artgraph doctor` subcommand. Diagnoses Tier 1 distribution
 // health (Skills sha256 / AGENTS.md marker / wrappers / extraneous files).
@@ -26,11 +30,24 @@ export function registerDoctorCommand(program: Command): void {
       // as init's --agents branch. `init` and `doctor` used to inline a byte-
       // identical try/catch; migrating doctor onto the helper keeps them in
       // sync when the error-to-exit behavior changes.
+      //
+      // issue #336 (meta-review F1) — `opts.format` is now threaded through
+      // so an `AgentsParseError` here gets the same format-aware treatment
+      // (json envelope / unchanged text) as every other fatal error, instead
+      // of always printing bare text regardless of `--format json`.
       const agents: AgentId[] | undefined =
-        opts.agents !== undefined ? parseAgentsFlag(String(opts.agents)) : undefined;
+        opts.agents !== undefined ? parseAgentsFlag(String(opts.agents), opts.format) : undefined;
       // C1 — mirror the `init` action's try/catch so `SkillsInstallError`,
       // `EACCES` reads, unknown-agent throws, etc. surface as a single
       // `Error: <msg>` line rather than a raw Node stack trace.
+      //
+      // issue #336 (meta-review F1) — this catch-all used to be plain-text-
+      // only (`console.error(\`Error: ${msg}\`)`) regardless of `--format`,
+      // so a `--format json` consumer piping doctor's fatal errors to `jq`
+      // got a parse error instead of a `{"error": ...}` envelope. `loadConfig()`
+      // (inside `runDoctor`, see doctor.ts's own `loadConfig` call) is the
+      // most common way to reach this — a malformed `.artgraph.json` now
+      // surfaces cleanly here instead of as a raw Node stack trace.
       try {
         const report = runDoctor({ rootDir, agents });
         const out =
@@ -40,8 +57,12 @@ export function registerDoctorCommand(program: Command): void {
           process.exitCode = 1;
         }
       } catch (e) {
+        if (e instanceof OxcLoadError) {
+          printOxcLoadError(opts.format, e);
+          process.exit(1);
+        }
         const msg = e instanceof Error ? e.message : String(e);
-        console.error(`Error: ${msg}`);
+        printFatalCatchAll(opts.format, msg);
         process.exit(1);
       }
     });

--- a/src/commands/impact.ts
+++ b/src/commands/impact.ts
@@ -7,6 +7,7 @@ import {
   pathsToEntries,
   reportGraphWarnings,
   TRACE_NO_SHARDS_GUIDANCE,
+  withOxcLoadErrorFatal,
 } from "./shared.js";
 import { printImpactText } from "./presenters/impact.js";
 
@@ -230,7 +231,12 @@ export function registerImpactCommand(program: Command): void {
       // `--diff` "no changes" early-exit JSON payload below (mirrors
       // `check --diff`'s equivalent branch) and to the final output at the
       // bottom of this action.
-      const { graph, warnings } = scan(rootDir, config);
+      // issue #279 — format-aware `OxcLoadError` handling (issue #263): this
+      // action had no catch of its own before, so the error used to
+      // propagate uncaught to cli.ts's format-blind top-level catch.
+      const { graph, warnings } = await withOxcLoadErrorFatal(opts.format, () =>
+        scan(rootDir, config),
+      );
       // issue #243 — read-only w.r.t. the lock: warn on a newer schema and
       // keep going (see commands/check.ts's identical comment).
       const { lock, schemaVersion } = readLockWithMeta(rootDir, config.lockFile);

--- a/src/commands/impact.ts
+++ b/src/commands/impact.ts
@@ -7,7 +7,7 @@ import {
   pathsToEntries,
   reportGraphWarnings,
   TRACE_NO_SHARDS_GUIDANCE,
-  withOxcLoadErrorFatal,
+  withFatalErrors,
 } from "./shared.js";
 import { printImpactText } from "./presenters/impact.js";
 
@@ -169,7 +169,11 @@ export function registerImpactCommand(program: Command): void {
       const { readLockWithMeta, warnIfNewerLockSchema } = await import("../lock.js");
       const { entryOriginIds, impact, resolveStartIds, resolveOriginReqs } =
         await import("../graph/traverse.js");
-      const config = loadConfig(rootDir);
+      // issue #279 / issue #336 (meta-review F1) — `loadConfig()` used to run
+      // unguarded here, so a malformed `.artgraph.json` propagated uncaught
+      // to cli.ts's format-blind top-level catch (see check.ts's identical
+      // comment on `withFatalErrors` for the full rationale).
+      const config = await withFatalErrors(opts.format, () => loadConfig(rootDir));
 
       // spec 020 (FR-018, contracts/cli-surface.md §5) — `--tests` requires
       // trace evidence to exist at all; exit 1 with the SAME guidance string
@@ -231,12 +235,10 @@ export function registerImpactCommand(program: Command): void {
       // `--diff` "no changes" early-exit JSON payload below (mirrors
       // `check --diff`'s equivalent branch) and to the final output at the
       // bottom of this action.
-      // issue #279 — format-aware `OxcLoadError` handling (issue #263): this
+      // issue #279 — format-aware fatal-error handling for `scan()`: this
       // action had no catch of its own before, so the error used to
       // propagate uncaught to cli.ts's format-blind top-level catch.
-      const { graph, warnings } = await withOxcLoadErrorFatal(opts.format, () =>
-        scan(rootDir, config),
-      );
+      const { graph, warnings } = await withFatalErrors(opts.format, () => scan(rootDir, config));
       // issue #243 — read-only w.r.t. the lock: warn on a newer schema and
       // keep going (see commands/check.ts's identical comment).
       const { lock, schemaVersion } = readLockWithMeta(rootDir, config.lockFile);

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,9 +6,14 @@ import {
   AGENTS_REQUIRED_ERROR,
   loadIntegrate,
   parseAgentsFlag,
+  printOxcLoadError,
   reportGraphWarnings,
 } from "./shared.js";
 import { printIntegrateText } from "./presenters/integrate.js";
+// See commands/shared.ts's `withFatalErrors` doc comment for why this static
+// import is free (cli.ts's own top-level catch already pays it
+// unconditionally on every real CLI invocation).
+import { OxcLoadError } from "../parsers/typescript.js";
 
 export function registerInitCommand(program: Command): void {
   program
@@ -55,9 +60,14 @@ export function registerInitCommand(program: Command): void {
       // hint before we even look at the other gates. The parser throws
       // `AgentsParseError` with the full stderr-ready message; we surface it
       // verbatim and exit 1.
+      // issue #336 (meta-review F1) — `opts.format` threaded through so an
+      // `AgentsParseError` here gets the same format-aware treatment (json
+      // envelope / unchanged text) as every other fatal error in this
+      // action, instead of always printing bare text regardless of
+      // `--format json`.
       let parsedAgents: AgentId[] | undefined;
       if (opts.agents !== undefined) {
-        parsedAgents = parseAgentsFlag(String(opts.agents));
+        parsedAgents = parseAgentsFlag(String(opts.agents), opts.format);
       }
 
       // @impl 013-cross-agent-extensions/FR-013
@@ -298,8 +308,16 @@ export function registerInitCommand(program: Command): void {
           process.exitCode = 1;
         }
       } catch (e) {
+        // issue #336 (meta-review F1) — `OxcLoadError` (issue #263: oxc-
+        // parser's native binding missing/broken, reachable here via the
+        // scan stage — see `runInit`) gets its own dedicated bare-message
+        // printer, same as every other command, rather than falling into
+        // the generic `Error: <msg>`-prefixed catch-all below.
+        if (e instanceof OxcLoadError) {
+          printOxcLoadError(opts.format, e);
+          process.exit(1);
+        }
         const msg = e instanceof Error ? e.message : String(e);
-        console.error(`Error: ${msg}`);
         // B6: `DistributionError.partiallyWritten` lists paths whose rollback
         // step itself failed (e.g. Windows AV / IDE holding a file open, or a
         // cross-agent survivor whose unlink hit EACCES). Silently dropping
@@ -307,10 +325,29 @@ export function registerInitCommand(program: Command): void {
         // which paths still needed manual cleanup. Surfacing them here means
         // the "manual cleanup required" hint arrives together with the error
         // that necessitates it.
-        if (e instanceof DistributionError && e.partiallyWritten && e.partiallyWritten.length > 0) {
-          console.error("");
-          console.error("Partial writes could not be rolled back. Manual cleanup required:");
-          for (const p of e.partiallyWritten) console.error(`  ${p}`);
+        const partiallyWritten =
+          e instanceof DistributionError && e.partiallyWritten && e.partiallyWritten.length > 0
+            ? e.partiallyWritten
+            : undefined;
+        // issue #336 (meta-review F1) — this catch-all used to be plain-
+        // text-only (`console.error(\`Error: ${msg}\`)`) regardless of
+        // `--format`, so a `--format json` consumer piping init's fatal
+        // errors to `jq` got a parse error instead of a `{"error": ...}`
+        // envelope (e.g. a malformed `.artgraph.json` on `init --force`).
+        // Text mode's wording (including the `AgentsParseError` /
+        // `DistributionError` cases above/below) is byte-identical to the
+        // pre-#336 behavior — only json mode's shape is new.
+        if (opts.format === "json") {
+          const envelope: { error: string; partiallyWritten?: string[] } = { error: msg };
+          if (partiallyWritten) envelope.partiallyWritten = partiallyWritten;
+          console.error(JSON.stringify(envelope));
+        } else {
+          console.error(`Error: ${msg}`);
+          if (partiallyWritten) {
+            console.error("");
+            console.error("Partial writes could not be rolled back. Manual cleanup required:");
+            for (const p of partiallyWritten) console.error(`  ${p}`);
+          }
         }
         process.exit(1);
       }

--- a/src/commands/plan-coverage.ts
+++ b/src/commands/plan-coverage.ts
@@ -10,7 +10,7 @@ import {
   printFatalCatchAll,
   printOxcLoadError,
 } from "./shared.js";
-// See commands/shared.ts's `withOxcLoadErrorFatal` doc comment for why this
+// See commands/shared.ts's `withFatalErrors` doc comment for why this
 // static import is free (cli.ts's own top-level catch already pays it
 // unconditionally on every real CLI invocation).
 import { OxcLoadError } from "../parsers/typescript.js";
@@ -73,6 +73,16 @@ export function registerPlanCoverageCommand(program: Command): void {
       const { loadConfig } = await import("../config.js");
       const { runPlanCoverage } = await import("../plan-coverage/index.js");
 
+      // issue #336 (meta-review F1) — resolved BEFORE `loadConfig()` (now
+      // inside the `try` below) is ever called: a malformed `.artgraph.json`
+      // must produce a format-aware fatal error, which requires `format` to
+      // already be known by the time `loadConfig()` can throw. This is the
+      // only reordering in this action — every usage-error check below
+      // (missing spec dir, missing tasks.md/plan.md) still runs in its
+      // original place; those are plain usage errors, not part of the
+      // fatal-error contract this section guards.
+      const format: "json" | "text" = opts.format === "json" ? "json" : "text";
+
       // Resolve spec dir per the contract precedence.
       const resolved = resolveSpecDir({
         explicitFlag: opts.spec,
@@ -115,14 +125,20 @@ export function registerPlanCoverageCommand(program: Command): void {
         .map((s) => s.trim())
         .filter((s) => s.length > 0);
 
-      // `.artgraph.json`'s planCoverage section drives requireFilesSection
-      // (default false).
-      const config = loadConfig(rootDir);
-      const requireFilesSection: boolean = config.planCoverage?.requireFilesSection ?? false;
-
-      const format: "json" | "text" = opts.format === "json" ? "json" : "text";
-
       try {
+        // issue #336 (meta-review F1) — `loadConfig()` moved INSIDE this
+        // guarded `try` (it used to run before the `try` block even
+        // started, so a malformed `.artgraph.json` threw straight past this
+        // action's catch-all to cli.ts's format-blind top-level handler — a
+        // raw Node stack trace regardless of `--format`). Mirrors
+        // rename.ts's `loadScanContext`, the reference implementation for
+        // "loadConfig inside the guarded region".
+        //
+        // `.artgraph.json`'s planCoverage section drives requireFilesSection
+        // (default false).
+        const config = loadConfig(rootDir);
+        const requireFilesSection: boolean = config.planCoverage?.requireFilesSection ?? false;
+
         const result = runPlanCoverage({
           repoRoot: rootDir,
           specDir,

--- a/src/commands/plan-coverage.ts
+++ b/src/commands/plan-coverage.ts
@@ -3,7 +3,17 @@
 import { Command, Option } from "commander";
 import { existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { DASH_PATH_HINT, nonOptionValue, reportGraphWarnings } from "./shared.js";
+import {
+  DASH_PATH_HINT,
+  nonOptionValue,
+  reportGraphWarnings,
+  printFatalCatchAll,
+  printOxcLoadError,
+} from "./shared.js";
+// See commands/shared.ts's `withOxcLoadErrorFatal` doc comment for why this
+// static import is free (cli.ts's own top-level catch already pays it
+// unconditionally on every real CLI invocation).
+import { OxcLoadError } from "../parsers/typescript.js";
 
 // spec 014 (FR-013 — FR-020): plan-coverage subcommand. Reads tasks.md /
 // plan.md (and the current spec.md) to detect REQs that are *affected*
@@ -136,8 +146,23 @@ export function registerPlanCoverageCommand(program: Command): void {
           process.exit(result.exitCode);
         }
       } catch (e) {
+        // issue #279 — `OxcLoadError` (issue #263: oxc-parser's native
+        // binding missing/broken) is an environment failure with its own
+        // complete diagnostic message; handled before the generic catch-all
+        // below so it never gets the generic `Error: ` prefix.
+        if (e instanceof OxcLoadError) {
+          printOxcLoadError(format, e);
+          process.exit(1);
+        }
+        // issue #279 (item 1) — this catch-all used to be plain-text-only
+        // (`console.error(\`Error: ${msg}\`)`) regardless of `--format`, so a
+        // `--format json` consumer piping this command's fatal errors to
+        // `jq` got a parse error instead of a `{"error": ...}` envelope.
+        // Mirrors `commands/rename.ts`'s original `fail()` (same envelope
+        // shape, same stderr stream — see docs/commands.md's fatal-error
+        // contract section); text mode's `Error: ${msg}` line is unchanged.
         const msg = e instanceof Error ? e.message : String(e);
-        console.error(`Error: ${msg}`);
+        printFatalCatchAll(format, msg);
         process.exit(1);
       }
     });

--- a/src/commands/presenters/rename.ts
+++ b/src/commands/presenters/rename.ts
@@ -2,7 +2,32 @@
 // verbatim from `src/cli.ts` (issue #162) — no behavior change.
 
 import type { RenameResult } from "../../rename-executor.js";
+import { isSilentWarning, type BuildWarning } from "../../graph/builder.js";
 import { printWarnings } from "./warnings.js";
+
+/**
+ * issue #273-2 ((a)-lite) — `postWriteWarnings` is the (already pre-write-
+ * deduped) set of `BuildWarning`s the post-rename re-scan surfaced that the
+ * PRE-write scan did not have. Printed as its own labeled block (stderr,
+ * same stream as `buildWarnings`) so a reader can tell "this warning existed
+ * before your rename" (`buildWarnings`) apart from "your rename's rewritten
+ * files triggered this warning on the very next scan" (`postWriteWarnings`)
+ * — e.g. a `--merge` scaffold landing in two spec files minting a fresh
+ * `duplicate-id`. Filters `isSilentWarning` types first (mirrors
+ * `printWarnings`'s own filtering) so an all-silent `postWriteWarnings`
+ * (e.g. only `phantom-import-repaired`) does not print a heading with
+ * nothing under it. A `no post-write scan ran` `undefined` (dry-run, or no
+ * lock file) prints nothing, same as an empty array.
+ */
+function printPostWriteWarnings(postWriteWarnings: BuildWarning[] | undefined): void {
+  if (!postWriteWarnings) return;
+  const visible = postWriteWarnings.filter((w) => !isSilentWarning(w.type));
+  if (visible.length === 0) return;
+  console.error(
+    "WARNING: new warnings detected by the post-rename re-scan (not necessarily caused by this rename):",
+  );
+  printWarnings(visible);
+}
 
 export function printRenameText(result: RenameResult) {
   if (result.changes.length === 0 && result.lockChanges.length === 0) {
@@ -11,6 +36,7 @@ export function printRenameText(result: RenameResult) {
     // class-member-collision, …) matter regardless of whether this
     // particular rename found any references to rewrite.
     printWarnings(result.buildWarnings);
+    printPostWriteWarnings(result.postWriteWarnings);
     return;
   }
 
@@ -48,6 +74,7 @@ export function printRenameText(result: RenameResult) {
 
   // issue #265 — see the note in printRenameText's early-return branch above.
   printWarnings(result.buildWarnings);
+  printPostWriteWarnings(result.postWriteWarnings);
 }
 
 export function printRenameJson(result: RenameResult) {

--- a/src/commands/reconcile.ts
+++ b/src/commands/reconcile.ts
@@ -1,7 +1,7 @@
 // `artgraph reconcile` — extracted verbatim from `src/cli.ts` (issue #162).
 
 import { Command } from "commander";
-import { reportGraphWarnings, withOxcLoadErrorFatal } from "./shared.js";
+import { reportGraphWarnings, withFatalErrors } from "./shared.js";
 
 export function registerReconcileCommand(program: Command): void {
   program
@@ -15,34 +15,31 @@ export function registerReconcileCommand(program: Command): void {
       const rootDir = process.cwd();
       const { loadConfig } = await import("../config.js");
       const { scan, reconcile } = await import("../scan.js");
-      const { LockSchemaVersionError } = await import("../lock.js");
-      const config = loadConfig(rootDir);
       // issue #265 — `warnings` used to be discarded here, so a
       // `pathological-bracket-nesting` / `class-member-collision` build
       // warning was invisible via `artgraph reconcile`. `reconcile` has no
       // `--format json` mode, so this always prints (mirrors scan/init/check's
       // text-mode behavior).
       //
-      // issue #279 — format-aware `OxcLoadError` handling (issue #263):
-      // `reconcile` has no `--format` at all, so `format` is `undefined`
-      // (text-mode diagnostic) — this action had no catch of its own before,
-      // so the error used to propagate uncaught to cli.ts's top-level catch.
-      const { graph, warnings } = await withOxcLoadErrorFatal(undefined, () =>
-        scan(rootDir, config),
+      // issue #279 / issue #336 (meta-review F1/F4) — `reconcile` has no
+      // `--format` at all, so `format` is `undefined` (text-only contract:
+      // a clean one-line message on stderr, exit 1 — never a raw stack
+      // trace). Pre-#336, ONLY the `scan()` call was guarded (against
+      // `OxcLoadError` only): `loadConfig()` ran unguarded above it, and the
+      // `reconcile()` call below had its own narrower try/catch that special-
+      // cased `LockSchemaVersionError` and rethrew everything else — so both
+      // a malformed `.artgraph.json` AND any OTHER `reconcile()` failure
+      // (not `LockSchemaVersionError`) still produced a raw Node stack
+      // trace. `withFatalErrors` now guards `loadConfig()`, `scan()`, AND
+      // `reconcile()` uniformly: `LockSchemaVersionError`'s `.message` is
+      // already the exact clean text the old dedicated catch printed, so
+      // routing it through the generic catch-all is not a wording change,
+      // just one fewer special case to maintain.
+      const config = await withFatalErrors(undefined, () => loadConfig(rootDir));
+      const { graph, warnings } = await withFatalErrors(undefined, () => scan(rootDir, config));
+      await withFatalErrors(undefined, () =>
+        reconcile(rootDir, config, graph, { force: Boolean(opts.force) }),
       );
-      // issue #243 — a lock schema newer than this CLI understands is a hard
-      // stop (not a silent coarse rebuild): print a clear, actionable error
-      // and exit non-zero instead of letting the exception's raw stack
-      // trace fall through commander's default handling.
-      try {
-        reconcile(rootDir, config, graph, { force: Boolean(opts.force) });
-      } catch (e) {
-        if (e instanceof LockSchemaVersionError) {
-          console.error(`Error: ${e.message}`);
-          process.exit(1);
-        }
-        throw e;
-      }
       console.log(`Lock file updated: ${config.lockFile}`);
       reportGraphWarnings(warnings);
     });

--- a/src/commands/reconcile.ts
+++ b/src/commands/reconcile.ts
@@ -1,7 +1,7 @@
 // `artgraph reconcile` — extracted verbatim from `src/cli.ts` (issue #162).
 
 import { Command } from "commander";
-import { reportGraphWarnings } from "./shared.js";
+import { reportGraphWarnings, withOxcLoadErrorFatal } from "./shared.js";
 
 export function registerReconcileCommand(program: Command): void {
   program
@@ -22,7 +22,14 @@ export function registerReconcileCommand(program: Command): void {
       // warning was invisible via `artgraph reconcile`. `reconcile` has no
       // `--format json` mode, so this always prints (mirrors scan/init/check's
       // text-mode behavior).
-      const { graph, warnings } = scan(rootDir, config);
+      //
+      // issue #279 — format-aware `OxcLoadError` handling (issue #263):
+      // `reconcile` has no `--format` at all, so `format` is `undefined`
+      // (text-mode diagnostic) — this action had no catch of its own before,
+      // so the error used to propagate uncaught to cli.ts's top-level catch.
+      const { graph, warnings } = await withOxcLoadErrorFatal(undefined, () =>
+        scan(rootDir, config),
+      );
       // issue #243 — a lock schema newer than this CLI understands is a hard
       // stop (not a silent coarse rebuild): print a clear, actionable error
       // and exit non-zero instead of letting the exception's raw stack

--- a/src/commands/rename.ts
+++ b/src/commands/rename.ts
@@ -2,7 +2,19 @@
 
 import { Command, Option } from "commander";
 import type { RenameResult } from "../rename-executor.js";
+// `OxcLoadError` is ALSO statically imported, unconditionally, by cli.ts's
+// own top-level catch (issue #263) — every real CLI invocation already pays
+// this module's (cheap, native-binding-free at import time — see
+// parsers/typescript.ts's own doc comment) load cost regardless of which
+// command runs, so importing it here too adds no new cost. `rename-executor.js`
+// stays a LAZY (`await import`) dependency below, unlike this — it pulls in
+// the whole scan/graph-builder stack, which the lazy-import refactor
+// (issue #162) deliberately keeps out of every command module's static
+// imports so `artgraph --help` doesn't pay for it.
+import { OxcLoadError } from "../parsers/typescript.js";
+import type { BuildWarning } from "../graph/builder.js";
 import { printRenameJson, printRenameText } from "./presenters/rename.js";
+import { printWarnings } from "./presenters/warnings.js";
 
 export function registerRenameCommand(program: Command): void {
   program
@@ -23,16 +35,28 @@ export function registerRenameCommand(program: Command): void {
     )
     .action(async (opts) => {
       const rootDir = process.cwd();
-      const { executeRename, executeSplit, executeMerge } = await import("../rename-executor.js");
+      const { executeRename, executeSplit, executeMerge, RenameValidationError } =
+        await import("../rename-executor.js");
       const format: "json" | "text" = opts.format;
       const baseOpts = { dryRun: !!opts.dryRun, format, rootDir, force: !!opts.force };
 
-      const fail = (msg: string): never => {
+      // issue #273-1 — `warnings` is the pre-write scan's `BuildWarning[]`
+      // carried by a `RenameValidationError` (undefined on every other error
+      // path — there's nothing to attach). json: folded into the SAME
+      // `{"error": ...}` envelope as a `warnings` field (F7's original
+      // contract stays byte-identical when there are none — the field is
+      // simply omitted, not `[]`). text: printed via `printWarnings` (stderr)
+      // BEFORE the `Error: ...` line, mirroring `printRenameText`'s existing
+      // success-path convention of always surfacing `buildWarnings`.
+      const fail = (msg: string, warnings?: BuildWarning[]): never => {
         // Honour --format json even on the error path so JSON consumers never
         // have to parse a plain-text line (F7).
         if (format === "json") {
-          console.error(JSON.stringify({ error: msg }));
+          const envelope: { error: string; warnings?: BuildWarning[] } = { error: msg };
+          if (warnings && warnings.length > 0) envelope.warnings = warnings;
+          console.error(JSON.stringify(envelope));
         } else {
+          if (warnings && warnings.length > 0) printWarnings(warnings);
           console.error(`Error: ${msg}`);
         }
         process.exit(1);
@@ -64,6 +88,29 @@ export function registerRenameCommand(program: Command): void {
           printRenameText(result);
         }
       } catch (e) {
+        // issue #279 — `OxcLoadError` (oxc-parser's native binding missing/
+        // broken, issue #263) is an environment failure, not a
+        // validation/IO problem about THIS rename. `.message` is already a
+        // complete, formatted diagnostic (see parsers/typescript.ts), so
+        // it's printed bare in text mode (no "Error:" prefix — matches
+        // cli.ts's own pre-existing top-level handling of the same error)
+        // and wrapped in the same envelope shape as every other fatal error
+        // here in json mode. See docs/commands.md's fatal-error contract.
+        if (e instanceof OxcLoadError) {
+          if (format === "json") {
+            console.error(JSON.stringify({ error: e.message }));
+          } else {
+            console.error(e.message);
+          }
+          process.exit(1);
+        }
+        // issue #273-1 — a validation/safety-valve throw from
+        // rename-executor.ts now carries the pre-write scan's
+        // buildWarnings; surface them via `fail` instead of the pre-fix
+        // behavior of extracting only `e.message` and discarding the rest.
+        if (e instanceof RenameValidationError) {
+          fail(e.message, e.buildWarnings);
+        }
         const msg = e instanceof Error ? e.message : String(e);
         fail(msg);
       }

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -2,7 +2,7 @@
 
 import { resolve } from "node:path";
 import { Command } from "commander";
-import { resolveTestResults, reportGraphWarnings, withOxcLoadErrorFatal } from "./shared.js";
+import { resolveTestResults, reportGraphWarnings, withFatalErrors } from "./shared.js";
 
 export function registerScanCommand(program: Command): void {
   program
@@ -21,11 +21,13 @@ export function registerScanCommand(program: Command): void {
       const rootDir = process.cwd();
       const { loadConfig } = await import("../config.js");
       const { scan } = await import("../scan.js");
-      const config = loadConfig(rootDir);
-      // issue #279 — format-aware `OxcLoadError` handling (issue #263): this
-      // was the only path in the command that can hit it, and previously it
-      // propagated uncaught to cli.ts's format-blind top-level catch.
-      const result = await withOxcLoadErrorFatal(opts.format, () => scan(rootDir, config));
+      // issue #279 / issue #336 (meta-review F1) — format-aware fatal-error
+      // handling for both `loadConfig()` and `scan()` (see check.ts's
+      // identical comment for the full rationale): pre-#336, `loadConfig()`
+      // ran unguarded, so a malformed `.artgraph.json` propagated uncaught
+      // to cli.ts's format-blind top-level catch.
+      const config = await withFatalErrors(opts.format, () => loadConfig(rootDir));
+      const result = await withFatalErrors(opts.format, () => scan(rootDir, config));
 
       // --serve / --output render the same scan graph as an interactive HTML
       // page (issue #125). The dedicated `graph` command was folded into

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -2,7 +2,7 @@
 
 import { resolve } from "node:path";
 import { Command } from "commander";
-import { resolveTestResults, reportGraphWarnings } from "./shared.js";
+import { resolveTestResults, reportGraphWarnings, withOxcLoadErrorFatal } from "./shared.js";
 
 export function registerScanCommand(program: Command): void {
   program
@@ -22,7 +22,10 @@ export function registerScanCommand(program: Command): void {
       const { loadConfig } = await import("../config.js");
       const { scan } = await import("../scan.js");
       const config = loadConfig(rootDir);
-      const result = scan(rootDir, config);
+      // issue #279 — format-aware `OxcLoadError` handling (issue #263): this
+      // was the only path in the command that can hit it, and previously it
+      // propagated uncaught to cli.ts's format-blind top-level catch.
+      const result = await withOxcLoadErrorFatal(opts.format, () => scan(rootDir, config));
 
       // --serve / --output render the same scan graph as an interactive HTML
       // page (issue #125). The dedicated `graph` command was folded into

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -9,6 +9,14 @@ import { parseAgentsList, AgentsParseError } from "../agents/parse-agents.js";
 import { AGENT_IDS, type AgentId } from "../agents/descriptors.js";
 import type { BuildWarning } from "../graph/builder.js";
 import { printWarnings } from "./presenters/warnings.js";
+// issue #279 — statically imported, same as `cli.ts`'s own top-level catch
+// (issue #263) already does unconditionally: this module's import cost is
+// cheap (no native binding load at import time — see the doc comment on
+// `OxcLoadError` in parsers/typescript.ts), and `cli.ts` already pays it on
+// EVERY real CLI invocation regardless of which command runs, so importing
+// it again here (this file is itself statically imported by every
+// `commands/*.ts` module) adds no new cost.
+import { OxcLoadError } from "../parsers/typescript.js";
 
 // issue #306 (PR #304 review F6/F7) — commander's required option-args are
 // greedy: a value-taking `--flag` immediately followed by ANOTHER flag
@@ -140,6 +148,70 @@ export function parseAgentsFlag(raw: string): AgentId[] {
 export function reportGraphWarnings(warnings: BuildWarning[], format?: string): void {
   if (format === "json") return;
   printWarnings(warnings);
+}
+
+// issue #279 — `OxcLoadError` (oxc-parser's native binding missing/broken,
+// issue #263) is a specifically-anticipated, actionable environment failure.
+// Before this helper, the ONLY place that caught it was `cli.ts`'s top-level
+// `program.parseAsync()` catch — a layer that has no idea what `--format`
+// the just-parsed command requested, so it always printed plain text to
+// stderr regardless of `--format json`. Each command action that can reach
+// `scan()`/`buildGraph()` (directly, or via a helper like
+// `plan-coverage/index.ts#runPlanCoverage` or `trace.ts#loadTraceInputs`)
+// wraps JUST that call in this helper instead of wrapping its entire body —
+// `format` is a normal command-local variable at every call site, so this
+// runs at a layer that DOES know it, without a broader restructure. Every
+// OTHER thrown error (including `RenameValidationError`, `LockSchemaVersionError`,
+// plain usage errors, …) passes through `fn`'s rethrow unchanged — this
+// helper only narrows on `OxcLoadError`. See docs/commands.md's "Fatal
+// errors" section for the resulting stdout/stderr contract this implements.
+export async function withOxcLoadErrorFatal<T>(
+  format: string | undefined,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (e) {
+    if (e instanceof OxcLoadError) {
+      printOxcLoadError(format, e);
+      process.exit(1);
+    }
+    throw e;
+  }
+}
+
+// issue #279 — shared with `withOxcLoadErrorFatal` above AND with the
+// handful of commands (`rename`, `plan-coverage`) that already had their own
+// catch-all before this issue and just needed an extra `instanceof
+// OxcLoadError` branch spliced in rather than a full call-site wrap.
+// `OxcLoadError.message` is already a complete, formatted diagnostic (see
+// parsers/typescript.ts) — printed bare in text mode (no "Error:" prefix,
+// matching `cli.ts`'s own pre-existing handling of this exact error) and
+// wrapped in the same `{"error": ...}` envelope every OTHER fatal error here
+// uses in json mode.
+export function printOxcLoadError(format: string | undefined, e: OxcLoadError): void {
+  if (format === "json") {
+    console.error(JSON.stringify({ error: e.message }));
+  } else {
+    console.error(e.message);
+  }
+}
+
+// issue #279 — the generic `{"error": ...}` stderr envelope every fatal
+// catch-all in this CLI converges on (`commands/rename.ts`'s original
+// `fail()` is the reference implementation this was extracted from
+// verbatim): text mode keeps the pre-existing plain `Error: <msg>` line,
+// json mode gets a parseable envelope instead of nothing/plain-text noise.
+// Both write to STDERR — this repo's existing convention (verified against
+// `rename.ts`'s `fail()`) is that stdout carries ONLY a successful result
+// payload; every diagnostic, `--format json` fatal errors included, goes to
+// stderr. See docs/commands.md's "Fatal errors" section.
+export function printFatalCatchAll(format: string | undefined, msg: string): void {
+  if (format === "json") {
+    console.error(JSON.stringify({ error: msg }));
+  } else {
+    console.error(`Error: ${msg}`);
+  }
 }
 
 // spec 020 (contracts/cli-surface.md §2 / §5, FR-018) — verbatim error UX

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -115,13 +115,24 @@ export async function loadIntegrate(): Promise<typeof import("../integrate/index
  * to the error-to-exit behavior only has to land once.
  *
  * Both `init` and `doctor` route --agents parsing through this helper.
+ *
+ * issue #336 (PR #336 meta-review) — `parseAgentsFlag` used to take no
+ * `format` parameter and always print `e.message` bare to stderr, ignoring
+ * `--format json` entirely (both call sites resolve their own `opts.format`
+ * before this runs — see `init.ts` / `doctor.ts`). `AgentsParseError.message`
+ * is already a complete, pre-formatted diagnostic (starts with `ERROR: `),
+ * exactly like `OxcLoadError.message` — so it goes through the same
+ * `printBareFatalMessage` a plain `printFatalCatchAll` would double-prefix
+ * (`Error: ERROR: Unknown agent...`). Text mode stays byte-identical to the
+ * pre-#336 behavior (bare message, no added prefix); json mode now wraps it
+ * in the same `{"error": ...}` envelope every other fatal error here uses.
  */
-export function parseAgentsFlag(raw: string): AgentId[] {
+export function parseAgentsFlag(raw: string, format?: string): AgentId[] {
   try {
     return parseAgentsList(raw);
   } catch (e) {
     if (e instanceof AgentsParseError) {
-      console.error(e.message);
+      printBareFatalMessage(format, e.message);
       process.exit(1);
     }
     throw e;
@@ -150,22 +161,43 @@ export function reportGraphWarnings(warnings: BuildWarning[], format?: string): 
   printWarnings(warnings);
 }
 
-// issue #279 — `OxcLoadError` (oxc-parser's native binding missing/broken,
-// issue #263) is a specifically-anticipated, actionable environment failure.
-// Before this helper, the ONLY place that caught it was `cli.ts`'s top-level
-// `program.parseAsync()` catch — a layer that has no idea what `--format`
-// the just-parsed command requested, so it always printed plain text to
-// stderr regardless of `--format json`. Each command action that can reach
-// `scan()`/`buildGraph()` (directly, or via a helper like
+// issue #279 / issue #336 (PR #336 meta-review F1) — `OxcLoadError` (oxc-
+// parser's native binding missing/broken, issue #263) is a specifically-
+// anticipated, actionable environment failure. Before issue #279, the ONLY
+// place that caught it was `cli.ts`'s top-level `program.parseAsync()` catch
+// — a layer that has no idea what `--format` the just-parsed command
+// requested, so it always printed plain text to stderr regardless of
+// `--format json`.
+//
+// issue #279's original helper (`withOxcLoadErrorFatal`) only narrowed on
+// `OxcLoadError` and rethrew everything else — which meant a call site whose
+// wrapped region also covers `loadConfig()` (e.g. `trace.ts#loadTraceInputs`,
+// `rename-executor.ts#loadScanContext`, the reference implementation) still
+// let a malformed `.artgraph.json`'s plain `Error` (`config.ts`'s
+// `Failed to parse ...`) escape uncaught to `cli.ts`'s format-blind
+// top-level catch — a full raw Node stack trace with internal `dist/`/`src/`
+// file paths, exactly like `OxcLoadError` before #279, just for a different
+// (much more commonly hit) error type. `withFatalErrors` widens the catch:
+// `OxcLoadError` still gets its own dedicated bare-message printer
+// (`printOxcLoadError`), and now EVERY other `Error` gets the generic
+// `{"error": ...}` / `Error: <msg>` envelope via `printFatalCatchAll`
+// instead of rethrowing. Each command action that can reach
+// `loadConfig()`/`scan()`/`buildGraph()` (directly, or via a helper like
 // `plan-coverage/index.ts#runPlanCoverage` or `trace.ts#loadTraceInputs`)
-// wraps JUST that call in this helper instead of wrapping its entire body —
-// `format` is a normal command-local variable at every call site, so this
-// runs at a layer that DOES know it, without a broader restructure. Every
-// OTHER thrown error (including `RenameValidationError`, `LockSchemaVersionError`,
-// plain usage errors, …) passes through `fn`'s rethrow unchanged — this
-// helper only narrows on `OxcLoadError`. See docs/commands.md's "Fatal
+// wraps that call (and, per the #336 fix, `loadConfig()` alongside it — see
+// check/scan/impact/reconcile.ts) in this helper instead of wrapping its
+// entire body — `format` is a normal command-local variable at every call
+// site, so this runs at a layer that DOES know it, without a broader
+// restructure. A `RenameValidationError` / `LockSchemaVersionError` /
+// command-specific validation error thrown from INSIDE a `withFatalErrors`-
+// wrapped call is caught here too (there is no more special-casing to
+// rethrow it unwrapped) — its `.message` is exactly what the pre-#336
+// dedicated catch for it would have printed, so this is not a behavior
+// change for any error type that already had its own catch layered around
+// `withOxcLoadErrorFatal`'s old call sites; it only closes the gap for
+// errors that previously had NO catch at all. See docs/commands.md's "Fatal
 // errors" section for the resulting stdout/stderr contract this implements.
-export async function withOxcLoadErrorFatal<T>(
+export async function withFatalErrors<T>(
   format: string | undefined,
   fn: () => T | Promise<T>,
 ): Promise<T> {
@@ -176,25 +208,38 @@ export async function withOxcLoadErrorFatal<T>(
       printOxcLoadError(format, e);
       process.exit(1);
     }
-    throw e;
+    const msg = e instanceof Error ? e.message : String(e);
+    printFatalCatchAll(format, msg);
+    process.exit(1);
   }
 }
 
-// issue #279 — shared with `withOxcLoadErrorFatal` above AND with the
-// handful of commands (`rename`, `plan-coverage`) that already had their own
-// catch-all before this issue and just needed an extra `instanceof
-// OxcLoadError` branch spliced in rather than a full call-site wrap.
-// `OxcLoadError.message` is already a complete, formatted diagnostic (see
-// parsers/typescript.ts) — printed bare in text mode (no "Error:" prefix,
-// matching `cli.ts`'s own pre-existing handling of this exact error) and
-// wrapped in the same `{"error": ...}` envelope every OTHER fatal error here
-// uses in json mode.
-export function printOxcLoadError(format: string | undefined, e: OxcLoadError): void {
+// issue #279 — shared bare-message printer: json wraps in `{"error": ...}`,
+// text prints the message with no added prefix. Used for errors whose
+// `.message` is ALREADY a complete, self-formatted diagnostic (starts with
+// its own `ERROR:`/similar lead-in, or is meant to stand alone) — as opposed
+// to `printFatalCatchAll` below, which prefixes a bare exception message
+// with `Error: ` in text mode. `OxcLoadError` (parsers/typescript.ts) and
+// `AgentsParseError` (agents/parse-agents.ts, via `parseAgentsFlag` above)
+// are both this shape.
+export function printBareFatalMessage(format: string | undefined, msg: string): void {
   if (format === "json") {
-    console.error(JSON.stringify({ error: e.message }));
+    console.error(JSON.stringify({ error: msg }));
   } else {
-    console.error(e.message);
+    console.error(msg);
   }
+}
+
+// issue #279 — shared with `withFatalErrors` above AND with the handful of
+// commands (`rename`, `plan-coverage`) that already had their own catch-all
+// before issue #279 and just needed an extra `instanceof OxcLoadError`
+// branch spliced in rather than a full call-site wrap. `OxcLoadError.message`
+// is already a complete, formatted diagnostic (see parsers/typescript.ts),
+// so this delegates to `printBareFatalMessage` — bare in text mode (no
+// "Error:" prefix, matching `cli.ts`'s own pre-existing handling of this
+// exact error), envelope in json mode.
+export function printOxcLoadError(format: string | undefined, e: OxcLoadError): void {
+  printBareFatalMessage(format, e.message);
 }
 
 // issue #279 — the generic `{"error": ...}` stderr envelope every fatal

--- a/src/commands/trace.ts
+++ b/src/commands/trace.ts
@@ -9,7 +9,7 @@ import { Command } from "commander";
 import type { ArtifactGraph } from "../types.js";
 import type { TraceDiagnostics } from "../trace/schema.js";
 import type { BuildWarning } from "../graph/builder.js";
-import { reportGraphWarnings, TRACE_NO_SHARDS_GUIDANCE } from "./shared.js";
+import { reportGraphWarnings, TRACE_NO_SHARDS_GUIDANCE, withOxcLoadErrorFatal } from "./shared.js";
 import { printTraceReportText, printTraceStatusText } from "./presenters/trace.js";
 
 export interface TraceStatusResult {
@@ -89,7 +89,14 @@ export function registerTraceCommand(program: Command): void {
     .option("--format <format>", "Output format: json | text", "text")
     .action(async (opts) => {
       const rootDir = process.cwd();
-      const { graph, trace: ingested, warnings } = await loadTraceInputs(rootDir);
+      // issue #279 — format-aware `OxcLoadError` handling (issue #263):
+      // `loadTraceInputs` had no catch of its own before, so the error
+      // used to propagate uncaught to cli.ts's format-blind top-level catch.
+      const {
+        graph,
+        trace: ingested,
+        warnings,
+      } = await withOxcLoadErrorFatal(opts.format, () => loadTraceInputs(rootDir));
       const { computeStaleNodeIds } = await import("../trace/report.js");
 
       const staleNodeIds = computeStaleNodeIds(graph, ingested);
@@ -119,7 +126,13 @@ export function registerTraceCommand(program: Command): void {
     .option("--format <format>", "Output format: json | text", "text")
     .action(async (opts) => {
       const rootDir = process.cwd();
-      const { config, graph, trace: ingested, warnings } = await loadTraceInputs(rootDir);
+      // issue #279 — see the identical comment on `trace status` above.
+      const {
+        config,
+        graph,
+        trace: ingested,
+        warnings,
+      } = await withOxcLoadErrorFatal(opts.format, () => loadTraceInputs(rootDir));
 
       // contracts/cli-surface.md §2 — zero shards is a hard error, not an
       // empty report: the report's entire premise (evidence exists to

--- a/src/commands/trace.ts
+++ b/src/commands/trace.ts
@@ -9,7 +9,7 @@ import { Command } from "commander";
 import type { ArtifactGraph } from "../types.js";
 import type { TraceDiagnostics } from "../trace/schema.js";
 import type { BuildWarning } from "../graph/builder.js";
-import { reportGraphWarnings, TRACE_NO_SHARDS_GUIDANCE, withOxcLoadErrorFatal } from "./shared.js";
+import { reportGraphWarnings, TRACE_NO_SHARDS_GUIDANCE, withFatalErrors } from "./shared.js";
 import { printTraceReportText, printTraceStatusText } from "./presenters/trace.js";
 
 export interface TraceStatusResult {
@@ -89,14 +89,20 @@ export function registerTraceCommand(program: Command): void {
     .option("--format <format>", "Output format: json | text", "text")
     .action(async (opts) => {
       const rootDir = process.cwd();
-      // issue #279 — format-aware `OxcLoadError` handling (issue #263):
-      // `loadTraceInputs` had no catch of its own before, so the error
-      // used to propagate uncaught to cli.ts's format-blind top-level catch.
+      // issue #279 / issue #336 (meta-review F1) — `loadTraceInputs` (which
+      // calls `loadConfig()` then `scan()`, both inside this one wrapped
+      // call) had no catch of its own before issue #279, so any error used
+      // to propagate uncaught to cli.ts's format-blind top-level catch.
+      // `withOxcLoadErrorFatal` (issue #279) only narrowed on `OxcLoadError`
+      // and rethrew everything else, so a malformed `.artgraph.json`
+      // (`loadConfig()`'s plain `Error`) still escaped uncaught even though
+      // it was structurally inside the wrap — `withFatalErrors` (issue #336)
+      // closes that gap by also catching every other `Error`.
       const {
         graph,
         trace: ingested,
         warnings,
-      } = await withOxcLoadErrorFatal(opts.format, () => loadTraceInputs(rootDir));
+      } = await withFatalErrors(opts.format, () => loadTraceInputs(rootDir));
       const { computeStaleNodeIds } = await import("../trace/report.js");
 
       const staleNodeIds = computeStaleNodeIds(graph, ingested);
@@ -126,13 +132,14 @@ export function registerTraceCommand(program: Command): void {
     .option("--format <format>", "Output format: json | text", "text")
     .action(async (opts) => {
       const rootDir = process.cwd();
-      // issue #279 — see the identical comment on `trace status` above.
+      // issue #279 / issue #336 — see the identical comment on `trace status`
+      // above.
       const {
         config,
         graph,
         trace: ingested,
         warnings,
-      } = await withOxcLoadErrorFatal(opts.format, () => loadTraceInputs(rootDir));
+      } = await withFatalErrors(opts.format, () => loadTraceInputs(rootDir));
 
       // contracts/cli-surface.md §2 — zero shards is a hard error, not an
       // empty report: the report's entire premise (evidence exists to

--- a/src/rename-executor.ts
+++ b/src/rename-executor.ts
@@ -89,13 +89,20 @@ export interface RenameResult {
   // issue #273-2 ((a)-lite) — `reconcileAfterWrite`'s post-write `scan()`
   // (which runs purely to refresh the lock) can surface a BuildWarning the
   // pre-write scan never had — e.g. a `--merge` scaffold landing in two
-  // spec files mints a fresh `duplicate-id`. Deliberately ADDITIVE: `.trace`
-  // lock — `buildWarnings` above is untouched, so existing `--format json`
-  // consumers that assert the full result shape are unaffected. Contains
-  // only warnings NOT already present pre-write (set-diffed by
-  // type+id+files+message against `buildWarnings`) — a warning that existed
-  // before the rename and that rename did nothing to cause or fix is not
-  // re-reported here. `undefined` (the key is present but unset, and
+  // spec files mints a fresh `duplicate-id`. Deliberately ADDITIVE: a new
+  // OPTIONAL field, `buildWarnings` above is untouched. This is
+  // non-breaking for a consumer that reads only KNOWN fields (the common
+  // case, and the only one `docs/commands.md` documents) — it is NOT a
+  // guarantee for every possible consumer: one that validates the JSON
+  // payload against a closed/exact schema, or asserts a byte-exact
+  // snapshot of the full result object, WILL observe a diff the first time
+  // a rename actually produces a new post-write warning (this field simply
+  // did not exist before issue #273-2 at all). Contains only warnings NOT
+  // already present pre-write (set-diffed via `warningKey`, issue #336
+  // F3/F4 — type+id+sorted-files+message, except `system-resource-exhausted`
+  // which keys on type alone — against `buildWarnings`) — a warning that
+  // existed before the rename and that rename did nothing to cause or fix
+  // is not re-reported here. `undefined` (the key is present but unset, and
   // `JSON.stringify` drops it) when no post-write scan ran at all — either
   // `--dry-run` (which never writes or reconciles) or no `.trace.lock` file
   // existed to reconcile against. Deliberately distinct from an empty array
@@ -164,9 +171,46 @@ function runValidation(graphWarnings: BuildWarning[], fn: () => void): void {
  * default presenter (`printWarnings`) actually renders, so two warnings that
  * key identically are indistinguishable to a reader regardless of which
  * scan produced them.
+ *
+ * issue #336 (meta-review F3/F4) — two refinements on top of the original
+ * key:
+ *
+ *   F4 — `w.files` is sorted before stringifying. `BuildWarning.files`'
+ *   ORDER is a byproduct of directory-traversal / glob-enumeration order,
+ *   which is not guaranteed stable across two independent `scan()` calls
+ *   (pre-write vs. post-write) even when the underlying file SET is
+ *   identical. An unsorted key would treat that pure ordering wobble as a
+ *   different warning, spuriously promoting an unchanged
+ *   `duplicate-id`/etc. warning into `postWriteWarnings`.
+ *
+ *   F3 — `system-resource-exhausted` is keyed on `type` ALONE (id/files/
+ *   message ignored). This warning is scan-wide, not about a specific file:
+ *   `graph/builder.ts`'s EMFILE/ENFILE guards report whichever file/glob/
+ *   tsconfig read happened to be the FIRST one hit by the exhaustion in
+ *   THIS particular scan ("Shown once per scan regardless of how many files
+ *   were affected" — see the warning's own `message` text at its push
+ *   sites), so the `id`/`files` it carries are a property of scan ORDER, not
+ *   of the underlying condition. Keying on the full tuple like every other
+ *   warning type would treat "the OS is still out of file descriptors" (the
+ *   same recurring condition on both the pre-write and post-write scan) as a
+ *   brand-new warning on almost every affected rename, purely because the
+ *   first-offender id/files happened to differ between the two scans —
+ *   drowning the genuinely-new-warnings signal `postWriteWarnings` exists to
+ *   surface. This does NOT special-case away system-resource-exhaustion
+ *   from `postWriteWarnings` entirely (meta-review recommendation (ii), not
+ *   the alternative "exclude the type outright"): a scan pair where the
+ *   PRE-write scan has no `system-resource-exhausted` key at all and the
+ *   POST-write scan hits one still diffs as new (`diffPostWriteWarnings`'s
+ *   `seen` set, built from `preWrite`, has nothing to match against) — only
+ *   "recurs across both scans" is suppressed, never "newly appeared".
+ *
+ * Exported purely for direct unit testing of the F3/F4 keying rules.
  */
-function warningKey(w: BuildWarning): string {
-  return JSON.stringify([w.type, w.id, w.files, w.message ?? null]);
+export function warningKey(w: BuildWarning): string {
+  if (w.type === "system-resource-exhausted") {
+    return JSON.stringify([w.type]);
+  }
+  return JSON.stringify([w.type, w.id, [...w.files].sort(), w.message ?? null]);
 }
 
 /**
@@ -175,11 +219,17 @@ function warningKey(w: BuildWarning): string {
  * lock file to reconcile), an array (possibly empty) otherwise. Returns
  * `undefined` unchanged in the former case (see `RenameResult.postWriteWarnings`'s
  * doc for why that's kept distinct from `[]`); otherwise returns only the
- * `postWrite` warnings whose structural key was NOT already present in
- * `preWrite` — a warning the pre-write scan already had, that this rename
- * did nothing to introduce, is not re-reported as "new".
+ * `postWrite` warnings whose structural key (`warningKey` above — type+id+
+ * sorted-files+message, except `system-resource-exhausted` which keys on
+ * `type` alone, issue #336 F3/F4) was NOT already present in `preWrite` — a
+ * warning the pre-write scan already had, that this rename did nothing to
+ * introduce, is not re-reported as "new".
+ *
+ * Exported (alongside `warningKey`) purely for direct unit testing of the
+ * F3/F4 keying rules — every real caller reaches this only through
+ * `execute*` above.
  */
-function diffPostWriteWarnings(
+export function diffPostWriteWarnings(
   postWrite: BuildWarning[] | undefined,
   preWrite: BuildWarning[],
 ): BuildWarning[] | undefined {

--- a/src/rename-executor.ts
+++ b/src/rename-executor.ts
@@ -84,18 +84,109 @@ export interface RenameResult {
   // issue #265 — `buildGraph()`'s own warnings (pathological-bracket-nesting,
   // class-member-collision, …) from the pre-rewrite scan that resolved
   // `existingIds` below. Kept as a separate field from `warnings` above (a
-  // different, rename-specific warning type). `reconcileAfterWrite` runs a
-  // SECOND scan after files are written purely to refresh the lock, and that
-  // second scan's warnings are currently discarded outright — not deduped
-  // against these, just dropped. See issue #273 for surfacing (or properly
-  // deduping) that post-write scan's warnings.
+  // different, rename-specific warning type).
   buildWarnings: BuildWarning[];
+  // issue #273-2 ((a)-lite) — `reconcileAfterWrite`'s post-write `scan()`
+  // (which runs purely to refresh the lock) can surface a BuildWarning the
+  // pre-write scan never had — e.g. a `--merge` scaffold landing in two
+  // spec files mints a fresh `duplicate-id`. Deliberately ADDITIVE: `.trace`
+  // lock — `buildWarnings` above is untouched, so existing `--format json`
+  // consumers that assert the full result shape are unaffected. Contains
+  // only warnings NOT already present pre-write (set-diffed by
+  // type+id+files+message against `buildWarnings`) — a warning that existed
+  // before the rename and that rename did nothing to cause or fix is not
+  // re-reported here. `undefined` (the key is present but unset, and
+  // `JSON.stringify` drops it) when no post-write scan ran at all — either
+  // `--dry-run` (which never writes or reconciles) or no `.trace.lock` file
+  // existed to reconcile against. Deliberately distinct from an empty array
+  // (`[]`, meaning the post-write scan ran and found nothing new): callers
+  // must not conflate "no post-write scan happened" with "post-write scan
+  // found nothing new" — the latter is a real, positive absence-of-warnings
+  // signal; the former is simply "no data".
+  postWriteWarnings?: BuildWarning[];
   applied: boolean;
 }
 
 // Scaffold placeholder appended for newly created requirements. Kept in English
 // to match the rest of the CLI output (M6).
 const SCAFFOLD_PLACEHOLDER = "(TODO: describe this requirement)";
+
+/**
+ * issue #273-1 — every throw AFTER `loadScanContext()` (below) has already
+ * captured this rename's pre-write `buildGraph()` warnings (`graphWarnings`
+ * — `duplicate-id`, `pathological-bracket-nesting`, …), but a bare `Error`
+ * has nowhere to carry them: `commands/rename.ts`'s catch used to keep only
+ * `e.message`, so those warnings were silently dropped on EVERY validation
+ * failure (`--from`/`--to` identical, invalid target ID, the zero-hit safety
+ * valve, a rejected `--force`-less lock-schema-version bump, …) — the exact
+ * "complete swallow" the Step 0-pre investigation confirmed. Every
+ * validation/safety-valve throw in `executeRename`/`executeSplit`/
+ * `executeMerge` below is routed through `runValidation` (also below)
+ * instead of a bare `throw new Error(...)`, so it surfaces as this type
+ * with `buildWarnings` attached. A throw that fires BEFORE
+ * `loadScanContext()` runs (there is none today) is deliberately exempt —
+ * it has no `graphWarnings` yet and stays a plain `Error`, matching the
+ * pre-#273 behavior for that (currently hypothetical) case.
+ */
+export class RenameValidationError extends Error {
+  readonly buildWarnings: BuildWarning[];
+
+  constructor(message: string, buildWarnings: BuildWarning[]) {
+    super(message);
+    this.name = "RenameValidationError";
+    this.buildWarnings = buildWarnings;
+  }
+}
+
+/**
+ * Run `fn`, converting anything it throws — a direct `throw new Error(...)`
+ * inline, or one bubbling up from a helper like `assertRenameableSource` /
+ * `assertValidTargetId` / `assertRenameLockWritable` — into a
+ * `RenameValidationError` carrying `graphWarnings`. A `RenameValidationError`
+ * thrown by a nested `runValidation` call (none today) passes through
+ * unwrapped rather than being double-wrapped.
+ */
+function runValidation(graphWarnings: BuildWarning[], fn: () => void): void {
+  try {
+    fn();
+  } catch (e) {
+    if (e instanceof RenameValidationError) throw e;
+    throw new RenameValidationError(e instanceof Error ? e.message : String(e), graphWarnings);
+  }
+}
+
+/**
+ * issue #273-2 ((a)-lite) — structural identity key for a `BuildWarning`,
+ * used to set-diff the post-write scan's warnings against the pre-write
+ * scan's. Two scans build unrelated `BuildWarning` object instances even for
+ * what is semantically "the same" warning, so object/reference identity
+ * can't be used — `type`+`id`+`files`+`message` together are what the
+ * default presenter (`printWarnings`) actually renders, so two warnings that
+ * key identically are indistinguishable to a reader regardless of which
+ * scan produced them.
+ */
+function warningKey(w: BuildWarning): string {
+  return JSON.stringify([w.type, w.id, w.files, w.message ?? null]);
+}
+
+/**
+ * issue #273-2 ((a)-lite) — `postWrite` is `reconcileAfterWrite`'s scan
+ * result: `undefined` when no post-write scan ran at all (dry-run, or no
+ * lock file to reconcile), an array (possibly empty) otherwise. Returns
+ * `undefined` unchanged in the former case (see `RenameResult.postWriteWarnings`'s
+ * doc for why that's kept distinct from `[]`); otherwise returns only the
+ * `postWrite` warnings whose structural key was NOT already present in
+ * `preWrite` — a warning the pre-write scan already had, that this rename
+ * did nothing to introduce, is not re-reported as "new".
+ */
+function diffPostWriteWarnings(
+  postWrite: BuildWarning[] | undefined,
+  preWrite: BuildWarning[],
+): BuildWarning[] | undefined {
+  if (postWrite === undefined) return undefined;
+  const seen = new Set(preWrite.map(warningKey));
+  return postWrite.filter((w) => !seen.has(warningKey(w)));
+}
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -176,16 +267,25 @@ function assertRenameableSource(id: string): void {
  * After files are written, rebuild the lock from a fresh scan so contentHashes,
  * cross-references and specFile entries reflect the new on-disk state. Without
  * this, `artgraph check` immediately reports drift for every rewritten node
- * (F1). Only runs when a lock file already existed.
+ * (F1). Only runs when a lock file already existed — returns `undefined` in
+ * that case (see `RenameResult.postWriteWarnings`'s doc: distinct from `[]`,
+ * "no post-write scan ran" vs. "ran and found nothing new").
+ *
+ * issue #273-2 ((a)-lite) — this second scan's `warnings` used to be
+ * discarded outright (`const { graph } = scan(...)`). Now returned as-is
+ * (undiffed); the caller (`applyWrites` → each `execute*`) diffs them
+ * against the pre-write `graphWarnings` via `diffPostWriteWarnings`.
  */
-function reconcileAfterWrite(rootDir: string, config: ArtgraphConfig, force: boolean): void {
+function reconcileAfterWrite(
+  rootDir: string,
+  config: ArtgraphConfig,
+  force: boolean,
+): BuildWarning[] | undefined {
   const lockFilePath = resolve(rootDir, config.lockFile);
-  if (!existsSync(lockFilePath)) return;
-  // This second scan's `warnings` are discarded outright (see the
-  // `buildWarnings` doc on `RenameResult` above — issue #273 tracks properly
-  // surfacing them instead of dropping them on the floor).
-  const { graph } = scan(rootDir, config);
+  if (!existsSync(lockFilePath)) return undefined;
+  const { graph, warnings } = scan(rootDir, config);
   reconcile(rootDir, config, graph, { force });
+  return warnings;
 }
 
 /**
@@ -228,18 +328,24 @@ function loadScanContext(rootDir: string): ScanContext {
   };
 }
 
+// issue #273-2 ((a)-lite) — returns `reconcileAfterWrite`'s raw (undiffed)
+// post-write scan warnings, or `undefined` on `--dry-run` (which never
+// writes or reconciles at all — same "no post-write scan ran" case as no
+// lock file existing). Each `execute*` below diffs this against its own
+// `graphWarnings` via `diffPostWriteWarnings` before putting it on the
+// result.
 function applyWrites(
   rootDir: string,
   config: ArtgraphConfig,
   filesToWrite: Map<string, string>,
   dryRun: boolean,
   force: boolean,
-): void {
-  if (dryRun) return;
+): BuildWarning[] | undefined {
+  if (dryRun) return undefined;
   for (const [absPath, content] of filesToWrite) {
     writeFileSync(absPath, content, "utf-8");
   }
-  reconcileAfterWrite(rootDir, config, force);
+  return reconcileAfterWrite(rootDir, config, force);
 }
 
 // ── executeRename ───────────────────────────────────────────────────
@@ -247,25 +353,29 @@ function applyWrites(
 export function executeRename(options: RenameOptions & { from: string; to: string }): RenameResult {
   const { rootDir, dryRun, from, to, force = false } = options;
   const { config, existingIds, rewriteOpts, graphWarnings } = loadScanContext(rootDir);
-  if (!dryRun) assertRenameLockWritable(rootDir, config, force);
+  if (!dryRun) {
+    runValidation(graphWarnings, () => assertRenameLockWritable(rootDir, config, force));
+  }
 
   // Validate
-  if (from === to) {
-    throw new Error(`Source and target IDs are identical ("${from}"); nothing to rename.`);
-  }
-  assertRenameableSource(from);
-  assertValidTargetId(
-    to,
-    config.reqPatterns,
-    config.taskConventions,
-    config.disableBuiltinTaskConventions,
-  );
-  if (!existingIds.has(from)) {
-    throw new Error(`ID "${from}" does not exist in the project.`);
-  }
-  if (existingIds.has(to)) {
-    throw new Error(`ID "${to}" already exists in the project.`);
-  }
+  runValidation(graphWarnings, () => {
+    if (from === to) {
+      throw new Error(`Source and target IDs are identical ("${from}"); nothing to rename.`);
+    }
+    assertRenameableSource(from);
+    assertValidTargetId(
+      to,
+      config.reqPatterns,
+      config.taskConventions,
+      config.disableBuiltinTaskConventions,
+    );
+    if (!existingIds.has(from)) {
+      throw new Error(`ID "${from}" does not exist in the project.`);
+    }
+    if (existingIds.has(to)) {
+      throw new Error(`ID "${to}" already exists in the project.`);
+    }
+  });
 
   // Rewrite each file
   const allChanges: RewriteChange[] = [];
@@ -291,11 +401,13 @@ export function executeRename(options: RenameOptions & { from: string; to: strin
   // file must carry a rewritable reference. Zero hits means the enumeration
   // and the scan disagree — report the failure loudly instead of "success".
   if (allChanges.length === 0) {
-    throw new Error(
-      `ID "${from}" was not found in any of the ${scannedFiles.length} files matched by ` +
-        `.artgraph.json include/specDirs/testPatterns — nothing was rewritten. ` +
-        `Check that the files referencing "${from}" are covered by those patterns.`,
-    );
+    runValidation(graphWarnings, () => {
+      throw new Error(
+        `ID "${from}" was not found in any of the ${scannedFiles.length} files matched by ` +
+          `.artgraph.json include/specDirs/testPatterns — nothing was rewritten. ` +
+          `Check that the files referencing "${from}" are covered by those patterns.`,
+      );
+    });
   }
 
   // Project lock changes (also the source of truth for dry-run reporting).
@@ -321,7 +433,7 @@ export function executeRename(options: RenameOptions & { from: string; to: strin
     ),
   ];
 
-  applyWrites(rootDir, config, filesToWrite, dryRun, force);
+  const postWriteScanWarnings = applyWrites(rootDir, config, filesToWrite, dryRun, force);
 
   return {
     operation: "rename",
@@ -334,6 +446,7 @@ export function executeRename(options: RenameOptions & { from: string; to: strin
     lockChanges,
     warnings,
     buildWarnings: graphWarnings,
+    postWriteWarnings: diffPostWriteWarnings(postWriteScanWarnings, graphWarnings),
     applied: !dryRun,
   };
 }
@@ -345,32 +458,36 @@ export function executeSplit(
 ): RenameResult {
   const { rootDir, dryRun, splitId, intoIds, force = false } = options;
   const { config, existingIds, rewriteOpts, graphWarnings } = loadScanContext(rootDir);
-  if (!dryRun) assertRenameLockWritable(rootDir, config, force);
+  if (!dryRun) {
+    runValidation(graphWarnings, () => assertRenameLockWritable(rootDir, config, force));
+  }
 
   // Validate
-  assertRenameableSource(splitId);
-  if (!existingIds.has(splitId)) {
-    throw new Error(`ID "${splitId}" does not exist in the project.`);
-  }
-  if (intoIds.length === 0) {
-    throw new Error(`--split requires at least one target ID via --into.`);
-  }
-  const seen = new Set<string>();
-  for (const newId of intoIds) {
-    assertValidTargetId(
-      newId,
-      config.reqPatterns,
-      config.taskConventions,
-      config.disableBuiltinTaskConventions,
-    );
-    if (seen.has(newId)) {
-      throw new Error(`Duplicate target ID "${newId}" in --into.`);
+  runValidation(graphWarnings, () => {
+    assertRenameableSource(splitId);
+    if (!existingIds.has(splitId)) {
+      throw new Error(`ID "${splitId}" does not exist in the project.`);
     }
-    seen.add(newId);
-    if (newId !== splitId && existingIds.has(newId)) {
-      throw new Error(`ID "${newId}" already exists in the project.`);
+    if (intoIds.length === 0) {
+      throw new Error(`--split requires at least one target ID via --into.`);
     }
-  }
+    const seen = new Set<string>();
+    for (const newId of intoIds) {
+      assertValidTargetId(
+        newId,
+        config.reqPatterns,
+        config.taskConventions,
+        config.disableBuiltinTaskConventions,
+      );
+      if (seen.has(newId)) {
+        throw new Error(`Duplicate target ID "${newId}" in --into.`);
+      }
+      seen.add(newId);
+      if (newId !== splitId && existingIds.has(newId)) {
+        throw new Error(`ID "${newId}" already exists in the project.`);
+      }
+    }
+  });
 
   const allChanges: RewriteChange[] = [];
   const warnings: RenameWarning[] = [];
@@ -427,18 +544,20 @@ export function executeSplit(
   // neither a spec definition (change) nor a code `@impl` (warning) — the
   // split would only touch the lock and report success. Fail loudly instead.
   if (allChanges.length === 0 && warnings.length === 0) {
-    throw new Error(
-      `ID "${splitId}" was not found in any of the ${scannedFiles.length} files matched by ` +
-        `.artgraph.json include/specDirs/testPatterns — nothing was rewritten. ` +
-        `Check that the files referencing "${splitId}" are covered by those patterns.`,
-    );
+    runValidation(graphWarnings, () => {
+      throw new Error(
+        `ID "${splitId}" was not found in any of the ${scannedFiles.length} files matched by ` +
+          `.artgraph.json include/specDirs/testPatterns — nothing was rewritten. ` +
+          `Check that the files referencing "${splitId}" are covered by those patterns.`,
+      );
+    });
   }
 
   const lockChanges = projectLockChanges(rootDir, config, dryRun, (lock) =>
     splitLockKey(lock, splitId, intoIds),
   );
 
-  applyWrites(rootDir, config, filesToWrite, dryRun, force);
+  const postWriteScanWarnings = applyWrites(rootDir, config, filesToWrite, dryRun, force);
 
   return {
     operation: "split",
@@ -452,6 +571,7 @@ export function executeSplit(
     lockChanges,
     warnings,
     buildWarnings: graphWarnings,
+    postWriteWarnings: diffPostWriteWarnings(postWriteScanWarnings, graphWarnings),
     applied: !dryRun,
   };
 }
@@ -463,30 +583,34 @@ export function executeMerge(
 ): RenameResult {
   const { rootDir, dryRun, mergeIds, intoId, force = false } = options;
   const { config, existingIds, rewriteOpts, graphWarnings } = loadScanContext(rootDir);
-  if (!dryRun) assertRenameLockWritable(rootDir, config, force);
+  if (!dryRun) {
+    runValidation(graphWarnings, () => assertRenameLockWritable(rootDir, config, force));
+  }
 
   // Validate
-  if (mergeIds.length < 1) {
-    throw new Error(`--merge requires at least one source ID.`);
-  }
-  assertValidTargetId(
-    intoId,
-    config.reqPatterns,
-    config.taskConventions,
-    config.disableBuiltinTaskConventions,
-  );
-  for (const id of mergeIds) {
-    assertRenameableSource(id);
-    if (!existingIds.has(id)) {
-      throw new Error(`ID "${id}" does not exist in the project.`);
+  runValidation(graphWarnings, () => {
+    if (mergeIds.length < 1) {
+      throw new Error(`--merge requires at least one source ID.`);
     }
-  }
-  // intoId must NOT exist UNLESS it equals one of mergeIds.
-  if (existingIds.has(intoId) && !mergeIds.includes(intoId)) {
-    throw new Error(
-      `ID "${intoId}" already exists in the project and is not one of the merge source IDs.`,
+    assertValidTargetId(
+      intoId,
+      config.reqPatterns,
+      config.taskConventions,
+      config.disableBuiltinTaskConventions,
     );
-  }
+    for (const id of mergeIds) {
+      assertRenameableSource(id);
+      if (!existingIds.has(id)) {
+        throw new Error(`ID "${id}" does not exist in the project.`);
+      }
+    }
+    // intoId must NOT exist UNLESS it equals one of mergeIds.
+    if (existingIds.has(intoId) && !mergeIds.includes(intoId)) {
+      throw new Error(
+        `ID "${intoId}" already exists in the project and is not one of the merge source IDs.`,
+      );
+    }
+  });
 
   // IDs whose references/definitions collapse into intoId.
   const idsToRewrite = mergeIds.filter((id) => id !== intoId);
@@ -544,11 +668,13 @@ export function executeMerge(
   // success. Fail loudly instead. (A degenerate `--merge X --into X` has
   // nothing to rewrite by definition and is left to the presenter.)
   if (idsToRewrite.length > 0 && allChanges.length === 0) {
-    throw new Error(
-      `None of the IDs ${idsToRewrite.map((id) => `"${id}"`).join(", ")} were found in any of ` +
-        `the ${scannedFiles.length} files matched by .artgraph.json include/specDirs/testPatterns — ` +
-        `nothing was rewritten. Check that the files referencing them are covered by those patterns.`,
-    );
+    runValidation(graphWarnings, () => {
+      throw new Error(
+        `None of the IDs ${idsToRewrite.map((id) => `"${id}"`).join(", ")} were found in any of ` +
+          `the ${scannedFiles.length} files matched by .artgraph.json include/specDirs/testPatterns — ` +
+          `nothing was rewritten. Check that the files referencing them are covered by those patterns.`,
+      );
+    });
   }
 
   const lockChanges = projectLockChanges(rootDir, config, dryRun, (lock) =>
@@ -577,7 +703,7 @@ export function executeMerge(
     ),
   ];
 
-  applyWrites(rootDir, config, filesToWrite, dryRun, force);
+  const postWriteScanWarnings = applyWrites(rootDir, config, filesToWrite, dryRun, force);
 
   return {
     operation: "merge",
@@ -591,6 +717,7 @@ export function executeMerge(
     lockChanges,
     warnings,
     buildWarnings: graphWarnings,
+    postWriteWarnings: diffPostWriteWarnings(postWriteScanWarnings, graphWarnings),
     applied: !dryRun,
   };
 }

--- a/tests/fatal-error-contract.test.ts
+++ b/tests/fatal-error-contract.test.ts
@@ -1,4 +1,5 @@
-// issue #279 — format-aware handling of fatal errors, in two parts:
+// issue #279 / issue #336 — format-aware handling of fatal errors, in three
+// parts:
 //
 //   1. An `OxcLoadError` (oxc-parser's native binding missing/broken, issue
 //      #263) used to be caught ONLY by `cli.ts`'s top-level
@@ -6,20 +7,34 @@
 //      the just-parsed command requested, so it always printed plain text to
 //      stderr regardless of `--format json`. Every command whose action can
 //      reach `scan()`/`buildGraph()` now routes through
-//      `commands/shared.ts#withOxcLoadErrorFatal` (scan/check/impact/
-//      reconcile/trace) or an inline `instanceof OxcLoadError` branch in its
-//      own pre-existing catch (rename/plan-coverage), so `--format json`
+//      `commands/shared.ts#withFatalErrors` (scan/check/impact/reconcile/
+//      trace/init) or an inline `instanceof OxcLoadError` branch in its own
+//      pre-existing catch (rename/plan-coverage/doctor), so `--format json`
 //      gets a parseable `{"error": ...}` envelope instead.
 //   2. `plan-coverage`'s generic catch-all was plain-text-only regardless of
 //      `--format`; it now branches on format the same way `rename`'s
 //      original `fail()` does.
+//   3. issue #336 (PR #336 meta-review F1) — `loadConfig()` (a malformed
+//      `.artgraph.json`'s `Failed to parse ...`) was called OUTSIDE any
+//      guarded region (or, for `trace`, inside a region whose catch only
+//      narrowed on `OxcLoadError` and rethrew everything else) in every one
+//      of `check`/`scan`/`impact`/`trace`/`reconcile`/`plan-coverage` — a
+//      full raw Node stack trace with internal `dist/`/`src/` file paths,
+//      completely ignoring `--format`. `init`'s and `doctor`'s catch-alls
+//      were ALSO format-blind, and `parseAgentsFlag` (shared by both,
+//      `--agents=<list>` parsing) called `process.exit(1)` directly with a
+//      bare `console.error`. `withFatalErrors` (the renamed/widened
+//      `withOxcLoadErrorFatal`) now catches every `Error`, not just
+//      `OxcLoadError`; `init`/`doctor`'s catch-alls and `parseAgentsFlag`
+//      are now format-aware too. See the "loadConfig() failure" describe
+//      block below.
 //
-// Both are pinned end-to-end here (real CLI invocations via the in-process
-// harness) PLUS at the `commands/shared.ts` helper level directly (mocked),
-// per the test plan's explicit allowance for OxcLoadError being hard to
-// trigger — here it IS reliably triggered via the same `Module._load`
-// monkey-patch technique `tests/oxc-load-failure.test.ts` established, so
-// both levels are covered.
+// All three are pinned end-to-end here (real CLI invocations via the
+// in-process harness) PLUS at the `commands/shared.ts` helper level directly
+// (mocked), per the test plan's explicit allowance for OxcLoadError being
+// hard to trigger — here it IS reliably triggered via the same
+// `Module._load` monkey-patch technique `tests/oxc-load-failure.test.ts`
+// established, so both levels are covered.
 
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { Module } from "node:module";
@@ -107,6 +122,12 @@ describe("fatal-error contract: OxcLoadError is format-aware across every scan()
     { name: "trace report", args: ["trace", "report"] },
     { name: "rename", args: ["rename", "--from", "REQ-001", "--to", "REQ-100"] },
     { name: "plan-coverage", args: ["plan-coverage", "--spec", "myspec"] },
+    // issue #336 — `init`'s default (no `--no-scan`) flow calls `scan()` near
+    // the end of `runInit` (after Skills distribution), so it can hit the
+    // same poisoned oxc-parser. `--force` is required (the fixture's
+    // `.artgraph.json` already exists) and `--agents=claude` is required
+    // whenever the Skills/agent-context stages run (the default).
+    { name: "init", args: ["init", "--force", "--agents=claude"] },
   ];
 
   for (const { name, args } of cases) {
@@ -158,9 +179,9 @@ describe("fatal-error contract: OxcLoadError is format-aware across every scan()
 // (not instead of) the end-to-end coverage above for a second, narrower
 // point of verification directly against `commands/shared.ts`'s contract.
 // ---------------------------------------------------------------------------
-describe("commands/shared.ts: withOxcLoadErrorFatal / printOxcLoadError / printFatalCatchAll (unit, mocked)", () => {
-  it('withOxcLoadErrorFatal: json format prints the {"error": ...} envelope to stderr and exits 1', async () => {
-    const { withOxcLoadErrorFatal } = await import("../src/commands/shared.js");
+describe("commands/shared.ts: withFatalErrors / printOxcLoadError / printFatalCatchAll (unit, mocked)", () => {
+  it('withFatalErrors: json format prints the {"error": ...} envelope to stderr and exits 1 for an OxcLoadError', async () => {
+    const { withFatalErrors } = await import("../src/commands/shared.js");
     const { OxcLoadError } = await import("../src/parsers/typescript.js");
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
@@ -169,7 +190,7 @@ describe("commands/shared.ts: withOxcLoadErrorFatal / printOxcLoadError / printF
 
     const err = new OxcLoadError(new Error("simulated"));
     await expect(
-      withOxcLoadErrorFatal("json", () => {
+      withFatalErrors("json", () => {
         throw err;
       }),
     ).rejects.toThrow("__exit_1__");
@@ -182,8 +203,8 @@ describe("commands/shared.ts: withOxcLoadErrorFatal / printOxcLoadError / printF
     exitSpy.mockRestore();
   });
 
-  it("withOxcLoadErrorFatal: text format prints the bare message (no envelope, no 'Error:' prefix) and exits 1", async () => {
-    const { withOxcLoadErrorFatal } = await import("../src/commands/shared.js");
+  it("withFatalErrors: text format prints the bare OxcLoadError message (no envelope, no 'Error:' prefix) and exits 1", async () => {
+    const { withFatalErrors } = await import("../src/commands/shared.js");
     const { OxcLoadError } = await import("../src/parsers/typescript.js");
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
@@ -192,7 +213,7 @@ describe("commands/shared.ts: withOxcLoadErrorFatal / printOxcLoadError / printF
 
     const err = new OxcLoadError(new Error("simulated"));
     await expect(
-      withOxcLoadErrorFatal(undefined, () => {
+      withFatalErrors(undefined, () => {
         throw err;
       }),
     ).rejects.toThrow("__exit_1__");
@@ -203,26 +224,56 @@ describe("commands/shared.ts: withOxcLoadErrorFatal / printOxcLoadError / printF
     exitSpy.mockRestore();
   });
 
-  it("withOxcLoadErrorFatal: rethrows every OTHER error unchanged (no swallowing, no exit)", async () => {
-    const { withOxcLoadErrorFatal } = await import("../src/commands/shared.js");
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit should not have been called");
-    });
+  // issue #336 (meta-review F1) — this is the behavior CHANGE from the old
+  // `withOxcLoadErrorFatal`: that helper rethrew every non-`OxcLoadError`
+  // unchanged (verified by this same test, pre-#336, asserting a rethrow).
+  // `withFatalErrors` now catches it too, via `printFatalCatchAll` — this is
+  // exactly what closes the "loadConfig() failure produces a raw stack
+  // trace" gap this issue fixes.
+  it('withFatalErrors: catches every OTHER Error too — json wraps it in the {"error": ...} envelope and exits 1 (no rethrow)', async () => {
+    const { withFatalErrors } = await import("../src/commands/shared.js");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}__`);
+    }) as never);
 
     await expect(
-      withOxcLoadErrorFatal("json", () => {
+      withFatalErrors("json", () => {
         throw new Error("some unrelated validation error");
       }),
-    ).rejects.toThrow("some unrelated validation error");
+    ).rejects.toThrow("__exit_1__");
 
-    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    const printed = JSON.parse(errSpy.mock.calls[0][0] as string);
+    expect(printed.error).toBe("some unrelated validation error");
+
+    errSpy.mockRestore();
     exitSpy.mockRestore();
   });
 
-  it("withOxcLoadErrorFatal: returns fn()'s value on success (no error at all)", async () => {
-    const { withOxcLoadErrorFatal } = await import("../src/commands/shared.js");
-    await expect(withOxcLoadErrorFatal("json", () => 42)).resolves.toBe(42);
-    await expect(withOxcLoadErrorFatal("json", async () => "async-ok")).resolves.toBe("async-ok");
+  it("withFatalErrors: catches every OTHER Error in text mode too — `Error: <msg>` line, exit 1 (no rethrow)", async () => {
+    const { withFatalErrors } = await import("../src/commands/shared.js");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}__`);
+    }) as never);
+
+    await expect(
+      withFatalErrors(undefined, () => {
+        throw new Error("some unrelated validation error");
+      }),
+    ).rejects.toThrow("__exit_1__");
+
+    expect(errSpy).toHaveBeenCalledWith("Error: some unrelated validation error");
+
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("withFatalErrors: returns fn()'s value on success (no error at all)", async () => {
+    const { withFatalErrors } = await import("../src/commands/shared.js");
+    await expect(withFatalErrors("json", () => 42)).resolves.toBe(42);
+    await expect(withFatalErrors("json", async () => "async-ok")).resolves.toBe("async-ok");
   });
 
   it('printFatalCatchAll: json wraps in {"error": ...}, text keeps the pre-existing `Error: <msg>` line', async () => {
@@ -239,5 +290,163 @@ describe("commands/shared.ts: withOxcLoadErrorFatal / printOxcLoadError / printF
     expect(errSpy.mock.calls[2][0]).toBe("Error: boom");
 
     errSpy.mockRestore();
+  });
+
+  it('printBareFatalMessage: json wraps in {"error": ...}, text prints the message bare (no prefix)', async () => {
+    const { printBareFatalMessage } = await import("../src/commands/shared.js");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    printBareFatalMessage("json", 'ERROR: Unknown agent identifier(s): "bogus".');
+    expect(JSON.parse(errSpy.mock.calls[0][0] as string)).toEqual({
+      error: 'ERROR: Unknown agent identifier(s): "bogus".',
+    });
+
+    printBareFatalMessage("text", 'ERROR: Unknown agent identifier(s): "bogus".');
+    expect(errSpy.mock.calls[1][0]).toBe('ERROR: Unknown agent identifier(s): "bogus".');
+
+    printBareFatalMessage(undefined, 'ERROR: Unknown agent identifier(s): "bogus".');
+    expect(errSpy.mock.calls[2][0]).toBe('ERROR: Unknown agent identifier(s): "bogus".');
+
+    errSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. issue #336 (PR #336 meta-review F1) — `loadConfig()` failure (a
+// malformed `.artgraph.json`) is format-aware across EVERY command that
+// reaches it, mirroring the OxcLoadError coverage above. This is a SEPARATE
+// fixture/describe block (not reusing the OxcLoadError one above) because it
+// does not depend on the `Module._load` poison — an ordinary CLI invocation
+// against a genuinely malformed config file reaches the same
+// `withFatalErrors`/catch-all code paths via a plain `Error`
+// (`config.ts#loadConfig`'s `Failed to parse ${configPath}: ...`) instead.
+// ---------------------------------------------------------------------------
+function makeMalformedConfigFixture(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  // Deliberately invalid JSON — `JSON.parse` throws, `loadConfig` wraps it
+  // in a plain `Error("Failed to parse ...")`.
+  write(dir, ".artgraph.json", "{ this is not valid json");
+  // `plan-coverage --spec myspec` needs a resolvable spec dir with a
+  // tasks.md to get past its own usage-error checks and reach the (now
+  // reordered, see plan-coverage.ts) `loadConfig()` call inside its guarded
+  // `try`. Content is irrelevant — `loadConfig()` throws before anything
+  // else in this file is ever read.
+  write(
+    dir,
+    "myspec/tasks.md",
+    ["# Tasks", "", "- [ ] T001 do something", "  Files: src/feature.ts", ""].join("\n"),
+  );
+  return dir;
+}
+
+describe("fatal-error contract: loadConfig() failure (malformed .artgraph.json) is format-aware across every command (issue #336 F1)", () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = makeMalformedConfigFixture("artgraph-fatal-config-");
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // A raw Node stack trace always contains an "at <fn> (<file>:<line>:<col>)"
+  // frame line; a clean fatal-error message never does. Used below instead
+  // of (or alongside) matching the expected message, so a regression that
+  // reintroduces the stack trace fails even if the clean message ALSO
+  // happens to appear somewhere in the (much longer) stack-trace output.
+  const STACK_FRAME_RE = /\bat .*\(.*:\d+:\d+\)/;
+
+  const cases: Array<{ name: string; args: string[] }> = [
+    { name: "check", args: ["check"] },
+    { name: "scan", args: ["scan"] },
+    { name: "impact", args: ["impact", "--diff"] },
+    { name: "trace status", args: ["trace", "status"] },
+    { name: "trace report", args: ["trace", "report"] },
+    { name: "plan-coverage", args: ["plan-coverage", "--spec", "myspec"] },
+    { name: "rename", args: ["rename", "--from", "REQ-001", "--to", "REQ-100"] },
+    // `.artgraph.json` already exists (malformed) — `--force` is required to
+    // get past init's "already exists" guard and actually reach `loadConfig()`.
+    { name: "init", args: ["init", "--force", "--agents=claude"] },
+    { name: "doctor", args: ["doctor"] },
+  ];
+
+  for (const { name, args } of cases) {
+    it(`${name} --format json: {"error": ...} envelope on stderr, no stack trace, empty stdout, exit 1`, async () => {
+      const { exitCode, stdout, stderr } = await runAt(root, [...args, "--format", "json"]);
+      expect(exitCode).toBe(1);
+      expect(stdout).toBe("");
+      expect(stderr).not.toMatch(STACK_FRAME_RE);
+      expect(() => JSON.parse(stderr)).not.toThrow();
+      const envelope = JSON.parse(stderr);
+      expect(envelope.error).toMatch(/failed to parse/i);
+    });
+
+    it(`${name} (text mode): clean single-line diagnostic on stderr, no stack trace, empty stdout, exit 1`, async () => {
+      const { exitCode, stdout, stderr } = await runAt(root, args);
+      expect(exitCode).toBe(1);
+      expect(stdout).toBe("");
+      expect(stderr).not.toMatch(STACK_FRAME_RE);
+      expect(stderr).toMatch(/failed to parse/i);
+      // Not a JSON envelope in text mode.
+      expect(() => JSON.parse(stderr)).toThrow();
+    });
+  }
+
+  // `reconcile` has no `--format` at all — always the text-mode contract.
+  it("reconcile: clean single-line diagnostic on stderr, no stack trace, empty stdout, exit 1", async () => {
+    const { exitCode, stdout, stderr } = await runAt(root, ["reconcile"]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe("");
+    expect(stderr).not.toMatch(STACK_FRAME_RE);
+    expect(stderr).toMatch(/failed to parse/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. issue #336 (meta-review F1) — `parseAgentsFlag` (shared by `init` and
+// `doctor`'s `--agents=<list>` parsing) is now format-aware: json wraps
+// `AgentsParseError.message` in the `{"error": ...}` envelope, text stays
+// byte-identical to the pre-#336 bare message.
+// ---------------------------------------------------------------------------
+describe("init / doctor: --agents=<bogus> is format-aware (issue #336 F1)", () => {
+  it("`doctor --agents=bogus --format json`: envelope on stderr, exit 1, text unchanged", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "artgraph-fatal-agents-"));
+    try {
+      write(
+        dir,
+        ".artgraph.json",
+        JSON.stringify({ include: ["src/**/*.ts"], specDirs: ["specs"] }),
+      );
+
+      const json = await runAt(dir, ["doctor", "--agents=bogus", "--format", "json"]);
+      expect(json.exitCode).toBe(1);
+      expect(json.stdout).toBe("");
+      const envelope = JSON.parse(json.stderr);
+      expect(envelope.error).toMatch(/Unknown agent identifier/i);
+
+      const text = await runAt(dir, ["doctor", "--agents=bogus"]);
+      expect(text.exitCode).toBe(1);
+      expect(text.stdout).toBe("");
+      // Byte-identical pre-#336 wording: bare message, no "Error:" prefix,
+      // not a JSON envelope.
+      expect(text.stderr.trim()).toMatch(/^ERROR: Unknown agent identifier/);
+      expect(() => JSON.parse(text.stderr)).toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("`init --agents=bogus --format json`: envelope on stderr, exit 1, text unchanged", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "artgraph-fatal-agents-init-"));
+    try {
+      const json = await runAt(dir, ["init", "--agents=bogus", "--format", "json"]);
+      expect(json.exitCode).toBe(1);
+      expect(json.stdout).toBe("");
+      const envelope = JSON.parse(json.stderr);
+      expect(envelope.error).toMatch(/Unknown agent identifier/i);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/fatal-error-contract.test.ts
+++ b/tests/fatal-error-contract.test.ts
@@ -1,0 +1,243 @@
+// issue #279 — format-aware handling of fatal errors, in two parts:
+//
+//   1. An `OxcLoadError` (oxc-parser's native binding missing/broken, issue
+//      #263) used to be caught ONLY by `cli.ts`'s top-level
+//      `program.parseAsync()` catch — a layer with no idea what `--format`
+//      the just-parsed command requested, so it always printed plain text to
+//      stderr regardless of `--format json`. Every command whose action can
+//      reach `scan()`/`buildGraph()` now routes through
+//      `commands/shared.ts#withOxcLoadErrorFatal` (scan/check/impact/
+//      reconcile/trace) or an inline `instanceof OxcLoadError` branch in its
+//      own pre-existing catch (rename/plan-coverage), so `--format json`
+//      gets a parseable `{"error": ...}` envelope instead.
+//   2. `plan-coverage`'s generic catch-all was plain-text-only regardless of
+//      `--format`; it now branches on format the same way `rename`'s
+//      original `fail()` does.
+//
+// Both are pinned end-to-end here (real CLI invocations via the in-process
+// harness) PLUS at the `commands/shared.ts` helper level directly (mocked),
+// per the test plan's explicit allowance for OxcLoadError being hard to
+// trigger — here it IS reliably triggered via the same `Module._load`
+// monkey-patch technique `tests/oxc-load-failure.test.ts` established, so
+// both levels are covered.
+
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { Module } from "node:module";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runAt } from "./helpers.js";
+
+function write(rootDir: string, relPath: string, content: string): void {
+  const abs = join(rootDir, relPath);
+  mkdirSync(join(abs, ".."), { recursive: true });
+  writeFileSync(abs, content, "utf-8");
+}
+
+// This repo's own dogfood self-scan (`check --diff` over THIS PR's diff)
+// matches `@impl`/`[...]` tag-shaped text ANYWHERE in a `tests/**/*.test.ts`
+// file's raw source, not just in genuinely-authored tags — see
+// tests/helpers.ts's `introduceNewOrphan`/`coverDebtReq` doc comments and
+// the `"REQ-" + "001"` split idiom used throughout tests/*.test.ts (e.g.
+// tests/trace-method-grain.test.ts). This fixture's temp-dir content is
+// UNRELATED to this repo's own graph, but it still needs the same split to
+// avoid a spurious new orphan from the file you're reading right now.
+function makeFixture(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  write(
+    dir,
+    ".artgraph.json",
+    JSON.stringify({
+      include: ["src/**/*.ts"],
+      specDirs: ["specs"],
+      testPatterns: ["tests/**/*.test.ts"],
+      lockFile: ".trace.lock",
+    }),
+  );
+  write(dir, "specs/feature.md", "# Feature\n\n- REQ-" + "001: something\n");
+  write(dir, "src/feature.ts", "// @impl " + "REQ-001\nexport const x = 1;\n");
+  write(dir, "tests/feature.test.ts", "// [" + "REQ-001]\nexport {};\n");
+  write(
+    dir,
+    "myspec/tasks.md",
+    ["# Tasks", "", "- [ ] T001 do something", "  Files: src/feature.ts", ""].join("\n"),
+  );
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// 1. End-to-end: a genuinely broken oxc-parser native binding (same
+// `Module._load` monkey-patch as tests/oxc-load-failure.test.ts), driven
+// through real command actions via the in-process CLI harness.
+//
+// IMPORTANT (mirrors oxc-load-failure.test.ts's own warning): `loadOxc`'s
+// failure is memoized module-wide once the first call fails (issue #263's
+// negative cache — no per-call retry), so this file is deliberately
+// single-purpose: every test below expects the poisoned/throwing state.
+// Vitest isolates module state per test FILE, so this cannot leak into
+// other suites.
+// ---------------------------------------------------------------------------
+describe("fatal-error contract: OxcLoadError is format-aware across every scan()-backed command (issue #279)", () => {
+  let root: string;
+  let originalLoad: (typeof Module)["_load"];
+
+  beforeAll(() => {
+    root = makeFixture("artgraph-fatal-oxc-");
+    originalLoad = Module._load;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Module as any)._load = function (request: string, ...rest: unknown[]) {
+      if (request === "oxc-parser") {
+        throw new Error("simulated missing native binding (ERR_DLOPEN_FAILED)");
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (originalLoad as any).apply(Module, [request, ...rest]);
+    };
+  });
+
+  afterAll(() => {
+    Module._load = originalLoad;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const cases: Array<{ name: string; args: string[] }> = [
+    { name: "scan", args: ["scan"] },
+    { name: "check", args: ["check"] },
+    { name: "impact", args: ["impact", "src/feature.ts"] },
+    { name: "trace status", args: ["trace", "status"] },
+    { name: "trace report", args: ["trace", "report"] },
+    { name: "rename", args: ["rename", "--from", "REQ-001", "--to", "REQ-100"] },
+    { name: "plan-coverage", args: ["plan-coverage", "--spec", "myspec"] },
+  ];
+
+  for (const { name, args } of cases) {
+    it(`${name} --format json: {"error": ...} envelope on stderr, empty stdout, exit 1`, async () => {
+      const { exitCode, stdout, stderr } = await runAt(root, [...args, "--format", "json"]);
+      expect(exitCode).toBe(1);
+      expect(stdout).toBe("");
+      expect(() => JSON.parse(stderr)).not.toThrow();
+      const envelope = JSON.parse(stderr);
+      expect(envelope.error).toMatch(/oxc-parser/i);
+      expect(envelope.error).toMatch(/native binding/i);
+    });
+
+    it(`${name} (text mode): plain diagnostic on stderr, empty stdout, exit 1`, async () => {
+      const { exitCode, stdout, stderr } = await runAt(root, args);
+      expect(exitCode).toBe(1);
+      expect(stdout).toBe("");
+      expect(stderr).toMatch(/oxc-parser/i);
+      expect(stderr).toMatch(/native binding/i);
+      // Not a JSON envelope in text mode.
+      expect(() => JSON.parse(stderr)).toThrow();
+    });
+  }
+
+  // `reconcile` has no `--format` at all — always the text-mode contract.
+  it("reconcile: plain diagnostic on stderr, empty stdout, exit 1", async () => {
+    const { exitCode, stdout, stderr } = await runAt(root, ["reconcile"]);
+    expect(exitCode).toBe(1);
+    expect(stdout).toBe("");
+    expect(stderr).toMatch(/oxc-parser/i);
+  });
+});
+
+// plan-coverage's OWN generic catch-all (a DIFFERENT throw than OxcLoadError
+// above — e.g. a corrupted `.trace.lock`) being format-aware (issue #279
+// item 1) is pinned in tests/plan-coverage-integration.test.ts instead of
+// here: that catch-all's error (`LockSchemaError` from a malformed
+// `.trace.lock`) is reached via `scan()`, which in THIS file's module
+// instance is permanently poisoned by the `Module._load` patch above
+// (loadOxc's negative cache — see the file-level doc comment), so it would
+// only ever observe the OxcLoadError branch spliced in AHEAD of the generic
+// catch-all, never the generic catch-all itself. Keeping that scenario in a
+// separate, oxc-unpoisoned test file is what actually exercises it.
+
+// ---------------------------------------------------------------------------
+// 2. Unit-level coverage of the shared helper itself (mocked `process.exit`
+// / `OxcLoadError`), independent of any command wiring — the test plan's
+// explicit fallback for "hard to trigger for real", included here alongside
+// (not instead of) the end-to-end coverage above for a second, narrower
+// point of verification directly against `commands/shared.ts`'s contract.
+// ---------------------------------------------------------------------------
+describe("commands/shared.ts: withOxcLoadErrorFatal / printOxcLoadError / printFatalCatchAll (unit, mocked)", () => {
+  it('withOxcLoadErrorFatal: json format prints the {"error": ...} envelope to stderr and exits 1', async () => {
+    const { withOxcLoadErrorFatal } = await import("../src/commands/shared.js");
+    const { OxcLoadError } = await import("../src/parsers/typescript.js");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}__`);
+    }) as never);
+
+    const err = new OxcLoadError(new Error("simulated"));
+    await expect(
+      withOxcLoadErrorFatal("json", () => {
+        throw err;
+      }),
+    ).rejects.toThrow("__exit_1__");
+
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    const printed = JSON.parse(errSpy.mock.calls[0][0] as string);
+    expect(printed.error).toBe(err.message);
+
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("withOxcLoadErrorFatal: text format prints the bare message (no envelope, no 'Error:' prefix) and exits 1", async () => {
+    const { withOxcLoadErrorFatal } = await import("../src/commands/shared.js");
+    const { OxcLoadError } = await import("../src/parsers/typescript.js");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit_${code}__`);
+    }) as never);
+
+    const err = new OxcLoadError(new Error("simulated"));
+    await expect(
+      withOxcLoadErrorFatal(undefined, () => {
+        throw err;
+      }),
+    ).rejects.toThrow("__exit_1__");
+
+    expect(errSpy).toHaveBeenCalledWith(err.message);
+
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it("withOxcLoadErrorFatal: rethrows every OTHER error unchanged (no swallowing, no exit)", async () => {
+    const { withOxcLoadErrorFatal } = await import("../src/commands/shared.js");
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit should not have been called");
+    });
+
+    await expect(
+      withOxcLoadErrorFatal("json", () => {
+        throw new Error("some unrelated validation error");
+      }),
+    ).rejects.toThrow("some unrelated validation error");
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it("withOxcLoadErrorFatal: returns fn()'s value on success (no error at all)", async () => {
+    const { withOxcLoadErrorFatal } = await import("../src/commands/shared.js");
+    await expect(withOxcLoadErrorFatal("json", () => 42)).resolves.toBe(42);
+    await expect(withOxcLoadErrorFatal("json", async () => "async-ok")).resolves.toBe("async-ok");
+  });
+
+  it('printFatalCatchAll: json wraps in {"error": ...}, text keeps the pre-existing `Error: <msg>` line', async () => {
+    const { printFatalCatchAll } = await import("../src/commands/shared.js");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    printFatalCatchAll("json", "boom");
+    expect(JSON.parse(errSpy.mock.calls[0][0] as string)).toEqual({ error: "boom" });
+
+    printFatalCatchAll("text", "boom");
+    expect(errSpy.mock.calls[1][0]).toBe("Error: boom");
+
+    printFatalCatchAll(undefined, "boom");
+    expect(errSpy.mock.calls[2][0]).toBe("Error: boom");
+
+    errSpy.mockRestore();
+  });
+});

--- a/tests/plan-coverage-integration.test.ts
+++ b/tests/plan-coverage-integration.test.ts
@@ -1228,3 +1228,56 @@ describe("plan-coverage E2E — build warnings surfaced (meta-review F2)", () =>
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// issue #279 (item 1) — the generic catch-all in commands/plan-coverage.ts
+// (an error thrown from inside `runPlanCoverage`/`scan`, distinct from the
+// `--spec`/`--tasks`/`--plan` early exits above which are pre-existing and
+// unaffected) used to be plain-text-only regardless of `--format`. It now
+// mirrors `rename`'s original `fail()`: json → `{"error": ...}` on stderr,
+// text → the pre-existing `Error: <msg>` line on stderr — both exit 1, both
+// with an EMPTY stdout (a fatal error is not a verdict payload).
+//
+// A malformed `.trace.lock` (a JSON array, not an object) reliably reaches
+// this catch: `readLockWithMeta` → `validateLockSchema` throws
+// `LockSchemaError` from deep inside `runPlanCoverage`, uncaught until this
+// command's own catch-all.
+// ---------------------------------------------------------------------------
+describe("CLI: plan-coverage's generic catch-all is format-aware (issue #279 item 1)", () => {
+  function makeFixtureWithCorruptLock(): Fixture {
+    const fx = setupFixture();
+    writeFileSync(join(fx.root, ".trace.lock"), "[]");
+    return fx;
+  }
+
+  it('--format json: {"error": ...} envelope on stderr, empty stdout, exit 1', async () => {
+    const fx = makeFixtureWithCorruptLock();
+    try {
+      const { stdout, stderr, exitCode } = await runCli(
+        ["plan-coverage", "--spec", fx.specDirAbsolute, "--format", "json"],
+        { cwd: fx.root },
+      );
+      expect(exitCode).toBe(1);
+      expect(stdout).toBe("");
+      expect(() => JSON.parse(stderr)).not.toThrow();
+      expect(JSON.parse(stderr).error).toMatch(/JSON object at the top level/i);
+    } finally {
+      rmSync(fx.root, { recursive: true, force: true });
+    }
+  });
+
+  it("text mode: `Error: <msg>` on stderr, empty stdout, exit 1 (pre-existing text behavior unchanged)", async () => {
+    const fx = makeFixtureWithCorruptLock();
+    try {
+      const { stdout, stderr, exitCode } = await runCli(
+        ["plan-coverage", "--spec", fx.specDirAbsolute],
+        { cwd: fx.root },
+      );
+      expect(exitCode).toBe(1);
+      expect(stdout).toBe("");
+      expect(stderr).toMatch(/^Error: .*JSON object at the top level/i);
+    } finally {
+      rmSync(fx.root, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/rename-cli.test.ts
+++ b/tests/rename-cli.test.ts
@@ -912,3 +912,295 @@ describe("CLI: rename rewrites trace shards (spec 020 FR-016)", () => {
     },
   );
 });
+
+// ---------------------------------------------------------------------------
+// issue #273-1 — a validation/safety-valve throw (from-and-to identical,
+// invalid target ID, ID not found, zero-hit safety valve, …) used to
+// completely swallow the pre-write scan's `buildWarnings`
+// (`RenameValidationError` didn't exist; `commands/rename.ts`'s catch only
+// ever preserved `e.message`). Now those warnings survive onto the error
+// path: text mode prints them (stderr, via `printWarnings`) BEFORE the
+// `Error: ...` line, and json mode folds them into the `{"error": ...}`
+// envelope's `warnings` field.
+// ---------------------------------------------------------------------------
+describe("CLI: rename validation failures surface pre-write buildWarnings (#273-1)", () => {
+  /** Add a second spec file that redefines REQ-001 — a genuine `duplicate-id`
+   *  BuildWarning from the pre-write scan, independent of whatever
+   *  validation failure the test triggers afterward. */
+  function addDuplicateIdWarning(tmp: string): void {
+    writeFileSync(
+      resolve(tmp, "specs/dup.md"),
+      ["# Dup", "", "- REQ-001: duplicate definition", ""].join("\n"),
+      "utf-8",
+    );
+  }
+
+  // `files` order on a `duplicate-id` warning reflects scan/glob traversal
+  // order, not a sorted/write order — assert membership, not array identity.
+  function expectSingleDuplicateIdWarning(
+    warnings: Array<{ type: string; id: string; files: string[] }>,
+    id: string,
+    files: string[],
+  ): void {
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].type).toBe("duplicate-id");
+    expect(warnings[0].id).toBe(id);
+    expect(warnings[0].files.slice().sort()).toEqual(files.slice().sort());
+  }
+
+  it("text mode: prints the duplicate-id WARNING before the validation Error line", async () => {
+    const tmp = await prepareTempDir();
+    addDuplicateIdWarning(tmp);
+    await runAt(tmp, ["reconcile"]);
+
+    // REQ-002 already exists → "already exists" validation throw, unrelated
+    // to the duplicate-id warning on REQ-001.
+    const { exitCode, stderr } = await runCli(
+      ["rename", "--from", "REQ-001", "--to", "REQ-002"],
+      tmp,
+    );
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/WARNING: duplicate ID "REQ-001"/);
+    expect(stderr).toMatch(/Error: ID "REQ-002" already exists/);
+    // The warning must print BEFORE the Error line (fail()'s contract: warn
+    // first, then fail).
+    expect(stderr.indexOf("WARNING:")).toBeLessThan(stderr.indexOf("Error:"));
+  });
+
+  it("json mode: folds buildWarnings into the error envelope's `warnings` field", async () => {
+    const tmp = await prepareTempDir();
+    addDuplicateIdWarning(tmp);
+    await runAt(tmp, ["reconcile"]);
+
+    const { exitCode, stderr } = await runCli(
+      ["rename", "--from", "REQ-001", "--to", "REQ-002", "--format", "json"],
+      tmp,
+    );
+    expect(exitCode).not.toBe(0);
+    const envelope = JSON.parse(stderr);
+    expect(envelope.error).toContain('ID "REQ-002" already exists');
+    expectSingleDuplicateIdWarning(envelope.warnings, "REQ-001", [
+      "specs/feature.md",
+      "specs/dup.md",
+    ]);
+  });
+
+  it("a validation failure with NO pre-write buildWarnings omits the `warnings` field in json (no shape regression)", async () => {
+    const tmp = await prepareTempDir();
+    const { exitCode, stderr } = await runCli(
+      ["rename", "--from", "REQ-001", "--to", "REQ-002", "--format", "json"],
+      tmp,
+    );
+    expect(exitCode).not.toBe(0);
+    const envelope = JSON.parse(stderr);
+    expect(envelope.error).toContain('ID "REQ-002" already exists');
+    expect(envelope.warnings).toBeUndefined();
+  });
+
+  it("also surfaces buildWarnings on the split/merge validation paths", async () => {
+    const tmp = await prepareTempDir();
+    addDuplicateIdWarning(tmp);
+    await runAt(tmp, ["reconcile"]);
+
+    // --into REQ-101 twice → "Duplicate target ID" validation throw on split.
+    const split = await runCli(
+      ["rename", "--split", "REQ-001", "--into", "REQ-101", "REQ-101", "--format", "json"],
+      tmp,
+    );
+    expect(split.exitCode).not.toBe(0);
+    const splitEnvelope = JSON.parse(split.stderr);
+    expectSingleDuplicateIdWarning(splitEnvelope.warnings, "REQ-001", [
+      "specs/feature.md",
+      "specs/dup.md",
+    ]);
+
+    // --merge with an invalid --into target → assertValidTargetId throw on merge.
+    const merge = await runCli(
+      ["rename", "--merge", "REQ-001", "REQ-002", "--into", "REQ-COMBINED", "--format", "json"],
+      tmp,
+    );
+    expect(merge.exitCode).not.toBe(0);
+    const mergeEnvelope = JSON.parse(merge.stderr);
+    expectSingleDuplicateIdWarning(mergeEnvelope.warnings, "REQ-001", [
+      "specs/feature.md",
+      "specs/dup.md",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// issue #273-2 ((a)-lite) — `reconcileAfterWrite`'s post-write scan used to
+// discard its `BuildWarning[]` outright. `RenameResult.postWriteWarnings`
+// now carries the ones NOT already present pre-write (set-diffed by
+// type+id+files+message), distinguishing "no post-write scan ran"
+// (`undefined`) from "ran and found nothing new" (`[]`).
+// ---------------------------------------------------------------------------
+describe("CLI: rename surfaces NEW post-write buildWarnings (#273-2, (a)-lite)", () => {
+  /** Real-harm case from the issue: a REQ defined in TWO spec files, merged
+   *  into a brand-new target ID — `mergeMarkdown`'s scaffold appends the new
+   *  ID's definition to EVERY file that hosted a merged-away definition, so
+   *  the post-write rescan discovers the merge target duplicated across both
+   *  files — a `duplicate-id` warning that did not exist before the merge. */
+  async function prepareTwoSpecMergeFixture(): Promise<string> {
+    const tmp = mkdtempSync(resolve(tmpdir(), "artgraph-rename-postwrite-"));
+    tempDirs.push(tmp);
+    writeFileSync(
+      resolve(tmp, ".artgraph.json"),
+      JSON.stringify({
+        include: ["src/**/*.ts"],
+        specDirs: ["specs"],
+        testPatterns: ["tests/**/*.test.ts"],
+        lockFile: ".trace.lock",
+      }),
+    );
+    mkdirSync(resolve(tmp, "specs"), { recursive: true });
+    mkdirSync(resolve(tmp, "src"), { recursive: true });
+    mkdirSync(resolve(tmp, "tests"), { recursive: true });
+    writeFileSync(resolve(tmp, "specs/a.md"), "# Spec A\n\n- REQ-001: alpha\n");
+    writeFileSync(resolve(tmp, "specs/b.md"), "# Spec B\n\n- REQ-002: beta\n");
+    writeFileSync(
+      resolve(tmp, "src/feature.ts"),
+      "// @impl REQ-001\n// @impl REQ-002\nexport const x = 1;\n",
+    );
+    writeFileSync(
+      resolve(tmp, "tests/feature.test.ts"),
+      "// [REQ-001]\n// [REQ-002]\nexport {};\n",
+    );
+    execFileSync("git", ["init"], { cwd: tmp, stdio: "pipe" });
+    gitCommit(tmp, "init");
+    await runAt(tmp, ["reconcile"]);
+    gitCommit(tmp, "add lock");
+    return tmp;
+  }
+
+  it("pins the real-harm case: a --merge scaffold duplicated across two spec files surfaces as a NEW postWriteWarnings entry", async () => {
+    const tmp = await prepareTwoSpecMergeFixture();
+
+    const { exitCode, stdout } = await runCli(
+      ["rename", "--merge", "REQ-001", "REQ-002", "--into", "REQ-100", "--format", "json"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+
+    // Pre-write scan had no duplicate — this is genuinely NEW.
+    expect(result.buildWarnings).toEqual([]);
+    expect(result.postWriteWarnings).toBeDefined();
+    expect(result.postWriteWarnings).toHaveLength(1);
+    expect(result.postWriteWarnings[0]).toMatchObject({ type: "duplicate-id", id: "REQ-100" });
+    expect(result.postWriteWarnings[0].files.sort()).toEqual(["specs/a.md", "specs/b.md"]);
+  });
+
+  it("prints the postWriteWarnings block (with heading) in text mode", async () => {
+    const tmp = await prepareTwoSpecMergeFixture();
+
+    const { exitCode, stderr } = await runCli(
+      ["rename", "--merge", "REQ-001", "REQ-002", "--into", "REQ-100"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+    expect(stderr).toMatch(/new warnings detected by the post-rename re-scan/);
+    expect(stderr).toMatch(/WARNING: duplicate ID "REQ-100"/);
+  });
+
+  it("a warning already present BEFORE the rename (unaffected by it) is NOT re-reported in postWriteWarnings (diff logic)", async () => {
+    const tmp = await prepareTwoSpecMergeFixture();
+    // A SEPARATE, pre-existing duplicate-id warning on REQ-999 that the
+    // merge below never touches — same two files, same id, before AND
+    // after the merge. Only the merge's OWN new REQ-100 duplicate should
+    // show up in postWriteWarnings; this pre-existing one must not.
+    writeFileSync(resolve(tmp, "specs/e.md"), "# Spec E\n\n- REQ-999: pre-existing dup\n", "utf-8");
+    writeFileSync(
+      resolve(tmp, "specs/f.md"),
+      "# Spec F\n\n- REQ-999: also pre-existing\n",
+      "utf-8",
+    );
+    gitCommit(tmp, "seed unrelated pre-existing REQ-999 duplicate");
+    await runAt(tmp, ["reconcile"]);
+    gitCommit(tmp, "reconcile pre-existing duplicate");
+
+    const { exitCode, stdout } = await runCli(
+      ["rename", "--merge", "REQ-001", "REQ-002", "--into", "REQ-100", "--format", "json"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+
+    // Pre-write: only the unrelated REQ-999 duplicate exists.
+    expect(result.buildWarnings).toHaveLength(1);
+    expect(result.buildWarnings[0].type).toBe("duplicate-id");
+    expect(result.buildWarnings[0].id).toBe("REQ-999");
+    expect(result.buildWarnings[0].files.sort()).toEqual(["specs/e.md", "specs/f.md"]);
+    // Post-write: the merge minted a NEW REQ-100 duplicate, and REQ-999's
+    // duplicate is untouched (same key) — so it must be excluded, leaving
+    // only REQ-100's.
+    expect(result.postWriteWarnings).toHaveLength(1);
+    expect(result.postWriteWarnings[0].id).toBe("REQ-100");
+    expect(result.postWriteWarnings.some((w: { id: string }) => w.id === "REQ-999")).toBe(false);
+  });
+
+  it("postWriteWarnings is undefined (omitted from JSON) when --dry-run skips the post-write scan", async () => {
+    const tmp = await prepareTwoSpecMergeFixture();
+
+    const { exitCode, stdout } = await runCli(
+      [
+        "rename",
+        "--merge",
+        "REQ-001",
+        "REQ-002",
+        "--into",
+        "REQ-100",
+        "--dry-run",
+        "--format",
+        "json",
+      ],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.applied).toBe(false);
+    expect("postWriteWarnings" in result).toBe(false);
+  });
+
+  it("postWriteWarnings is undefined (omitted from JSON) when no .trace.lock exists to reconcile against", async () => {
+    const tmp = mkdtempSync(resolve(tmpdir(), "artgraph-rename-nolock-"));
+    tempDirs.push(tmp);
+    writeFileSync(
+      resolve(tmp, ".artgraph.json"),
+      JSON.stringify({
+        include: ["src/**/*.ts"],
+        specDirs: ["specs"],
+        testPatterns: ["tests/**/*.test.ts"],
+        lockFile: ".trace.lock",
+      }),
+    );
+    mkdirSync(resolve(tmp, "specs"), { recursive: true });
+    mkdirSync(resolve(tmp, "src"), { recursive: true });
+    writeFileSync(resolve(tmp, "specs/feature.md"), "# Feature\n\n- REQ-001: alpha\n");
+    writeFileSync(resolve(tmp, "src/feature.ts"), "// @impl REQ-001\nexport const x = 1;\n");
+    // No `.trace.lock` written, no reconcile ever run — applyWrites still
+    // writes source files but reconcileAfterWrite short-circuits.
+
+    const { exitCode, stdout } = await runCli(
+      ["rename", "--from", "REQ-001", "--to", "REQ-100", "--format", "json"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+    expect(result.applied).toBe(true);
+    expect("postWriteWarnings" in result).toBe(false);
+  });
+
+  it("printRenameJson's full-result shape stays byte-compatible for a rename with no new post-write warnings", async () => {
+    const tmp = await prepareTempDir();
+    const { exitCode, stdout } = await runCli(
+      ["rename", "--from", "REQ-001", "--to", "REQ-100", "--format", "json"],
+      tmp,
+    );
+    expect(exitCode).toBe(0);
+    const result = JSON.parse(stdout);
+    // Ran with a lock present, non-dry-run → postWriteWarnings is a defined
+    // (possibly empty) array, not omitted.
+    expect(result.postWriteWarnings).toEqual([]);
+  });
+});

--- a/tests/rename-executor-warning-diff.test.ts
+++ b/tests/rename-executor-warning-diff.test.ts
@@ -1,0 +1,94 @@
+// issue #336 (PR #336 meta-review F3/F4) — direct unit coverage of
+// `warningKey`/`diffPostWriteWarnings` (`src/rename-executor.ts`), the pure
+// helpers `RenameResult.postWriteWarnings` is built from. Exercised here at
+// unit level (rather than only end-to-end through the CLI, as
+// `tests/rename-cli.test.ts`'s existing `postWriteWarnings` suite does)
+// because the two scenarios this fix targets are impractical to reproduce
+// reliably end-to-end:
+//
+//   F4 — two independent `scan()` calls enumerating the exact same file SET
+//        in a different order (this depends on directory-traversal/glob
+//        order, which isn't something a fixture can deterministically force
+//        to differ between a pre-write and post-write scan).
+//   F3 — a REAL EMFILE/ENFILE condition hitting the pre-write scan and the
+//        post-write scan with a DIFFERENT "first offending file" each time
+//        (this would require orchestrating actual file-descriptor
+//        exhaustion at two specific points in a rename run).
+//
+// Both `warningKey` and `diffPostWriteWarnings` are pure functions of
+// `BuildWarning[]`, so constructing the pre/post arrays directly is the
+// precise, deterministic way to pin the exact keying rule.
+
+import { describe, expect, it } from "vitest";
+import { diffPostWriteWarnings, warningKey } from "../src/rename-executor.js";
+import type { BuildWarning } from "../src/graph/builder.js";
+
+function dup(files: string[], id = "REQ-100"): BuildWarning {
+  return { type: "duplicate-id", id, files, message: `duplicate ID "${id}"` };
+}
+
+function exhausted(id: string, files: string[], message: string): BuildWarning {
+  return { type: "system-resource-exhausted", id, files, message };
+}
+
+describe("rename-executor: warningKey (issue #336 F3/F4)", () => {
+  it("F4: is stable across a reversed `files` order for an ordinary warning type", () => {
+    const a = dup(["specs/a.md", "specs/b.md"]);
+    const b = dup(["specs/b.md", "specs/a.md"]);
+    expect(warningKey(a)).toBe(warningKey(b));
+  });
+
+  it("F4: still distinguishes a genuinely different `files` SET (not just order)", () => {
+    const a = dup(["specs/a.md", "specs/b.md"]);
+    const b = dup(["specs/a.md", "specs/c.md"]);
+    expect(warningKey(a)).not.toBe(warningKey(b));
+  });
+
+  it("F3: system-resource-exhausted keys on `type` alone — differing id/files/message collapse to the same key", () => {
+    const a = exhausted("doc:specs/a.md", ["specs/a.md"], "fd exhaustion (EMFILE) round 1");
+    const b = exhausted("glob:code-files", [], "fd exhaustion (ENFILE) round 2");
+    expect(warningKey(a)).toBe(warningKey(b));
+  });
+
+  it("F3: a DIFFERENT warning type is never collapsed by the system-resource-exhausted special case", () => {
+    const a = exhausted("doc:specs/a.md", ["specs/a.md"], "fd exhaustion");
+    const b = dup(["specs/a.md"]);
+    expect(warningKey(a)).not.toBe(warningKey(b));
+  });
+});
+
+describe("rename-executor: diffPostWriteWarnings (issue #336 F3/F4)", () => {
+  it("F4: a duplicate-id warning whose `files` enumerate in reversed order across pre/post scans is NOT reported as new", () => {
+    const pre: BuildWarning[] = [dup(["specs/a.md", "specs/b.md"])];
+    const post: BuildWarning[] = [dup(["specs/b.md", "specs/a.md"])];
+    expect(diffPostWriteWarnings(post, pre)).toEqual([]);
+  });
+
+  it("F3: system-resource-exhausted recurring (with a different id/files/message) across pre/post scans is NOT reported as new", () => {
+    const pre: BuildWarning[] = [
+      exhausted("doc:specs/a.md", ["specs/a.md"], "fd exhaustion (EMFILE) pre-write"),
+    ];
+    const post: BuildWarning[] = [
+      exhausted("glob:code-files", [], "fd exhaustion (ENFILE) post-write"),
+    ];
+    expect(diffPostWriteWarnings(post, pre)).toEqual([]);
+  });
+
+  it("F3: a system-resource-exhausted warning ABSENT pre-write that appears post-write still surfaces (no blanket exclusion)", () => {
+    const pre: BuildWarning[] = [];
+    const post: BuildWarning[] = [
+      exhausted("doc:specs/a.md", ["specs/a.md"], "fd exhaustion (EMFILE)"),
+    ];
+    expect(diffPostWriteWarnings(post, pre)).toEqual(post);
+  });
+
+  it("a genuinely new warning of an ordinary type (not present pre-write) still surfaces", () => {
+    const pre: BuildWarning[] = [];
+    const post: BuildWarning[] = [dup(["specs/a.md", "specs/b.md"])];
+    expect(diffPostWriteWarnings(post, pre)).toEqual(post);
+  });
+
+  it("returns undefined unchanged when no post-write scan ran at all", () => {
+    expect(diffPostWriteWarnings(undefined, [dup(["specs/a.md"])])).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

警告配線シリーズ **PR-B** (PR-A = #334 merge 済みの後続。バンドル構成・設計はユーザー承認済み)。2 コミット構成 (rename 側 / cli アーキ側+docs)。

Closes #273, Closes #279.

### #273 — rename の警告握りつぶし 2 系統の解消

1. **throw 経路** (#273-1): `loadScanContext` 後の全バリデーション throw を `RenameValidationError` (pre-write scan の `buildWarnings` を運搬) に統一。コマンド側 catch が fail の**前に** text では printWarnings、json では error envelope に warnings を同梱
2. **post-write scan** (#273-2、承認済み (a)-lite): `reconcileAfterWrite` が捨てていた post-write scan の警告を、pre-write との**集合差分で新規分のみ** `RenameResult.postWriteWarnings` (加算的フィールド = JSON 後方互換) に格納。text は「rename が原因とは限らない」注記付きの見出しで表示。**post-write scan が走らなかった (`--dry-run` / lock 不在) 場合の `undefined` と「走ったが新規なし」の `[]` を意図的に区別**。issue 記載の実害ケース (`--merge` の duplicate-id scaffold) をテストで pin

### #279 — 致命的エラー時の `--format json` 出力統一

- `OxcLoadError` は従来 cli.ts トップレベル (format を知らない層) でのみ捕捉 → 各コマンドの `scan()` 到達サイトを `withOxcLoadErrorFatal(format, fn)` (shared.ts 新設) で外科的にラップし、**format を知る層で捕捉**。rename / plan-coverage は既存 catch-all に `instanceof` 分岐を追加して同じ printer を共有
- plan-coverage の catch-all を format-aware 化: json 時は rename の `fail()` が確立した `{"error": ...}` **stderr** envelope に統一 (stdout は成功 payload 専用 — 既存 F7 テストが stderr を assert している実契約に整合。計画時の「stdout に出す」記述は rename の実挙動確認により stderr に補正)
- `docs/commands.md` に「Fatal errors: stdout/stderr contract」セクションを新設し、宣言済みの例外 (impact `--diff --base` の zero-stdout 契約 / rename text モードの warning stream 分裂 = Step 0-pre M3、いずれも挙動不変で現状仕様として記録) を明文化

## Change type

- [x] fix (bug fix)
- [ ] feat / refactor / docs / chore / test

## Testing

- [x] Existing tests pass (`pnpm -r test`) — 2321 passed / 19 skipped、0 failed
- [x] Added tests where needed — 34 tests 追加: `tests/rename-cli.test.ts` +12 (throw 経路の text/json、merge 実害 pin、差分ロジック、undefined vs [] 区別)、`tests/fatal-error-contract.test.ts` 新設 +20 (実 `Module._load` 失敗による OxcLoadError の全コマンド E2E + 共有ヘルパー unit)、`tests/plan-coverage-integration.test.ts` +2
- [x] Ran `pnpm -r knip` and `pnpm -r build` — clean、`tsc --noEmit` clean、`node dist/cli.js check --diff` exit 0

## Breaking change

- [ ] Yes (described below)
- [x] No

`RenameResult.postWriteWarnings` は加算的 optional。エラー時の json envelope は従来 plain text だった経路が構造化される方向のみの変更 (exit code 不変)。

## Notes

- Step 0-pre (シリーズ一括調査) の帰属表が特定した「cli.ts の OxcLoadError catch は format 非依存の単一集約点」というアーキ障害点への対処が本 PR の中核。調査の caveat (rename `fail()` の出力先) を brief で逐語引用した結果、実装エージェントが stderr 契約の齟齬を検出し正しく整合させた (brief 転記ルールの効果実証)
- rename text モードの warning stream 分裂 (M3) は挙動変更せず契約文書化のみ — 変更する場合は別 issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BREZStzmU62xFvKSydGKZV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BREZStzmU62xFvKSydGKZV)_