### PR TITLE
fix(parser): let the class win a declaration merge, and treat .d.ts as ambient

### DIFF
--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -1216,9 +1216,20 @@ type OxcComment = OxcParseResult["comments"][number];
 function extractClassMembers(
   classNode: unknown,
   classPrefix: string,
+  ambientFile: boolean,
 ): Map<string, Array<{ start: number; end: number }>> {
   const members = new Map<string, Array<{ start: number; end: number }>>();
-  if ((classNode as { declare?: boolean }).declare) return members;
+  // issue #248 — a declaration file's top-level declarations are implicitly
+  // ambient per the TS spec even without the keyword, but oxc reports
+  // `declare: false` unless it is literally written. `tsc --declaration`
+  // emits `export declare class`, so generated files were already caught by
+  // the per-node flag below; hand-written `.d.ts` in the keyword-omitting
+  // style slipped through and had its bodyless signatures symbolized as if
+  // they were real methods. Gate MEMBER extraction only: the file's top-level
+  // symbols stay registered exactly as before, because the per-node guard
+  // never touched those either and dropping them would regress the
+  // already-correct generated-file case.
+  if (ambientFile || (classNode as { declare?: boolean }).declare) return members;
   const body = (classNode as { body?: { body?: Array<Record<string, unknown>> } }).body?.body;
   if (!body) return members;
 
@@ -1281,6 +1292,10 @@ function extractSymbols(
   const entries: ExportEntry[] = [];
   const seen = new Set<string>();
   let groupCounter = 0;
+  // issue #248 — the default `include: ["src/**/*.ts"]` matches declaration
+  // files, whose top-level declarations are ambient with or without the
+  // keyword. Computed once per file and passed to `extractClassMembers`.
+  const ambientFile = /\.d\.(?:ts|mts|cts)$/.test(relPath);
   const push = (
     name: string,
     start: number,
@@ -1305,7 +1320,42 @@ function extractSymbols(
       // Exception: interface / namespace entries declaration-merge with a
       // same-name class in legal TS, so a collision where either side is
       // such an entry stays silent (`mergeableWithClass`).
-      const existing = entries.find((e) => e.name === name);
+      // Skip entries already demoted to loser: they no longer own the name.
+      const existingIdx = entries.findIndex((e) => e.name === name && !e.collisionLoser);
+      const existing = existingIdx === -1 ? undefined : entries[existingIdx];
+
+      // issue #251 — class × interface/namespace declaration merge, class
+      // written SECOND. first-registered-wins would drop the class outright,
+      // taking its member symbols with it and hashing the node off the
+      // interface/namespace text instead. TS puts the implementation on the
+      // class side, so the class has to own the node.
+      //
+      // Demote the earlier declaration to `collisionLoser` rather than
+      // discarding it: a loser still contributes its attribution RANGE under
+      // the same name (see the range loop below), so an `@impl` tag written
+      // above the interface half keeps resolving to `symbol:<path>#<name>` —
+      // which is now the class's node. Replacing the entry outright would
+      // move the attribution range onto the class's own (later) span and
+      // silently demote that tag to file grain.
+      //
+      // Class-written-FIRST is untouched: `existing` is then the class, which
+      // is not `mergeableWithClass`, so this branch does not fire and the
+      // pre-existing drop stands.
+      if (existing?.mergeableWithClass && classMembers !== undefined) {
+        entries[existingIdx] = { ...existing, collisionLoser: true };
+        entries.push({
+          name,
+          start,
+          end,
+          group,
+          attrStart,
+          attrEnd,
+          classMembers,
+          mergeableWithClass,
+        });
+        return;
+      }
+
       if (
         existing &&
         !existing.mergeableWithClass &&
@@ -1375,7 +1425,7 @@ function extractSymbols(
               // `export { Sample }` / alias exports resolve via `lookup()`
               // above and never reach this branch, so they stay
               // member-symbol-free (FR-001's "分離 export は対象外").
-              extractClassMembers(decl, className),
+              extractClassMembers(decl, className, ambientFile),
             );
           }
         } else if (decl.type === "TSInterfaceDeclaration") {
@@ -1432,7 +1482,7 @@ function extractSymbols(
           groupCounter++,
           undefined,
           undefined,
-          extractClassMembers(decl, "default"),
+          extractClassMembers(decl, "default", ambientFile),
         );
       } else if (decl.type === "TSInterfaceDeclaration") {
         push("default", stmt.start, decl.end, groupCounter++);

--- a/tests/typescript.test.ts
+++ b/tests/typescript.test.ts
@@ -1357,9 +1357,26 @@ describe("createTSParser (symbol mode — class-level seen-collision warnings, P
         "",
       ].join("\n"),
     );
-    // Three-way merge in the one ordering TypeScript accepts (a namespace may
-    // not precede the class it merges with — TS2434). Pins a known limitation,
-    // see the test below.
+    // Class-first two-way merge with a tag on the non-class half. Pins the
+    // same known limitation as the three-way fixture below, in its smallest
+    // reproducing shape — no third declaration required.
+    write(
+      "src/merge-classfirst-tagged.ts",
+      [
+        "// @impl REQ-961",
+        "export class CF {",
+        "  m(): void {}",
+        "}",
+        "// @impl REQ-962",
+        "export interface CF {",
+        "  y: number;",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    // Three-way merge. TypeScript accepts any ordering that keeps the namespace
+    // after the class (ICN / CIN / CNI); the three namespace-first orderings are
+    // TS2434. Pins a known limitation, see the test below.
     write(
       "src/merge-triple.ts",
       [
@@ -1500,13 +1517,23 @@ describe("createTSParser (symbol mode — class-level seen-collision warnings, P
     expect(implEdges.map((e) => e.source)).toEqual(["symbol:src/merge-tagged.ts#Tagged"]);
   });
 
-  // KNOWN LIMITATION, pinned rather than fixed. `collisionLoser` holds one
-  // winner and one loser, so in a three-way merge the third declaration is
-  // still dropped whole — its attribution range included — and a tag above it
-  // falls back to file grain with no warning. Unchanged from before the
-  // class-wins rule (which only moved the CLASS off file grain); tracked
-  // separately. Pinned so that a future change to the demotion logic has to
-  // update this expectation deliberately.
+  // KNOWN LIMITATION, pinned rather than fixed — smallest reproducing shape.
+  // The demotion only fires one way (interface/namespace first, class second).
+  // When the CLASS is written first it already owns the entry, so the later
+  // half hits the original unconditional drop and loses its attribution range,
+  // sending a tag above it to file grain with no warning. Unchanged by the
+  // class-wins rule; tracked separately.
+  it("class-first merge: a tag on the non-class half degrades to file grain", () => {
+    const result = parse();
+    const sourceFor = (req: string) =>
+      result.edges.filter((e) => e.kind === "implements" && e.target === req).map((e) => e.source);
+
+    expect(sourceFor("REQ-961")).toEqual(["symbol:src/merge-classfirst-tagged.ts#CF"]); // class
+    expect(sourceFor("REQ-962")).toEqual(["file:src/merge-classfirst-tagged.ts"]); // interface
+  });
+
+  // The three-way case is the same gap with one more declaration: `collisionLoser`
+  // holds one winner and one loser, so a third declaration is dropped whole.
   it("three-way merge: the third declaration's tag still degrades to file grain", () => {
     const result = parse();
     const sourceFor = (req: string) =>

--- a/tests/typescript.test.ts
+++ b/tests/typescript.test.ts
@@ -1341,6 +1341,22 @@ describe("createTSParser (symbol mode — class-level seen-collision warnings, P
         "",
       ].join("\n"),
     );
+    // issue #251 — an `@impl` tag above the LOSING (interface) half. The class
+    // takes over the node, but the interface must keep contributing its
+    // attribution range, or this tag silently degrades to file grain.
+    write(
+      "src/merge-tagged.ts",
+      [
+        "// @impl REQ-251",
+        "export interface Tagged {",
+        "  y: number;",
+        "}",
+        "export class Tagged {",
+        "  m(): void {}",
+        "}",
+        "",
+      ].join("\n"),
+    );
   });
 
   afterAll(() => {
@@ -1416,6 +1432,129 @@ describe("createTSParser (symbol mode — class-level seen-collision warnings, P
   it("legal interface+class declaration merge does NOT warn (interface first)", () => {
     const result = parse();
     expect(result.warnings.filter((w) => w.filePath === "src/merge-iface.ts")).toEqual([]);
+  });
+
+  // issue #251 — first-registered-wins used to drop the class outright when the
+  // interface was written first, taking its member symbols with it and hashing
+  // the surviving node off the INTERFACE text. TS puts the implementation on
+  // the class, so the class has to own the node.
+  it("interface+class merge (interface first): the class wins the node and keeps member grain", () => {
+    const result = parse();
+    const symbolIds = result.nodes
+      .filter((n) => n.kind === "symbol" && n.filePath === "src/merge-iface.ts")
+      .map((n) => n.id)
+      .sort();
+    expect(symbolIds).toEqual([
+      "symbol:src/merge-iface.ts#MergedI",
+      "symbol:src/merge-iface.ts#MergedI.m",
+    ]);
+  });
+
+  it("interface+class merge (interface first): the node hashes the CLASS body, not the interface", () => {
+    const result = parse();
+    const node = result.nodes.find((n) => n.id === "symbol:src/merge-iface.ts#MergedI");
+    // The class declaration, verbatim — if the interface still owned the node
+    // this would be `export interface MergedI {\n  y: number;\n}`.
+    expect(node!.contentHash).toBe(hash("export class MergedI {\n  m(): void {}\n}"));
+  });
+
+  // The class-written-FIRST ordering already kept member grain before this
+  // change; pinned so the #251 branch cannot silently alter it.
+  it("class+namespace merge (class first) is unaffected by the class-wins rule", () => {
+    const result = parse();
+    const symbolIds = result.nodes
+      .filter((n) => n.kind === "symbol" && n.filePath === "src/merge-ns.ts")
+      .map((n) => n.id)
+      .sort();
+    expect(symbolIds).toEqual(["symbol:src/merge-ns.ts#Merged", "symbol:src/merge-ns.ts#Merged.m"]);
+  });
+
+  // The demoted interface keeps contributing its attribution range, so the tag
+  // resolves to `symbol:…#Tagged` — the id the class now registers. Handing the
+  // range to the class's own (later) span instead would drop this to
+  // `file:src/merge-tagged.ts` with no warning.
+  it("interface+class merge: an @impl above the losing half stays at symbol grain", () => {
+    const result = parse();
+    const implEdges = result.edges.filter((e) => e.kind === "implements" && e.target === "REQ-251");
+    expect(implEdges.map((e) => e.source)).toEqual(["symbol:src/merge-tagged.ts#Tagged"]);
+  });
+});
+
+// issue #248 — a declaration file's top-level declarations are ambient with or
+// without the keyword, but oxc only sets `declare: true` when it is literally
+// written. `tsc --declaration` emits `export declare class`, so generated files
+// were already handled; hand-written declaration files were not.
+describe("createTSParser (symbol mode — ambient declaration files, issue #248)", () => {
+  let root: string;
+
+  const write = (relPath: string, content: string): void => {
+    const abs = join(root, relPath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  };
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "artgraph-dts-248-"));
+    write(
+      "src/hand.d.ts",
+      [
+        "export class Widget {",
+        "  method(): void;",
+        "}",
+        "export function helper(): void;",
+        "",
+      ].join("\n"),
+    );
+    write(
+      "src/gen.d.ts",
+      [
+        "export declare class Gadget {",
+        "  method(): void;",
+        "}",
+        "export declare function gadgetHelper(): void;",
+        "",
+      ].join("\n"),
+    );
+    write("src/real.ts", ["export class Real {", "  method(): void {}", "}", ""].join("\n"));
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  const parse = () => createTSParser(root, ["src/**/*.ts"], "symbol").parse();
+  const idsFor = (filePath: string) =>
+    parse()
+      .nodes.filter((n) => n.kind === "symbol" && n.filePath === filePath)
+      .map((n) => n.id)
+      .sort();
+
+  it("a hand-written .d.ts fabricates no member symbols for its bodyless signatures", () => {
+    expect(idsFor("src/hand.d.ts")).toEqual([
+      "symbol:src/hand.d.ts#Widget",
+      "symbol:src/hand.d.ts#helper",
+    ]);
+  });
+
+  // The narrow fix gates MEMBER extraction only. Skipping the whole file would
+  // also drop these top-level symbols, regressing a case that already worked.
+  it("keeps the declaration file's top-level symbols", () => {
+    expect(idsFor("src/hand.d.ts")).toContain("symbol:src/hand.d.ts#Widget");
+    expect(idsFor("src/hand.d.ts")).toContain("symbol:src/hand.d.ts#helper");
+  });
+
+  it("a tsc-generated .d.ts (explicit declare) is unchanged", () => {
+    expect(idsFor("src/gen.d.ts")).toEqual([
+      "symbol:src/gen.d.ts#Gadget",
+      "symbol:src/gen.d.ts#gadgetHelper",
+    ]);
+  });
+
+  it("an ordinary .ts file still gets member grain", () => {
+    expect(idsFor("src/real.ts")).toEqual([
+      "symbol:src/real.ts#Real",
+      "symbol:src/real.ts#Real.method",
+    ]);
   });
 });
 

--- a/tests/typescript.test.ts
+++ b/tests/typescript.test.ts
@@ -1357,6 +1357,27 @@ describe("createTSParser (symbol mode — class-level seen-collision warnings, P
         "",
       ].join("\n"),
     );
+    // Three-way merge in the one ordering TypeScript accepts (a namespace may
+    // not precede the class it merges with — TS2434). Pins a known limitation,
+    // see the test below.
+    write(
+      "src/merge-triple.ts",
+      [
+        "// @impl REQ-951",
+        "export interface Triple {",
+        "  y: number;",
+        "}",
+        "// @impl REQ-952",
+        "export class Triple {",
+        "  m(): void {}",
+        "}",
+        "// @impl REQ-953",
+        "export namespace Triple {",
+        "  export const x = 1;",
+        "}",
+        "",
+      ].join("\n"),
+    );
   });
 
   afterAll(() => {
@@ -1477,6 +1498,23 @@ describe("createTSParser (symbol mode — class-level seen-collision warnings, P
     const result = parse();
     const implEdges = result.edges.filter((e) => e.kind === "implements" && e.target === "REQ-251");
     expect(implEdges.map((e) => e.source)).toEqual(["symbol:src/merge-tagged.ts#Tagged"]);
+  });
+
+  // KNOWN LIMITATION, pinned rather than fixed. `collisionLoser` holds one
+  // winner and one loser, so in a three-way merge the third declaration is
+  // still dropped whole — its attribution range included — and a tag above it
+  // falls back to file grain with no warning. Unchanged from before the
+  // class-wins rule (which only moved the CLASS off file grain); tracked
+  // separately. Pinned so that a future change to the demotion logic has to
+  // update this expectation deliberately.
+  it("three-way merge: the third declaration's tag still degrades to file grain", () => {
+    const result = parse();
+    const sourceFor = (req: string) =>
+      result.edges.filter((e) => e.kind === "implements" && e.target === req).map((e) => e.source);
+
+    expect(sourceFor("REQ-951")).toEqual(["symbol:src/merge-triple.ts#Triple"]); // interface (loser)
+    expect(sourceFor("REQ-952")).toEqual(["symbol:src/merge-triple.ts#Triple"]); // class (winner)
+    expect(sourceFor("REQ-953")).toEqual(["file:src/merge-triple.ts"]); // namespace — the gap
   });
 });
 


### PR DESCRIPTION
## Summary

Two defects in `extractSymbols`, shipped together because **fixing only #251 makes #248 measurably worse** (see Sequencing below).

**#251 — class × interface/namespace declaration merge, class written second.** `push()`'s first-registered-wins dropped the class outright, taking its member symbols with it and hashing the surviving node off the interface/namespace text. TypeScript puts the implementation on the class side, so the class has to own the node.

The earlier declaration is now demoted to `collisionLoser` rather than discarded, reusing the mechanism PR #242 built for class-member collisions. A loser still contributes its attribution **range** under the same name, so an `@impl` written above the interface half keeps resolving to `symbol:<path>#<name>` — which is now the class's node. Replacing the entry outright would move the attribution range onto the class's own, later span and **silently demote that tag to file grain**; that failure mode was measured before choosing this shape. Class-written-first is untouched — it already kept member grain.

**#248 — hand-written declaration files.** A `.d.ts`'s top-level declarations are ambient with or without the keyword, but oxc reports `declare: false` unless it is literally written. `tsc --declaration` emits `export declare class`, so generated files were already caught by the existing per-node guard; hand-written `.d.ts` in the keyword-omitting style had its bodyless signatures symbolized as if they were real methods. Member extraction is now gated on the file extension as well.

Top-level symbols stay registered exactly as before. Skipping the whole file was the other candidate, but it also drops `Widget`/`helper` — regressing the generated-file case the issue itself calls already-correct.

Closes #251
Closes #248

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass
- [x] Added tests where needed
- [x] Ran `knip` and `build`

Unit **2591 passed / 0 failed** (122 files), e2e **122 passed / 0 failed**, `typecheck` / `lint` / `format:check` / `knip` clean.

Measured on one fixture carrying all four shapes:

| symbol node | before | after |
|---|---|---|
| `merge.ts#C` | present (interface-derived, `c427c135a6abd5c1`) | present (**class-derived, `b85fb3b7140af523`**) |
| `merge.ts#C.m`, `#C.other` | **absent** | **present** |
| `hand.d.ts#Widget.method` | **present (phantom)** | **absent** |
| `hand.d.ts#Widget`, `#helper` | present | present |
| `gen.d.ts#Gadget`, `#gadgetHelper` | present | present |
| `mergeclassfirst.ts#D`, `#D.m` | present | present |
| `implements` edge for a tag above the interface | `symbol:…#C -> REQ-777` | **identical** |

Ten tests added. Measured against `origin/main`, **four** fail without the fix:

- the class wins the node and keeps member grain
- the node hashes the **class** body, not the interface
- a hand-written `.d.ts` fabricates no member symbols
- the three-way merge pin — it also asserts the *class* half resolves at symbol grain, which is #251's fix

The remaining six pass with or without this diff, by design. Two are worth calling out:

- **tag attribution**: passes against `main` because the interface currently owns the node anyway, but it fails against the naive slot-replace implementation of #251 — exactly the trap it exists to catch.
- **class-first merge** and **three-way merge**: pin *known limitations* rather than fixes. See Notes.

## Breaking change

- [ ] Yes (described below)
- [x] No

No API or CLI surface changes, but this **changes the graph's symbol node set**, so `.trace.lock` entries move: `#C` rehashes, `C.m`/`C.other` appear, `Widget.method` disappears.

**Run `artgraph reconcile` right after upgrading, before the next PR that touches an affected symbol.** This is more urgent than a routine lock refresh, for two measured reasons:

1. Plain `check` / `check --gate` goes red immediately on upgrade with **zero source changes** (exit 2, `DRIFT: symbol:…#Tagged`). Projects using `--gate` in a Stop hook see this before they see anything else.
2. Worse, if reconcile is skipped, `check --diff --gate` then **hides a genuinely new edit** to the same symbol — reproduced end-to-end twice, independently, by rewriting a method body and watching `newIssues.drifted: []`, `pass: true`, `exit 0`, with a control run confirming that reconciling first restores `exit 2`. `computeBaselineIssues` rescans the base ref with the already-upgraded parser and `driftKey` carries no hash component, so both sides disagree with the lock identically and the drift is subtracted as pre-existing, indefinitely.

Point 2 is **#383** — pre-existing spec 017 behaviour that would have applied to specs 018–021's parser changes too, so it is filed rather than fixed here. But this PR is what makes projects encounter it, so it belongs in this section rather than buried in the notes.

## Notes

Also surfaced and deliberately kept out of this diff:

- **The issue text for #251 is partly wrong.** It says namespace-before-class behaves the same way, but a namespace may not precede the class it merges with — **TS2434**. Verified against this repo's own `typescript@7.0.2` across all six three-way permutations: `CIN`, `CNI` and `ICN` compile; `INC`, `NCI`, `NIC` do not.
- **#385** — the demotion fires one way only (interface/namespace first, class second). When the class is written **first** it already owns the entry, so the later half hits the original unconditional drop, loses its attribution range, and a tag above it goes to file grain with no warning. This needs only **two** declarations; the three-way case is the same gap with one more. Unchanged by this PR, which only moved the class off file grain. Both shapes are pinned by tests here so a future change to the demotion logic has to update the expectations deliberately. Widening the demotion is the obvious fix but it moves `implements` edge sources from `file:` to `symbol:` for existing class-first merges, which wants measuring on its own.
- **Trace evidence exclusivity** can reclassify a REQ when `trace.acceptExercises` is on (default off) as per-method ids replace a single converged one. Source-read only, not measured — not filed, and not used to justify anything in this diff.

`src/trace/symbol-table.ts` re-derives class members from the AST independently of `extractSymbols` and knows nothing about `ambientFile` or `collisionLoser`. Checked rather than assumed, by two reviewers independently: its `symbolIds.has(memberSymbolId) ? memberSymbolId : classSymbolId` existence-guard makes it track this change automatically — `resolve(…, "m")` returns the new `#Tagged.m`, and a `.d.ts` bodyless signature falls back to the class id instead of dangling. `src/vitest/plugin.ts` is the only other independent AST walker (confirmed by an exhaustive `--text` grep, which matters here because four files in this repo carry raw NUL bytes and drop out of a default cross-file search); it is structurally unaffected, since a bodyless declaration fails its `if (!body) return` guard and a `.d.ts` never reaches Vite's transform hook. `declare module "x" { … }` bodies never reach `extractSymbols` at all — it only walks `program.body`.

## Sequencing

These are one PR rather than two because landing #251 alone is a **measured regression**: in a hand-written `.d.ts` written interface-then-class, the class starts winning and its bodyless signature then gets symbolized as a method — 1 phantom symbol becomes 2. If they are ever split, #248 must land first and no release may ship with only #251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)