### PR TITLE
fix(graph): label symbol nodes by symbol name instead of file basename

### DIFF
--- a/src/graph/render.ts
+++ b/src/graph/render.ts
@@ -90,6 +90,27 @@ export function renderGraphData(graph: ArtifactGraph, options: RenderOptions): R
       label = node.label;
     } else if (node.kind === "req") {
       label = node.id;
+    } else if (node.kind === "symbol") {
+      // issue #245 — symbol nodes never carry `node.label` (it is only set for
+      // req/doc/task nodes in parsers/markdown.ts and builder.ts), so without
+      // this branch every symbol falls through to the basename below and a
+      // class plus all of its methods render as the SAME label. spec 021's
+      // method-grain symbols multiply the collision per file.
+      //
+      // Strip the exact `symbol:<filePath>#` prefix rather than splitting on
+      // `#`. A filePath may legally contain `#`, and there `indexOf("#")`
+      // yields the wrong side: `symbol:src/we#ird.ts#Odd` -> `ird.ts#Odd`.
+      // `lastIndexOf("#")` happens to be correct today, but only because
+      // symbol NAMES never contain `#` — private members (`#m`) are dropped by
+      // the `key.type !== "Identifier"` guard in parsers/typescript.ts, an
+      // invariant owned by a different module that this presenter would then
+      // silently depend on. The prefix strip depends on nothing outside here.
+      const prefix = `symbol:${node.filePath}#`;
+      const name = node.id.startsWith(prefix) ? node.id.slice(prefix.length) : "";
+      // Degrade to the full id, never to the basename: an unexpected id shape
+      // (or an empty symbol name) should stay verbose-but-unique rather than
+      // collapse back into the ambiguity this branch exists to remove.
+      label = name.length > 0 ? name : node.id;
     } else {
       label = node.filePath.split("/").pop() ?? node.id;
     }

--- a/src/graph/render.ts
+++ b/src/graph/render.ts
@@ -107,10 +107,20 @@ export function renderGraphData(graph: ArtifactGraph, options: RenderOptions): R
       // silently depend on. The prefix strip depends on nothing outside here.
       const prefix = `symbol:${node.filePath}#`;
       const name = node.id.startsWith(prefix) ? node.id.slice(prefix.length) : "";
-      // Degrade to the full id, never to the basename: an unexpected id shape
-      // (or an empty symbol name) should stay verbose-but-unique rather than
-      // collapse back into the ambiguity this branch exists to remove.
-      label = name.length > 0 ? name : node.id;
+      // Degrade to the full id, never to the basename: an unexpected id shape,
+      // or a name that renders as nothing, should stay verbose-but-unique
+      // rather than collapse back into the ambiguity this branch exists to
+      // remove.
+      //
+      // A non-empty check is not enough here. ES2022 arbitrary module
+      // namespace names make `export { x as " " }` legal, so a symbol name can
+      // be whitespace- or zero-width-only while still having length — it would
+      // then paint a blank node in --serve/--output. `\s` already covers the
+      // space family (TAB/LF/CR/NBSP/U+3000/BOM), but U+200B-U+200D (ZWSP,
+      // ZWNJ, ZWJ) are not whitespace to the regex engine and have to be named.
+      // A lone combining mark still passes: it does render (as a dotted
+      // circle), so it stays a visible—if odd—label rather than degrading.
+      label = /[^\s\u200B-\u200D]/.test(name) ? name : node.id;
     } else {
       label = node.filePath.split("/").pop() ?? node.id;
     }

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1133,6 +1133,47 @@ describe("CLI: symbol mode", () => {
     const result = JSON.parse(stdout);
     expect(result.symbolCount).toBeGreaterThan(0);
   });
+
+  // issue #245 — the unit tests in graph-render.test.ts pin `renderGraphData`
+  // in isolation; this is the crossing cell (symbol mode x `--output` payload)
+  // that carries the fix end-to-end through the real CLI and the template
+  // injection pipeline. src/auth.ts ships three exported functions, so before
+  // the fix all three arrived labelled `auth.ts`.
+  it(
+    "T-graph-serve-6: --output labels same-file symbols distinctly",
+    { timeout: 30000 },
+    async () => {
+      const outDir = mkdtempSync(join(tmpdir(), "artgraph-symbol-label-"));
+      try {
+        const { exitCode } = await runAt(SYM_CONFIG_FIXTURE, ["scan", "--output", outDir]);
+        expect(exitCode).toBe(0);
+
+        const html = readFileSync(join(outDir, "index.html"), "utf-8");
+        const match = html.match(
+          /<script id="artgraph-data" type="application\/json">([\s\S]*?)<\/script>/,
+        );
+        expect(match).not.toBeNull();
+        const data = JSON.parse(match![1]!);
+
+        const authSymbols = (
+          data.nodes as { id: string; label: string; kind: string; filePath: string }[]
+        )
+          .filter((n) => n.kind === "symbol" && n.filePath === "src/auth.ts")
+          .sort((a, b) => (a.id < b.id ? -1 : 1));
+        expect(authSymbols.length).toBeGreaterThanOrEqual(3);
+
+        // No symbol may still be labelled with the file's basename, and the
+        // labels must be pairwise distinct.
+        for (const n of authSymbols) expect(n.label).not.toBe("auth.ts");
+        expect(new Set(authSymbols.map((n) => n.label)).size).toBe(authSymbols.length);
+        expect(authSymbols.map((n) => n.label)).toEqual(
+          expect.arrayContaining(["validateToken", "issueToken", "revokeToken"]),
+        );
+      } finally {
+        rmSync(outDir, { recursive: true, force: true });
+      }
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/graph-render.test.ts
+++ b/tests/graph-render.test.ts
@@ -256,6 +256,92 @@ describe("renderGraphData: label fallback", () => {
     const out = renderGraphData(graph, { rootDir: ".", generatedAt: FIXED_TS });
     expect(out.nodes[0].label).toBe("User can log in");
   });
+
+  // issue #245 — symbol nodes used to fall through to basename(filePath), so a
+  // class and every one of its methods rendered as the same label and were
+  // indistinguishable in --serve/--output.
+  describe("symbol nodes (issue #245)", () => {
+    it("labels symbols by their symbol name, not the file basename", () => {
+      const graph = makeGraph([
+        makeNode({ id: "symbol:src/sample.ts#Sample", kind: "symbol", filePath: "src/sample.ts" }),
+        makeNode({
+          id: "symbol:src/sample.ts#Sample.methodA",
+          kind: "symbol",
+          filePath: "src/sample.ts",
+        }),
+        makeNode({
+          id: "symbol:src/sample.ts#Sample.methodB",
+          kind: "symbol",
+          filePath: "src/sample.ts",
+        }),
+      ]);
+
+      const out = renderGraphData(graph, { rootDir: ".", generatedAt: FIXED_TS });
+      const byId = new Map(out.nodes.map((n) => [n.id, n]));
+      expect(byId.get("symbol:src/sample.ts#Sample")!.label).toBe("Sample");
+      expect(byId.get("symbol:src/sample.ts#Sample.methodA")!.label).toBe("Sample.methodA");
+      expect(byId.get("symbol:src/sample.ts#Sample.methodB")!.label).toBe("Sample.methodB");
+      // The point of the issue: same-file symbols must not collide.
+      expect(new Set(out.nodes.map((n) => n.label)).size).toBe(3);
+    });
+
+    // A filePath may legally contain `#`. Splitting the id on the FIRST `#`
+    // would yield `ird.ts#Odd` here; this pins the prefix-strip behaviour.
+    it("handles a filePath containing '#'", () => {
+      const graph = makeGraph([
+        makeNode({ id: "symbol:src/we#ird.ts#Odd", kind: "symbol", filePath: "src/we#ird.ts" }),
+        makeNode({
+          id: "symbol:src/we#ird.ts#Odd.doThing",
+          kind: "symbol",
+          filePath: "src/we#ird.ts",
+        }),
+      ]);
+
+      const out = renderGraphData(graph, { rootDir: ".", generatedAt: FIXED_TS });
+      const byId = new Map(out.nodes.map((n) => [n.id, n]));
+      expect(byId.get("symbol:src/we#ird.ts#Odd")!.label).toBe("Odd");
+      expect(byId.get("symbol:src/we#ird.ts#Odd.doThing")!.label).toBe("Odd.doThing");
+    });
+
+    it("degrades to the full id when the id does not carry the expected prefix", () => {
+      const graph = makeGraph([
+        makeNode({ id: "symbol:mismatched", kind: "symbol", filePath: "src/other.ts" }),
+        // Empty symbol name — must not render as a blank label.
+        makeNode({ id: "symbol:src/empty.ts#", kind: "symbol", filePath: "src/empty.ts" }),
+      ]);
+
+      const out = renderGraphData(graph, { rootDir: ".", generatedAt: FIXED_TS });
+      const byId = new Map(out.nodes.map((n) => [n.id, n]));
+      expect(byId.get("symbol:mismatched")!.label).toBe("symbol:mismatched");
+      expect(byId.get("symbol:src/empty.ts#")!.label).toBe("symbol:src/empty.ts#");
+    });
+
+    it("still prefers node.label on a symbol node when one is set", () => {
+      const graph = makeGraph([
+        makeNode({
+          id: "symbol:src/sample.ts#Sample",
+          kind: "symbol",
+          filePath: "src/sample.ts",
+          label: "explicit",
+        }),
+      ]);
+
+      const out = renderGraphData(graph, { rootDir: ".", generatedAt: FIXED_TS });
+      expect(out.nodes[0].label).toBe("explicit");
+    });
+
+    it("leaves file nodes on the basename fallback", () => {
+      const graph = makeGraph([
+        makeNode({ id: "file:src/sample.ts", kind: "file", filePath: "src/sample.ts" }),
+        makeNode({ id: "symbol:src/sample.ts#Sample", kind: "symbol", filePath: "src/sample.ts" }),
+      ]);
+
+      const out = renderGraphData(graph, { rootDir: ".", generatedAt: FIXED_TS });
+      const byId = new Map(out.nodes.map((n) => [n.id, n]));
+      expect(byId.get("file:src/sample.ts")!.label).toBe("sample.ts");
+      expect(byId.get("symbol:src/sample.ts#Sample")!.label).toBe("Sample");
+    });
+  });
 });
 
 describe("renderGraphData: state precedence", () => {

--- a/tests/graph-render.test.ts
+++ b/tests/graph-render.test.ts
@@ -316,6 +316,51 @@ describe("renderGraphData: label fallback", () => {
       expect(byId.get("symbol:src/empty.ts#")!.label).toBe("symbol:src/empty.ts#");
     });
 
+    // PR #376 review — a non-empty check is not enough. ES2022 arbitrary module
+    // namespace names (`export { x as " " }`) make whitespace- and zero-width-
+    // only symbol names legal, and those paint a blank node. Every name here is
+    // `length >= 1`, so each one would slip through a bare emptiness guard.
+    //
+    // This asserts at `renderGraphData`, which is the single choke point every
+    // symbol node passes through regardless of which producer synthesised it
+    // (`parsers/typescript.ts`'s six sites and `graph/star-expansion.ts`'s
+    // barrel expansion alike), so the guard is covered for all of them here.
+    it.each([
+      ["single space", " "],
+      ["tab", "\t"],
+      ["newline", "\n"],
+      ["carriage return", "\r"],
+      ["multiple spaces", "   "],
+      ["non-breaking space", "\u00A0"],
+      ["ideographic space", "\u3000"],
+      ["zero-width space", "\u200B"],
+      ["zero-width non-joiner", "\u200C"],
+      ["zero-width joiner", "\u200D"],
+      ["byte order mark", "\uFEFF"],
+      ["mixed blank run", " \u200B\t"],
+    ])("degrades a symbol name that renders as nothing (%s)", (_name, raw) => {
+      const id = `symbol:src/weird.ts#${raw}`;
+      const graph = makeGraph([makeNode({ id, kind: "symbol", filePath: "src/weird.ts" })]);
+
+      const out = renderGraphData(graph, { rootDir: ".", generatedAt: FIXED_TS });
+      expect(out.nodes[0].label).toBe(id);
+      expect(out.nodes[0].label).not.toBe(raw);
+    });
+
+    it("keeps a symbol name that does render, even alongside blank characters", () => {
+      const graph = makeGraph([
+        makeNode({ id: "symbol:src/a.ts# spaced ", kind: "symbol", filePath: "src/a.ts" }),
+        makeNode({ id: "symbol:src/a.ts#\u200Bfn", kind: "symbol", filePath: "src/a.ts" }),
+      ]);
+
+      const out = renderGraphData(graph, { rootDir: ".", generatedAt: FIXED_TS });
+      const byId = new Map(out.nodes.map((n) => [n.id, n]));
+      // Not degraded: these carry visible characters, so the name is kept
+      // verbatim rather than being second-guessed by the presenter.
+      expect(byId.get("symbol:src/a.ts# spaced ")!.label).toBe(" spaced ");
+      expect(byId.get("symbol:src/a.ts#\u200Bfn")!.label).toBe("\u200Bfn");
+    });
+
     it("still prefers node.label on a symbol node when one is set", () => {
       const graph = makeGraph([
         makeNode({


### PR DESCRIPTION
## Summary

`renderGraphData` only ever set `node.label` for req/doc/task nodes (`parsers/markdown.ts`, `builder.ts:431`), so symbol nodes fell through to `basename(filePath)`. A class and every one of its methods rendered as the same label in `scan --serve` / `scan --output`, making same-file symbols indistinguishable — spec 021's method-grain symbols multiply the collision per file.

Symbol nodes now derive their label by stripping the exact `symbol:<filePath>#` prefix from their id, degrading to the full node id when that yields nothing usable.

Measured on artgraph's own source (81 files) with `mode: "symbol"` forced:

| | before | after |
|---|---|---|
| symbol nodes | 475 | 475 |
| distinct labels | **66** | **475** |
| colliding groups | 63 | **0** |
| symbols trapped in a collision | **457 / 475** | **0** |
| worst file | `src/types.ts` — 44 symbols sharing one label | — |

**Why prefix-strip rather than splitting on `#`** (the approach the issue sketched): a filePath may legally contain `#`, and there `indexOf("#")` picks the wrong side — measured, `symbol:src/we#ird.ts#Odd` would yield `ird.ts#Odd`. `lastIndexOf("#")` is correct today, but only because symbol *names* never contain `#` — private members (`#m`) are dropped by the `key.type !== "Identifier"` guard in `parsers/typescript.ts:1247`. That is an invariant owned by a different module, which this presenter would then silently depend on; if private-member support is ever added, `lastIndexOf` breaks with no failing test. The prefix strip depends on nothing outside the function.

**Why the degrade guard is not a non-empty check.** ES2022 arbitrary module namespace names make `export { x as " " }` legal, so a symbol name can be whitespace- or zero-width-only while still having length, and would paint a blank node. The guard asks whether the name renders anything: `\s` covers the space family (TAB/LF/CR/NBSP/U+3000/BOM), and U+200B–U+200D (ZWSP/ZWNJ/ZWJ) are named explicitly because they are not whitespace to the regex engine — a `.trim()`-based check lets those three through. A lone combining mark still passes, since it renders as a dotted circle.

Scoped to `kind === "symbol"`; file/doc/test/req labels are unchanged.

Closes #245

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass
- [x] Added tests where needed
- [x] Ran `knip` and `build`

Unit **2581 passed / 0 failed** (122 files), e2e **122 passed / 0 failed**, plus `typecheck`, `lint`, `format:check`, `knip` — all clean.

Every added test was confirmed to **fail without the corresponding fix**, not merely to pass with it:

| Test | Guards |
|---|---|
| labels symbols by symbol name | The reported symptom; 3 same-file symbols get 3 distinct labels |
| filePath containing `#` | The `indexOf` trap above |
| degrades to the full id | Unexpected id shape + empty symbol name |
| **12 × renders-as-nothing** (space, tab, LF, CR, NBSP, U+3000, ZWSP, ZWNJ, ZWJ, BOM, mixed) | The blank-label defect. Each name is `length >= 1`, so each defeats a bare emptiness check |
| keeps names that do render | The guard does not over-degrade names that merely contain blanks |
| `node.label` still preferred | Branch precedence — this one passes with or without the fix by design; it is not a regression guard |
| file nodes stay on basename | The change does not leak past `kind === "symbol"` |
| `cli.test.ts` `T-graph-serve-6` | **Crossing cell**: symbol mode × `--output`, end-to-end through the real CLI and template injection. Without the fix: `expected 'auth.ts' not to be 'auth.ts'` |

End-to-end check of the blank-alias case through the built CLI: `export { spacey as " ", blank as "", zw as "", ok as "realName" }` yields three full-id labels and one `realName`.

The degenerate-name tests assert at `renderGraphData` — the single choke point every symbol node passes through regardless of producer — so `graph/star-expansion.ts`'s barrel expansion, which inherits origin-side alias names verbatim, is covered by the same guard.

**Correction to an earlier version of this description:** it claimed dogfood `artgraph check --diff` exit 0 as supporting evidence. That was true but vacuous — `check` never reaches `renderGraphData` (it is dynamically imported only under `scan`'s `--serve`/`--output` branch), and artgraph's own `.artgraph.json` leaves `mode` unset, so it runs in file mode where symbol nodes are never emitted. The real evidence is the tests above plus the forced-symbol-mode measurement.

## Breaking change

- [ ] Yes (described below)
- [x] No

`label` is consumed only by the `--serve` / `--output` renderings. It is absent from `lock.ts`, `check.ts` and `baseline.ts`, so no gate verdict, exit code or lock content can change. Browser search (`templates/graph/app.js:348`) matches on `id.includes(query) || label.includes(query)`; the filename leaves the label but remains in the id, so filename search still resolves.

## Notes

Adversarial review and meta-review surfaced three items deliberately left out of this PR:

- **`ownerFilePath()` (`src/trace/report.ts:508`) has the same root cause** — it uses `indexOf("#")` and returns `"src/we"` for `symbol:src/we#ird.ts#Odd` (measured). Different subsystem (trace join keys), so the blast radius is far wider than this presenter fix. Note `builder.ts:1113` already uses `lastIndexOf` for the same split, so `report.ts` is the outlier.
- **`if (node.label)` shares the same non-empty-check shape**, and `doc` node ids come from user-controlled frontmatter (`parsers/markdown.ts:227`). A `node_id: ""` makes both the id *and* the label a zero-width string — worse than the symbol case, since the graph's primary key becomes invisible. Out of scope here (`markdown.ts` is untouched).
- **The edge visual distinction** floated in #245 (dashed rendering for symbol→symbol `contains`) is a `templates/graph/app.js` browser-UI change with a separate verification story — that file has no test coverage today.

One tooling hazard worth recording: `src/graph/star-expansion.ts` embeds a literal NUL byte in a cache key, so ripgrep classifies it as binary and **silently omits it from cross-file searches**. A `grep -r 'kind: "symbol"' src/` therefore reports 6 symbol-producing sites when there are 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)