### PR TITLE
fix(vitest,scan): plugin oxc-load negative cache + dedicated warning; serve CLI polish (#278, #172)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -128,6 +128,12 @@ artgraph scan --serve --port 4000 --host 0.0.0.0
 artgraph scan --output ./graph-out                      # static HTML export
 ```
 
+Binding to `0.0.0.0` (or an equivalent IPv6 "all interfaces" address, e.g.
+`::`) is an intentional opt-in to expose the server beyond localhost to your
+LAN; `artgraph` prints a `warning: binding to 0.0.0.0 exposes the graph to
+your network` line on stderr when it does, since the server has no
+authentication.
+
 `--serve` and `--output` are mutually exclusive. Both read `.trace.lock` when
 present to color drift/orphan/uncovered nodes; a missing lock just renders
 without that extra state.

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -29,6 +29,31 @@ function parsePort(value: string): number {
   return port;
 }
 
+// PR #346 review (H1) — `--host ""` reaches `server.listen()` as the empty
+// string, which Node binds the same as `0.0.0.0` (all interfaces) — but
+// silently: it matched neither the exact-string C6 network-exposure warning
+// nor the C7 display substitution in `graph/serve.ts` (both keyed on exact
+// "0.0.0.0"/"::" at the time), and the printed URL came out as the malformed
+// `http://:PORT` (empty authority host) — confirmed empirically. A value
+// with leading/trailing whitespace is equally malformed input `--host` was
+// never meant to accept. Reject both at parse time, mirroring `parsePort`'s
+// shape above (InvalidArgumentError naming the offending value). This
+// validates SHAPE only (non-empty, no surrounding whitespace) — it does NOT
+// check DNS resolvability or any other semantic validity of the host; a bad
+// but well-formed value still surfaces as a `server.listen()` error at bind
+// time, same as before this change.
+function parseHost(value: string): string {
+  if (value.trim() === "") {
+    throw new InvalidArgumentError(`--host must not be empty (got "${value}").`);
+  }
+  if (value !== value.trim()) {
+    throw new InvalidArgumentError(
+      `--host must not have leading/trailing whitespace (got "${value}").`,
+    );
+  }
+  return value;
+}
+
 export function registerScanCommand(program: Command): void {
   program
     .command("scan")
@@ -36,7 +61,7 @@ export function registerScanCommand(program: Command): void {
     .option("--format <format>", "Output format: json | text", "text")
     .option("--serve", "Start a local HTTP server rendering the graph interactively")
     .option("--port <n>", "Port for --serve (default 3737)", parsePort)
-    .option("--host <h>", "Host for --serve (default 127.0.0.1)")
+    .option("--host <h>", "Host for --serve (default 127.0.0.1)", parseHost)
     .option("--output <dir>", "Emit a static HTML export into <dir>")
     .option(
       "--force",

--- a/src/commands/scan.ts
+++ b/src/commands/scan.ts
@@ -1,8 +1,33 @@
 // `artgraph scan` — extracted verbatim from `src/cli.ts` (issue #162).
 
 import { resolve } from "node:path";
-import { Command } from "commander";
+import { Command, InvalidArgumentError } from "commander";
 import { resolveTestResults, reportGraphWarnings, withFatalErrors } from "./shared.js";
+
+// issue #172 (C3) — `Number.parseInt` alone silently accepts trailing
+// garbage (`--port 3737abc` -> 3737), truncates fractions (`--port 3.14` ->
+// 3), and never validates range, so an out-of-range value (negative, or
+// >=65536) only surfaced as a raw Node `RangeError` from deep inside
+// `server.listen()`, far from the flag that caused it. Mirrors
+// `src/commands/check.ts`'s `--base` validator's shape (InvalidArgumentError
+// + a message naming the offending value) — `/^\d+$/` requires the ENTIRE
+// value to be decimal digits (no sign, no fraction, no trailing text), so
+// only a clean whole number ever reaches `Number.parseInt`. `--port 0` is a
+// legal value (OS auto-assigns a free port — see graph/serve.ts's
+// `formatServeUrl`/`server.address()` handling for how the actual bound
+// port is surfaced).
+function parsePort(value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new InvalidArgumentError(
+      `--port must be a whole number with no extra characters (got "${value}").`,
+    );
+  }
+  const port = Number.parseInt(value, 10);
+  if (port > 65535) {
+    throw new InvalidArgumentError(`--port must be between 0 and 65535 (got ${port}).`);
+  }
+  return port;
+}
 
 export function registerScanCommand(program: Command): void {
   program
@@ -10,7 +35,7 @@ export function registerScanCommand(program: Command): void {
     .description("Build the artifact graph and show summary (JSON output includes the full graph)")
     .option("--format <format>", "Output format: json | text", "text")
     .option("--serve", "Start a local HTTP server rendering the graph interactively")
-    .option("--port <n>", "Port for --serve (default 3737)", (v) => Number.parseInt(v, 10))
+    .option("--port <n>", "Port for --serve (default 3737)", parsePort)
     .option("--host <h>", "Host for --serve (default 127.0.0.1)")
     .option("--output <dir>", "Emit a static HTML export into <dir>")
     .option(
@@ -19,6 +44,22 @@ export function registerScanCommand(program: Command): void {
     )
     .action(async (opts) => {
       const rootDir = process.cwd();
+
+      // issue #172 (C1) — `--format` only affects the plain `scan` summary
+      // printed at the bottom of this action; `--serve`/`--output` render
+      // HTML instead and silently ignored an explicit `--format json`
+      // before this warning. The default is "text", so `opts.format ===
+      // "json"` can only be true here if the user passed it explicitly.
+      if (opts.format === "json" && (opts.serve || opts.output)) {
+        console.error("warning: --format is ignored with --serve/--output.");
+      }
+      // issue #172 (C8) — `--port`/`--host` only matter for `--serve`
+      // (`--output` doesn't start a server); passing either without
+      // `--serve` was silently a no-op. Warn instead.
+      if ((opts.port !== undefined || typeof opts.host === "string") && !opts.serve) {
+        console.error("warning: --port/--host are ignored without --serve.");
+      }
+
       const { loadConfig } = await import("../config.js");
       const { scan } = await import("../scan.js");
       // issue #279 / issue #336 (meta-review F1) — format-aware fatal-error
@@ -99,7 +140,10 @@ export function registerScanCommand(program: Command): void {
         // --serve: keep the process alive on the http.Server. SIGINT/SIGTERM
         // trigger a graceful shutdown; without the handler Ctrl+C would still
         // work but skip the server.close() drain.
-        const port = typeof opts.port === "number" && !Number.isNaN(opts.port) ? opts.port : 3737;
+        // `opts.port` is either `undefined` (flag not passed) or a
+        // validated non-NaN integer in [0, 65535] — `parsePort` above never
+        // lets a malformed or out-of-range value reach here.
+        const port = opts.port ?? 3737;
         const host = typeof opts.host === "string" ? opts.host : "127.0.0.1";
         try {
           const handle = await startServer({ data, port, host });

--- a/src/graph/serve.ts
+++ b/src/graph/serve.ts
@@ -1,4 +1,5 @@
 import { createServer, type Server } from "node:http";
+import { isIPv6 } from "node:net";
 import {
   copyFileSync,
   existsSync,
@@ -37,6 +38,33 @@ export interface ExportOptions {
 
 const DEFAULT_PORT = 3737;
 const DEFAULT_HOST = "127.0.0.1";
+
+// issue #172 (C4/C5/C7) — the URL printed by `scan --serve` used to be a
+// bare `http://${host}:${port}` string built from the REQUESTED host/port,
+// which was wrong in three ways this helper fixes:
+//   (C5) an IPv6 host (`::1`, a literal address, …) needs `[...]` bracketing
+//        in a URL — `http://::1:3737` is not a valid authority, the colons
+//        collide with the port separator.
+//   (C7) `0.0.0.0` (IPv4 "all interfaces") and `::` (IPv6 "all interfaces")
+//        are valid BIND addresses but not valid addresses to actually
+//        connect back to from the machine that just started the server —
+//        display the loopback equivalent instead. This is a DISPLAY-ONLY
+//        substitution: the caller still binds to the literal host it was
+//        given (see `startServer` below) — only the printed/returned URL
+//        text is adjusted.
+//   (C4) `port` here must be the ACTUALLY bound port, not the requested one
+//        — the caller is responsible for passing `server.address()`'s port
+//        (relevant for `--port 0`, where the OS picks a free port).
+export function formatServeUrl(host: string, port: number): string {
+  let displayHost = host;
+  if (host === "0.0.0.0") {
+    displayHost = "127.0.0.1";
+  } else if (host === "::") {
+    displayHost = "::1";
+  }
+  const authorityHost = isIPv6(displayHost) ? `[${displayHost}]` : displayHost;
+  return `http://${authorityHost}:${port}`;
+}
 
 // `dist/graph/serve.js` → `dist/graph/../../templates/graph` = `<root>/templates/graph`.
 // At dev time (vitest reads src directly), `src/graph/serve.ts` → same relative
@@ -103,6 +131,13 @@ function readStaticAsset(path: string, name: string): Buffer {
 export async function startServer(opts: ServeOptions): Promise<ServeHandle> {
   const port = opts.port ?? DEFAULT_PORT;
   const host = opts.host ?? DEFAULT_HOST;
+
+  // issue #172 (C6) — binding to every interface (`0.0.0.0`/`::`) exposes
+  // this server (no auth, arbitrary graph data) to the whole LAN, not just
+  // localhost. `--host` is opt-in, so this is a heads-up, not a refusal.
+  if (host === "0.0.0.0" || host === "::") {
+    console.error(`warning: binding to ${host} exposes the graph to your network`);
+  }
 
   // Read and cache all three static payloads at startup:
   //   - fail-fast: a missing template kills startup with a clear message
@@ -213,7 +248,13 @@ export async function startServer(opts: ServeOptions): Promise<ServeHandle> {
 
     server.listen(port, host, () => {
       phase = "listening";
-      const url = `http://${host}:${port}`;
+      // issue #172 (C4) — read back the ACTUALLY bound port from the OS
+      // rather than echoing the requested `port` value: with `--port 0` the
+      // OS assigns a free ephemeral port, and the pre-fix code printed
+      // "serving at http://host:0", which is not a URL anyone can visit.
+      const address = server.address();
+      const actualPort = address && typeof address === "object" ? address.port : port;
+      const url = formatServeUrl(host, actualPort);
       resolvePromise({
         url,
         close(): Promise<void> {

--- a/src/graph/serve.ts
+++ b/src/graph/serve.ts
@@ -45,7 +45,8 @@ const DEFAULT_HOST = "127.0.0.1";
 //   (C5) an IPv6 host (`::1`, a literal address, …) needs `[...]` bracketing
 //        in a URL — `http://::1:3737` is not a valid authority, the colons
 //        collide with the port separator.
-//   (C7) `0.0.0.0` (IPv4 "all interfaces") and `::` (IPv6 "all interfaces")
+//   (C7) `0.0.0.0` (IPv4 "all interfaces") and `::` (and its equivalent
+//        spellings — see `isUnspecifiedHost` below) (IPv6 "all interfaces")
 //        are valid BIND addresses but not valid addresses to actually
 //        connect back to from the machine that just started the server —
 //        display the loopback equivalent instead. This is a DISPLAY-ONLY
@@ -55,12 +56,37 @@ const DEFAULT_HOST = "127.0.0.1";
 //   (C4) `port` here must be the ACTUALLY bound port, not the requested one
 //        — the caller is responsible for passing `server.address()`'s port
 //        (relevant for `--port 0`, where the OS picks a free port).
+
+// PR #346 review (M1) — the C6 network-exposure warning below and this
+// function's C7 display substitution used to key on an exact-string match
+// against `"0.0.0.0"` / `"::"` only, so equivalent IPv6 "all interfaces"
+// spellings (`::0`, `0:0:0:0:0:0:0:0`,
+// `0000:0000:0000:0000:0000:0000:0000:0000`, …) — which bind identically to
+// `::` — silently skipped both the warning and the display fix. `net.isIPv6`
+// accepts every one of these spellings; this helper additionally checks that
+// every colon-separated segment is either empty (the `::` zero-run
+// shorthand) or parses as the literal number 0, which holds for every
+// spelling of the IPv6 unspecified address.
+//
+// IPv4-mapped IPv6 forms (`::ffff:0.0.0.0`) are deliberately NOT covered:
+// they're a rare spelling, and it isn't confirmed that `server.listen()`
+// binds them the same all-interfaces way as literal `::`/`0.0.0.0` — folding
+// them in risks a wrong warning/substitution rather than a merely missing
+// one, so they're left as a known gap rather than guessed at. (As a side
+// effect, the last segment of an IPv4-mapped address is dotted-decimal, e.g.
+// `0.0.0.0`, which `Number(...)` doesn't parse as `0` — so this check
+// naturally falls through to `false` for those forms without special-casing
+// them.)
+export function isUnspecifiedHost(host: string): boolean {
+  if (host === "0.0.0.0") return true;
+  if (!isIPv6(host)) return false;
+  return host.split(":").every((segment) => segment === "" || Number(segment) === 0);
+}
+
 export function formatServeUrl(host: string, port: number): string {
   let displayHost = host;
-  if (host === "0.0.0.0") {
-    displayHost = "127.0.0.1";
-  } else if (host === "::") {
-    displayHost = "::1";
+  if (isUnspecifiedHost(host)) {
+    displayHost = host === "0.0.0.0" ? "127.0.0.1" : "::1";
   }
   const authorityHost = isIPv6(displayHost) ? `[${displayHost}]` : displayHost;
   return `http://${authorityHost}:${port}`;
@@ -132,10 +158,11 @@ export async function startServer(opts: ServeOptions): Promise<ServeHandle> {
   const port = opts.port ?? DEFAULT_PORT;
   const host = opts.host ?? DEFAULT_HOST;
 
-  // issue #172 (C6) — binding to every interface (`0.0.0.0`/`::`) exposes
-  // this server (no auth, arbitrary graph data) to the whole LAN, not just
-  // localhost. `--host` is opt-in, so this is a heads-up, not a refusal.
-  if (host === "0.0.0.0" || host === "::") {
+  // issue #172 (C6) — binding to every interface (`0.0.0.0`/`::` and their
+  // equivalent spellings, see `isUnspecifiedHost` above) exposes this server
+  // (no auth, arbitrary graph data) to the whole LAN, not just localhost.
+  // `--host` is opt-in, so this is a heads-up, not a refusal.
+  if (isUnspecifiedHost(host)) {
     console.error(`warning: binding to ${host} exposes the graph to your network`);
   }
 
@@ -253,6 +280,18 @@ export async function startServer(opts: ServeOptions): Promise<ServeHandle> {
       // OS assigns a free ephemeral port, and the pre-fix code printed
       // "serving at http://host:0", which is not a URL anyone can visit.
       const address = server.address();
+      // PR #346 review (L1) — the `: port` half of this fallback is
+      // unreachable in practice: inside `server.listen()`'s own callback,
+      // `server.address()` always returns a populated `AddressInfo` (never
+      // `null`/a string), so `typeof address === "object"` is always true
+      // here. This is defensive-for-the-type-checker code, not a live
+      // branch — TypeScript's declared return type for `address()` is wider
+      // than what's actually possible at this specific call site. If it were
+      // ever somehow reached, it would display the REQUESTED port (`0` for
+      // `--port 0`) rather than the actual bound port — silently
+      // reintroducing the exact C4 bug this fallback's sibling branch
+      // exists to fix. Known, accepted limitation of an unreachable path,
+      // not something worth guarding further.
       const actualPort = address && typeof address === "object" ? address.port : port;
       const url = formatServeUrl(host, actualPort);
       resolvePromise({

--- a/src/vitest/plugin.ts
+++ b/src/vitest/plugin.ts
@@ -83,6 +83,14 @@ let oxcModule: typeof import("oxc-parser") | undefined;
 // (slow, and — a native dlopen failure being an environment property —
 // certain to fail again) require. Mirrors `src/parsers/typescript.ts`'s
 // identical `oxcLoadError` memo.
+// PR #346 review (M3, recorded) — in a long-lived process (`vitest --watch`,
+// which keeps this module instance alive across reruns), fixing the
+// underlying environment (reinstalling node_modules, matching the
+// platform-specific binding, …) does NOT un-poison this cache — there is no
+// retry path once `oxcLoadFailure` is set, by design (see `loadOxc` below).
+// A process restart is the recovery step; a watch-mode user who fixes their
+// environment still needs to stop and re-run `vitest --watch` for it to take
+// effect.
 let oxcLoadFailure: PluginOxcLoadError | undefined;
 // issue #278 — dedup flag for the dedicated load-failure warning emitted
 // from `transform()`'s catch block below. Module-scope `let`/boolean (NOT
@@ -468,7 +476,23 @@ export default function artgraphTracePlugin(): ArtgraphTracePlugin {
           warnedParseFailures.add(relPath);
           process.stderr.write(
             `[artgraph] trace instrumentation: could not parse ${relPath} — passing through ` +
-              `un-instrumented (contracts/instrumentation-runtime.md §変換のスキップ).\n`,
+              `un-instrumented (contracts/instrumentation-runtime.md §変換のスキップ).\n` +
+              // PR #346 review (H2, minimal) — a single genuinely-broken file
+              // is expected and this per-file warning is the right amount of
+              // signal for that. But this same warning also fires for EVERY
+              // file when the real cause is a partially-broken oxc native
+              // binding that still loads but mis-parses everything (unlike
+              // `PluginOxcLoadError` above, which only covers the binding
+              // failing to LOAD at all) — a failure mode this per-file
+              // warning alone doesn't distinguish from ordinary broken
+              // syntax. Point at the same escape hatch
+              // `PluginOxcLoadError` already documents, so a user staring at
+              // a wall of these has a next step without having to guess.
+              // Deliberately NOT deduped/escalated based on volume (e.g.
+              // "warn once if this fires for every file") — that's a
+              // separate, harder problem (issue #347) left for its own fix.
+              "If this happens for EVERY file, the oxc native binding may be partially broken — " +
+              "try ARTGRAPH_TRACE_ENGINE=cdp as an alternative engine.\n",
           );
         }
         return undefined;

--- a/src/vitest/plugin.ts
+++ b/src/vitest/plugin.ts
@@ -31,9 +31,81 @@ import { REGISTRY_KEY, REGISTRY_VERSION, hashContent, isExcludedRelPath } from "
 // module never needs to touch that file — see the dependency-boundary
 // comment above).
 const requireCjs = createRequire(import.meta.url);
+
+// issue #278 — LOCAL duplicate of `src/parsers/typescript.ts`'s
+// `OxcLoadError` diagnostic text/shape. This file's own top-of-file
+// dependency-boundary comment forbids importing any `src/` module besides
+// `trace/schema.ts` (the two v2-engine halves must share nothing but the
+// `globalThis` registry shape this file writes and the runner reads), so
+// the class and its message are duplicated here — by hand, not by import —
+// rather than reused from `src/parsers/typescript.ts`'s `OxcLoadError`.
+// Keep the cause list / recovery steps in sync with that class's wording if
+// either one changes.
+class PluginOxcLoadError extends Error {
+  constructor(cause: unknown) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(
+      [
+        "[artgraph] trace instrumentation: failed to load the oxc-parser native binding.",
+        'This is DIFFERENT from the per-file "could not parse" warning below — no file can',
+        "be instrumented until the binding loads, so every module transformed by this",
+        "plugin for the rest of THIS PROCESS will pass through un-instrumented (tests still",
+        "run, but no trace evidence is captured for them).",
+        "",
+        `Underlying error: ${detail}`,
+        "",
+        "Likely causes:",
+        "  - oxc-parser's optional platform-specific package was not installed",
+        "  - node_modules is corrupted or only partially installed",
+        "  - the installed native binary does not match this machine's OS/CPU",
+        "    architecture (e.g. a lockfile/install from a different platform, or a",
+        "    Docker image built for a different target)",
+        "",
+        "To resolve, try:",
+        "  1. Reinstall dependencies from scratch (e.g. `rm -rf node_modules` then",
+        "     reinstall with your package manager)",
+        "  2. Confirm oxc-parser's platform-specific optional dependency is present",
+        "     for THIS OS/architecture (check node_modules/@oxc-parser/binding-*)",
+        "  3. If this happens in CI/Docker, make sure the image architecture matches",
+        "     what was used to install/lock dependencies",
+        "",
+        "Alternative: re-run with ARTGRAPH_TRACE_ENGINE=cdp to use the legacy",
+        "inspector-based engine instead, which does not depend on this binding.",
+      ].join("\n"),
+    );
+    this.name = "PluginOxcLoadError";
+  }
+}
+
 let oxcModule: typeof import("oxc-parser") | undefined;
+// issue #278 — negative cache: once `requireCjs("oxc-parser")` has failed,
+// every LATER call re-throws this SAME error instead of re-attempting the
+// (slow, and — a native dlopen failure being an environment property —
+// certain to fail again) require. Mirrors `src/parsers/typescript.ts`'s
+// identical `oxcLoadError` memo.
+let oxcLoadFailure: PluginOxcLoadError | undefined;
+// issue #278 — dedup flag for the dedicated load-failure warning emitted
+// from `transform()`'s catch block below. Module-scope `let`/boolean (NOT
+// a `Set` like `warnedParseFailures` below, and not per-plugin-instance
+// state): the decided design is "warn once per PROCESS", and this file's
+// top-of-file dependency-boundary comment already establishes that
+// `transform()` runs once per module in the MAIN-PROCESS vite-node
+// pipeline, shared across worker forks/threads — a per-relPath `Set` would
+// track the wrong axis (it would re-warn once per DISTINCT file, which
+// silently violates "once per process" the moment more than one file is
+// transformed after the binding breaks). Exactly like
+// `src/parsers/typescript.ts`'s `oxcLoadError` memoization unit.
+let warnedOxcLoadFailure = false;
 function loadOxc(): typeof import("oxc-parser") {
-  return (oxcModule ??= requireCjs("oxc-parser") as typeof import("oxc-parser"));
+  if (oxcLoadFailure) throw oxcLoadFailure;
+  if (oxcModule) return oxcModule;
+  try {
+    oxcModule = requireCjs("oxc-parser") as typeof import("oxc-parser");
+  } catch (e) {
+    oxcLoadFailure = new PluginOxcLoadError(e);
+    throw oxcLoadFailure;
+  }
+  return oxcModule;
 }
 
 // oxc's real AST node union (`@oxc-project/types`) is large and this module
@@ -366,7 +438,29 @@ export default function artgraphTracePlugin(): ArtgraphTracePlugin {
         if (parsed.errors.length > 0) throw new Error("oxc reported parse errors");
         program = parsed.program as unknown as AnyNode;
         visitorKeys = oxc.visitorKeys as unknown as Record<string, readonly string[]>;
-      } catch {
+      } catch (e) {
+        // issue #278: a `PluginOxcLoadError` (the native binding itself
+        // never loaded) is a DIFFERENT failure from an ordinary per-file
+        // parse failure below — no file will ever parse successfully in
+        // this process, so warn ONCE (module-scope `warnedOxcLoadFailure`,
+        // see its doc comment) with the dedicated diagnostic instead of
+        // repeating the misleading "could not parse <file>" warning (the
+        // file was never even handed to the parser) for every subsequent
+        // module.
+        //
+        // `src/vitest/runner.ts` also has a per-WORKER
+        // `warnedNoRegistration` warning ("no module was ever registered by
+        // this worker …") that fires alongside this one when oxc is broken
+        // for the whole run — that's intentional, not redundant: this
+        // warning names the specific cause, runner.ts's is a generic
+        // safety net for ANY reason zero modules got registered.
+        if (e instanceof PluginOxcLoadError) {
+          if (!warnedOxcLoadFailure) {
+            warnedOxcLoadFailure = true;
+            process.stderr.write(`${e.message}\n`);
+          }
+          return undefined;
+        }
         // contract §変換のスキップ: unparseable — pass through un-instrumented
         // rather than fail the build (FR-008, silent skip is what's
         // forbidden, not the skip itself).

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -494,6 +494,81 @@ describe("CLI: scan graph payload", () => {
       rmSync(outDir, { recursive: true, force: true });
     }
   });
+
+  // issue #172 (C3) — `--port` used to be a bare `Number.parseInt`, so
+  // `--port abc` silently fell back to the default (NaN), `--port 3.14`
+  // silently started on port 3, and `--port 3737abc` silently started on
+  // port 3737. All of these are now rejected at PARSE time with a clear
+  // `InvalidArgumentError` message (commander exits 1 before the action
+  // ever runs, so `--serve` never gets a chance to bind).
+  describe("--port validation (issue #172 C3)", () => {
+    it.each([
+      ["abc", /whole number/],
+      ["3.14", /whole number/],
+      ["3737abc", /whole number/],
+      ["70000", /between 0 and 65535/],
+      ["-1", /whole number/],
+    ])("rejects --port %s", async (value, messagePattern) => {
+      const { exitCode, stderr } = await run(["scan", "--serve", "--port", value]);
+      expect(exitCode).toBe(1);
+      expect(stderr).toMatch(messagePattern);
+    });
+
+    // `--port 0` is a legal value (OS auto-assigns a free port, C4) — this
+    // only checks it's ACCEPTED at parse time (not that a server actually
+    // starts and binds; that's the e2e test in
+    // tests/e2e/graph-serve.e2e.test.ts, since --serve keeps the process
+    // alive on the http.Server socket and the in-process runCli harness
+    // can't drive that — see that file's own top-of-file comment).
+  });
+
+  // issue #172 (C1/C8) — flags that are silently ignored on this path now
+  // get a heads-up warning instead (behavior is otherwise unchanged).
+  describe("scan: silently-ignored flag combinations now warn (issue #172 C1/C8)", () => {
+    it("C1: --format json is ignored with --output — warns on stderr", async () => {
+      const outDir = mkdtempSync(join(tmpdir(), "artgraph-c1-output-"));
+      try {
+        const { exitCode, stderr } = await run(["scan", "--format", "json", "--output", outDir]);
+        expect(exitCode).toBe(0);
+        expect(stderr).toContain("--format is ignored with --serve/--output");
+      } finally {
+        rmSync(outDir, { recursive: true, force: true });
+      }
+    });
+
+    it("C1: --format json is not warned about for plain scan (no --serve/--output)", async () => {
+      const { exitCode, stderr } = await run(["scan", "--format", "json"]);
+      expect(exitCode).toBe(0);
+      expect(stderr).not.toContain("--format is ignored");
+    });
+
+    it("C8: --port without --serve warns on stderr (and --output still runs normally)", async () => {
+      const outDir = mkdtempSync(join(tmpdir(), "artgraph-c8-port-"));
+      try {
+        const { exitCode, stderr } = await run(["scan", "--output", outDir, "--port", "4000"]);
+        expect(exitCode).toBe(0);
+        expect(stderr).toContain("--port/--host are ignored without --serve");
+      } finally {
+        rmSync(outDir, { recursive: true, force: true });
+      }
+    });
+
+    it("C8: --host without --serve warns on stderr", async () => {
+      const { exitCode, stderr } = await run(["scan", "--format", "json", "--host", "0.0.0.0"]);
+      expect(exitCode).toBe(0);
+      expect(stderr).toContain("--port/--host are ignored without --serve");
+    });
+
+    it("C8: --port/--host alongside --serve does not warn", async () => {
+      // Validated via the e2e suite's real --serve invocations (which always
+      // pass --port); this just checks the warning doesn't ALSO fire on the
+      // parse-error path (a bad port here would exit 1 before reaching the
+      // warning check, which would be a false negative for this assertion).
+      const { exitCode, stderr } = await run(["scan", "--serve", "--port", "abc"]);
+      expect(exitCode).toBe(1);
+      expect(stderr).not.toContain("--port/--host are ignored without --serve");
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -522,6 +522,23 @@ describe("CLI: scan graph payload", () => {
     // can't drive that — see that file's own top-of-file comment).
   });
 
+  // PR #346 review (H1) — `--host ""` used to reach `server.listen()`
+  // unvalidated, binding all interfaces (like `0.0.0.0`) while skipping the
+  // C6 warning and C7 display substitution (both keyed on exact-string
+  // matches at the time) and printing the malformed `http://:PORT`. A value
+  // with surrounding whitespace is equally malformed. Both are now rejected
+  // at PARSE time by `parseHost`, mirroring `--port`'s validator shape.
+  describe("--host validation (PR #346 review H1)", () => {
+    it.each([
+      ["", /must not be empty/],
+      [" 127.0.0.1", /leading\/trailing whitespace/],
+    ])("rejects --host %j", async (value, messagePattern) => {
+      const { exitCode, stderr } = await run(["scan", "--serve", "--host", value]);
+      expect(exitCode).toBe(1);
+      expect(stderr).toMatch(messagePattern);
+    });
+  });
+
   // issue #172 (C1/C8) — flags that are silently ignored on this path now
   // get a heads-up warning instead (behavior is otherwise unchanged).
   describe("scan: silently-ignored flag combinations now warn (issue #172 C1/C8)", () => {
@@ -559,15 +576,16 @@ describe("CLI: scan graph payload", () => {
       expect(stderr).toContain("--port/--host are ignored without --serve");
     });
 
-    it("C8: --port/--host alongside --serve does not warn", async () => {
-      // Validated via the e2e suite's real --serve invocations (which always
-      // pass --port); this just checks the warning doesn't ALSO fire on the
-      // parse-error path (a bad port here would exit 1 before reaching the
-      // warning check, which would be a false negative for this assertion).
-      const { exitCode, stderr } = await run(["scan", "--serve", "--port", "abc"]);
-      expect(exitCode).toBe(1);
-      expect(stderr).not.toContain("--port/--host are ignored without --serve");
-    });
+    // PR #346 review (M2) — the prior "C8: --port/--host alongside --serve
+    // does not warn" test here passed `--serve --port abc`, which
+    // `parsePort` rejects at PARSE time (commander exits 1 before the
+    // action — and thus the C8 warning check — ever runs). It could not
+    // fail no matter what the C8 logic did, so it had zero discriminating
+    // power. Replaced by the e2e test
+    // "C8: --serve --port 0 --host 127.0.0.1 does not warn that --port/--host
+    // are ignored" in tests/e2e/graph-serve.e2e.test.ts, which drives a real
+    // `--serve` startup (valid flags, so the action actually runs) and
+    // asserts the warning is absent from stderr up to the "serving at" line.
   });
 });
 

--- a/tests/e2e/graph-serve.e2e.test.ts
+++ b/tests/e2e/graph-serve.e2e.test.ts
@@ -268,4 +268,55 @@ describe("e2e: scan --serve", () => {
       expect(code).toBe(0);
     },
   );
+
+  // PR #346 review (M2) — replaces a unit test in tests/cli.test.ts that
+  // paired `--serve` with a deliberately-invalid `--port abc`: `parsePort`
+  // rejects that at PARSE time, so the process exits before the action (and
+  // the C8 "--port/--host are ignored without --serve" check) ever runs —
+  // the old test had no discriminating power, since it could not fail
+  // regardless of what the C8 logic did. This drives a real `--serve`
+  // startup with VALID `--port`/`--host` (so the action, and the C8 check,
+  // actually execute) and asserts the ignored-without-`--serve` warning
+  // never fires — same spawn pattern as the C6 test above, using the
+  // "serving at" line as the startup-complete signal and inspecting stderr
+  // accumulated up to that point.
+  it(
+    "C8: --serve --port 0 --host 127.0.0.1 does not warn that --port/--host are ignored",
+    { timeout: 15000 },
+    async () => {
+      let stderrBuf = "";
+      const proc = spawn("node", [CLI, "scan", "--serve", "--port", "0", "--host", "127.0.0.1"], {
+        cwd: FIXTURE_DIR,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      proc.stdout.on("data", () => {});
+      proc.stderr.on("data", (d: Buffer) => {
+        stderrBuf += d.toString("utf-8");
+      });
+
+      const earlyExit = new Promise<never>((_, reject) => {
+        proc.once("exit", (code) => {
+          reject(new Error(`server exited early with code ${code}; stderr so far: ${stderrBuf}`));
+        });
+      });
+
+      const waitForServing = (async (): Promise<void> => {
+        const deadline = Date.now() + 5000;
+        while (Date.now() < deadline) {
+          if (/serving at/.test(stderrBuf)) return;
+          await new Promise((r) => setTimeout(r, 50));
+        }
+        throw new Error(
+          `did not see a "serving at" line within budget; stderr so far: ${stderrBuf}`,
+        );
+      })();
+      await Promise.race([waitForServing, earlyExit]);
+
+      expect(stderrBuf).not.toContain("ignored");
+
+      proc.kill("SIGINT");
+      const code = await waitExit(proc, 3000);
+      expect(code).toBe(0);
+    },
+  );
 });

--- a/tests/e2e/graph-serve.e2e.test.ts
+++ b/tests/e2e/graph-serve.e2e.test.ts
@@ -168,4 +168,104 @@ describe("e2e: scan --serve", () => {
       expect(code).toBe(0);
     },
   );
+
+  // issue #172 (C4) — before this fix, `--port 0` (ask the OS for a free
+  // ephemeral port) printed the literal requested port back
+  // ("serving at http://127.0.0.1:0"), which is not a URL anyone can visit.
+  // `startServer` now reads the ACTUAL bound port from `server.address()`.
+  // This needs a real listening socket (the in-process `runCli` harness
+  // can't drive `--serve` — see this file's own top-of-file comment), so
+  // it's covered here rather than in the unit suite.
+  it(
+    "T-graph-serve-172-C4: --port 0 prints the real bound port, and that port is reachable",
+    { timeout: 15000 },
+    async () => {
+      let stderrBuf = "";
+      const proc = spawn("node", [CLI, "scan", "--serve", "--port", "0"], {
+        cwd: FIXTURE_DIR,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      proc.stdout.on("data", () => {});
+      proc.stderr.on("data", (d: Buffer) => {
+        stderrBuf += d.toString("utf-8");
+      });
+
+      const earlyExit = new Promise<never>((_, reject) => {
+        proc.once("exit", (code) => {
+          reject(new Error(`server exited early with code ${code}; stderr so far: ${stderrBuf}`));
+        });
+      });
+
+      const waitForServingLine = (async (): Promise<RegExpMatchArray> => {
+        const deadline = Date.now() + 5000;
+        while (Date.now() < deadline) {
+          const match = stderrBuf.match(/serving at http:\/\/127\.0\.0\.1:(\d+)/);
+          if (match) return match;
+          await new Promise((r) => setTimeout(r, 50));
+        }
+        throw new Error(
+          `did not see a "serving at" line within budget; stderr so far: ${stderrBuf}`,
+        );
+      })();
+
+      const match = await Promise.race([waitForServingLine, earlyExit]);
+      const boundPort = Number(match[1]);
+      // The whole point of C4: the OS-assigned port must not be the literal
+      // requested `0` — it must be a real, distinct ephemeral port.
+      expect(boundPort).toBeGreaterThan(0);
+
+      const res = await fetchOnce(`http://127.0.0.1:${boundPort}/`);
+      expect(res.status).toBe(200);
+      expect(res.contentType).toMatch(/text\/html/);
+
+      proc.kill("SIGINT");
+      const code = await waitExit(proc, 3000);
+      expect(code).toBe(0);
+    },
+  );
+
+  // issue #172 (C6) — `--host 0.0.0.0` binds every interface, not just
+  // localhost, exposing the (unauthenticated) graph server to the whole
+  // LAN. `startServer` now prints a one-line heads-up warning when it does.
+  it(
+    "T-graph-serve-172-C6: --host 0.0.0.0 warns about network exposure on stderr",
+    { timeout: 15000 },
+    async () => {
+      let stderrBuf = "";
+      // --port 0: avoids any risk of colliding with the fixed-port test
+      // above under the single-fork e2e config (fileParallelism:false).
+      const proc = spawn("node", [CLI, "scan", "--serve", "--host", "0.0.0.0", "--port", "0"], {
+        cwd: FIXTURE_DIR,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      proc.stdout.on("data", () => {});
+      proc.stderr.on("data", (d: Buffer) => {
+        stderrBuf += d.toString("utf-8");
+      });
+
+      const earlyExit = new Promise<never>((_, reject) => {
+        proc.once("exit", (code) => {
+          reject(new Error(`server exited early with code ${code}; stderr so far: ${stderrBuf}`));
+        });
+      });
+
+      const waitForServing = (async (): Promise<void> => {
+        const deadline = Date.now() + 5000;
+        while (Date.now() < deadline) {
+          if (/serving at/.test(stderrBuf)) return;
+          await new Promise((r) => setTimeout(r, 50));
+        }
+        throw new Error(
+          `did not see a "serving at" line within budget; stderr so far: ${stderrBuf}`,
+        );
+      })();
+      await Promise.race([waitForServing, earlyExit]);
+
+      expect(stderrBuf).toContain("warning: binding to 0.0.0.0 exposes the graph to your network");
+
+      proc.kill("SIGINT");
+      const code = await waitExit(proc, 3000);
+      expect(code).toBe(0);
+    },
+  );
 });

--- a/tests/graph-serve-format-url.test.ts
+++ b/tests/graph-serve-format-url.test.ts
@@ -38,6 +38,19 @@ describe("formatServeUrl (issue #172 C4/C5/C7)", () => {
     expect(formatServeUrl("::", 3737)).toBe("http://[::1]:3737");
   });
 
+  // PR #346 review (M1) — `isUnspecifiedHost` (used by both this function's
+  // C7 substitution and `startServer`'s C6 warning) recognizes every
+  // spelling of the IPv6 unspecified address, not just the exact string
+  // "::" — these two are equivalent binds that used to slip past both
+  // string-equality checks.
+  it("M1: displays ::0 (equivalent IPv6 unspecified spelling) as [::1], bracketed", () => {
+    expect(formatServeUrl("::0", 3737)).toBe("http://[::1]:3737");
+  });
+
+  it("M1: displays 0:0:0:0:0:0:0:0 (fully expanded IPv6 unspecified) as [::1], bracketed", () => {
+    expect(formatServeUrl("0:0:0:0:0:0:0:0", 3737)).toBe("http://[::1]:3737");
+  });
+
   it("passes the port through unchanged, including 0 (caller's responsibility to pass the actual bound port)", () => {
     expect(formatServeUrl("127.0.0.1", 0)).toBe("http://127.0.0.1:0");
   });

--- a/tests/graph-serve-format-url.test.ts
+++ b/tests/graph-serve-format-url.test.ts
@@ -1,0 +1,44 @@
+// issue #172 (C4/C5/C7) — unit tests for `formatServeUrl`, the helper
+// `startServer` uses to build the URL it prints/returns. Exercises the
+// three fixes in isolation (no real HTTP server needed):
+//   C5 — an IPv6 host gets `[...]` bracketing in the URL authority.
+//   C7 — `0.0.0.0` / `::` (bind-only "every interface" addresses) are
+//        display-substituted for a loopback address a user can actually
+//        visit — DISPLAY ONLY, this helper never touches the bind call.
+//   C4 — the caller is expected to pass the ACTUALLY bound port (this
+//        helper just formats whatever port it's given; the "read back
+//        server.address()" half of C4 is covered by the e2e `--port 0` test
+//        in tests/e2e/graph-serve.e2e.test.ts, since that needs a real
+//        listening socket).
+import { describe, expect, it } from "vitest";
+import { formatServeUrl } from "../src/graph/serve.js";
+
+describe("formatServeUrl (issue #172 C4/C5/C7)", () => {
+  it("formats an ordinary IPv4 host/port with no bracketing", () => {
+    expect(formatServeUrl("127.0.0.1", 3737)).toBe("http://127.0.0.1:3737");
+  });
+
+  it("formats a plain hostname with no bracketing", () => {
+    expect(formatServeUrl("localhost", 8080)).toBe("http://localhost:8080");
+  });
+
+  it("C5: brackets an IPv6 loopback address", () => {
+    expect(formatServeUrl("::1", 3737)).toBe("http://[::1]:3737");
+  });
+
+  it("C5: brackets an arbitrary IPv6 literal address", () => {
+    expect(formatServeUrl("2001:db8::1", 4000)).toBe("http://[2001:db8::1]:4000");
+  });
+
+  it("C7: displays 0.0.0.0 as 127.0.0.1 (bind address unaffected, display only)", () => {
+    expect(formatServeUrl("0.0.0.0", 3737)).toBe("http://127.0.0.1:3737");
+  });
+
+  it("C7: displays :: (IPv6 unspecified) as [::1], bracketed", () => {
+    expect(formatServeUrl("::", 3737)).toBe("http://[::1]:3737");
+  });
+
+  it("passes the port through unchanged, including 0 (caller's responsibility to pass the actual bound port)", () => {
+    expect(formatServeUrl("127.0.0.1", 0)).toBe("http://127.0.0.1:0");
+  });
+});

--- a/tests/vitest-plugin-oxc-load-failure.test.ts
+++ b/tests/vitest-plugin-oxc-load-failure.test.ts
@@ -1,0 +1,144 @@
+// issue #278 — before this fix, `src/vitest/plugin.ts`'s `loadOxc()`
+// (`oxcModule ??= requireCjs("oxc-parser")`) retried the native dlopen for
+// EVERY transformed file once oxc-parser's binding failed to load, and each
+// retry's failure was swallowed by `transform()`'s single catch block
+// together with ordinary per-file parse failures — producing a misleading
+// "[artgraph] trace instrumentation: could not parse <file>" warning, once
+// per file, instead of a single diagnostic naming the real cause.
+//
+// These tests mirror `tests/oxc-load-failure.test.ts`'s `Module._load`
+// monkey-patch technique (see that file's doc comment for why this is the
+// only mechanism that actually reaches `createRequire(...).require`'s call
+// site) but drive `src/vitest/plugin.ts`'s `transform()` hook directly,
+// covering the decided design for #278: negative-cache the load failure,
+// warn exactly once per PROCESS (not per file) with a dedicated diagnostic,
+// then pass every subsequent module through un-instrumented.
+//
+// (d) from the design ("an ordinary per-file parse failure — broken syntax,
+// oxc itself loads fine — keeps the pre-existing per-file 'could not parse'
+// warning") is NOT re-tested here: it's already covered by
+// tests/vitest-plugin.test.ts's "fail-soft" describe block, which runs in a
+// separate test-file module instance where oxc genuinely loads. That
+// separation is required, not incidental — see the IMPORTANT note below.
+//
+// IMPORTANT: like `tests/oxc-load-failure.test.ts`, this file's
+// module-scope `oxcLoadFailure` / `warnedOxcLoadFailure` state in
+// `src/vitest/plugin.ts` is poisoned for the lifetime of THIS test file's
+// module instance once the first test below fails to load oxc — every
+// later `transform()` call in this file passes through un-instrumented by
+// design (the negative cache has no "unpoison" path, by design). Vitest
+// isolates module state per test file, so this cannot leak into other
+// suites; this file is kept single-purpose (every test here expects the
+// poisoned state) for the same reason as that file.
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { Module } from "node:module";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import artgraphTracePlugin, { type ArtgraphTracePlugin } from "../src/vitest/plugin.js";
+
+function write(rootDir: string, relPath: string, content: string): string {
+  const abs = join(rootDir, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, content, "utf-8");
+  return abs;
+}
+
+function makePlugin(root: string): ArtgraphTracePlugin {
+  const plugin = artgraphTracePlugin();
+  plugin.configResolved({ root });
+  return plugin;
+}
+
+describe("vitest plugin: oxc-parser load failure (issue #278) — negative cache + dedicated once-per-process warning", () => {
+  let root: string;
+  let requireAttempts = 0;
+  let originalLoad: (typeof Module)["_load"];
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "artgraph-vitest-plugin-oxc-load-fail-"));
+
+    originalLoad = Module._load;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Module as any)._load = function (request: string, ...rest: unknown[]) {
+      if (request === "oxc-parser") {
+        requireAttempts++;
+        throw new Error("simulated missing native binding (ERR_DLOPEN_FAILED)");
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (originalLoad as any).apply(Module, [request, ...rest]);
+    };
+  });
+
+  afterAll(() => {
+    Module._load = originalLoad;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // Restoring in `afterEach` (rather than at the tail of each `it`) means a
+  // failed assertion mid-test still detaches the `process.stderr.write` spy
+  // before the next test runs — otherwise a thrown assertion leaves a stale
+  // spy installed and the next test's own `vi.spyOn` wraps IT instead of the
+  // real `process.stderr.write`, corrupting that test's call count.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("(a)+(b)+(c): warns once on stderr across multiple files' transform() calls, each transform is an un-instrumented pass-through, and dlopen is never retried", () => {
+    const plugin = makePlugin(root);
+    const warn = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const srcA = "export function a() { return 1; }\n";
+    const absA = write(root, "src/oxc-fail-a.js", srcA);
+    const srcB = "export function b() { return 2; }\n";
+    const absB = write(root, "src/oxc-fail-b.js", srcB);
+    const srcC = "export function c() { return 3; }\n";
+    const absC = write(root, "src/oxc-fail-c.js", srcC);
+
+    const resultA = plugin.transform(srcA, absA);
+    const resultB = plugin.transform(srcB, absB);
+    const resultC = plugin.transform(srcC, absC);
+
+    // (b): every transform is an un-instrumented pass-through (undefined).
+    expect(resultA).toBeUndefined();
+    expect(resultB).toBeUndefined();
+    expect(resultC).toBeUndefined();
+
+    // (a): exactly one dedicated warning, not one per file.
+    const calls = warn.mock.calls.map((c) => String(c[0]));
+    const loadFailureWarnings = calls.filter((msg) =>
+      msg.includes("failed to load the oxc-parser native binding"),
+    );
+    expect(loadFailureWarnings.length).toBe(1);
+
+    // Distinguishable from the ordinary per-file parse warning: that
+    // warning's unique, fixed substring (its `§変換のスキップ` contract
+    // reference) never appears in the dedicated load-failure diagnostic.
+    expect(loadFailureWarnings[0]).not.toContain("§変換のスキップ");
+    expect(loadFailureWarnings[0]).toMatch(/un-instrumented/);
+    expect(loadFailureWarnings[0]).toMatch(/ARTGRAPH_TRACE_ENGINE=cdp/);
+
+    // No stray per-file "could not parse <file>" warnings were emitted
+    // instead (that warning's fixed suffix, keyed on the same substring).
+    expect(calls.some((msg) => msg.includes("§変換のスキップ"))).toBe(false);
+
+    // (c): dlopen was attempted exactly once despite 3 transform() calls.
+    expect(requireAttempts).toBe(1);
+  });
+
+  it("a later transform() call (new plugin instance, same process) still doesn't re-warn or retry dlopen", () => {
+    // A fresh plugin instance (as a real second vitest project/config would
+    // create) still shares the module-scope negative cache and warned-once
+    // flag — the design's unit is the PROCESS, not the plugin instance.
+    const plugin = makePlugin(root);
+    const warn = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    const src = "export function d() { return 4; }\n";
+    const abs = write(root, "src/oxc-fail-d.js", src);
+    const result = plugin.transform(src, abs);
+
+    expect(result).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled(); // already warned once earlier in this process
+    expect(requireAttempts).toBe(1); // still no retry
+  });
+});


### PR DESCRIPTION
D-group quick-win sweep, wave 2.

## #278 — vitest plugin: oxc load failure handling (design: warn-once + continue un-instrumented, user-approved)

The capture plugin's own `loadOxc` still had the pre-#263 pattern: a broken oxc-parser native binding was re-`dlopen`'d for every transformed file, and the failure was swallowed by the per-file "could not parse" catch — silently un-instrumenting the whole run (only indirect symptom: mass false-positive `unexercisedClaims`).

Shift-left investigation pinned three implementation constraints, all honored:
- **once-per-process semantics**: `transform()` runs in the main-process vite-node pipeline (shared across worker forks/threads), so a module-scope boolean is the correct dedup unit — not a per-file `Set` like the adjacent `warnedParseFailures`
- **dependency boundary**: `plugin.ts` must not import `src/` modules beyond `trace/schema.ts` (separate lean build artifact) — `PluginOxcLoadError` is a deliberate local duplicate of `typescript.ts`'s `OxcLoadError` diagnostic, cross-referenced by comment
- **catch boundary preserved**: only an `instanceof` branch added inside the existing catch; `instrumentModule()` stays outside it so genuine instrumentation bugs still crash loudly

Also: negative cache (dlopen attempted at most once per process), warning text names the un-instrumented consequence + recovery steps + `ARTGRAPH_TRACE_ENGINE=cdp` alternative, and documents the intentional coexistence with `runner.ts`'s per-worker generic no-registration safety net (runner untouched).

New unit tests (`Module._load` monkey-patch, mirroring `tests/oxc-load-failure.test.ts`): warning fires exactly once across multiple transforms, subsequent transforms pass through, no dlopen retry. Ordinary parse-failure warnings already covered by the existing `vitest-plugin.test.ts` fail-soft block. Real broken-binding e2e is infeasible with the symlink-shared `node_modules` fixture infra (noted, out of scope).

## #172 — `scan --serve` / `--output` CLI polish (PR #155 follow-up)

Every item re-verified against current code first (the issue's line refs predate the #162 command extraction):

| Item | Status | Change |
|---|---|---|
| C3 `--port` validation | still open — worse than reported: `--port 3.14` silently served on **port 3**, `--port abc` silently fell back to 3737 | strict whole-number 0-65535 `InvalidArgumentError` validator |
| C4 `--port 0` shows `:0` URL | still open | display the actually-bound port from `server.address()` |
| C5 IPv6 bracket / C7 `0.0.0.0` display | still open | `formatServeUrl()` — IPv6 `[...]`, display-only `0.0.0.0`→`127.0.0.1`, `::`→`[::1]` (bind unchanged) |
| C6 LAN warning | still open | stderr warning when binding `0.0.0.0`/`::` |
| C1 `--format json --serve` / C8 `--port`/`--host` sans `--serve` | still open | stderr warnings for silently-ignored combos |
| C9 `--kind` wording | **moot** — `--kind` was dropped entirely in the #135 fold-in; nothing to warn about | none |
| C10 `--output ""`/`.` | **already safe** — falsy no-op + #170 unmanaged-dir guard (verified live) | none |
| C11 scan warnings dropped | **already fixed** by #274 with regression test | none |

Tests: `formatServeUrl` unit tests; port-validation + C1/C8 warning tests in `tests/cli.test.ts`; two new e2e tests (`--port 0` real-port reachability over HTTP, `0.0.0.0` warning).

## Verification

- full unit suite 109 files, 2409 passed / 22 skipped, 0 failed
- e2e: graph-serve + vitest-runner suites 52 passed
- `pnpm knip` clean

Closes #278, closes #172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BREZStzmU62xFvKSydGKZV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BREZStzmU62xFvKSydGKZV)_