### PR TITLE
fix(trace,graph): split symbol ids on the last `#`, in all four places at once

### DIFF
--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -1111,16 +1111,25 @@ export function buildGraph(
       if (edge.kind !== "imports" || !edge.target.startsWith("symbol:")) continue;
       if (nodes.has(edge.target)) continue;
       const body = edge.target.slice("symbol:".length);
+      const rel = symbolIdOwnerPath(body);
+      // Symbol name for the message below. Deliberately the same `lastIndexOf`
+      // the helper uses, so the two halves of one id can never disagree; the
+      // `-1 + 1 === 0` case keeps a `#`-less body reported whole, as before.
       const hashIdx = body.lastIndexOf("#");
-      const rel = hashIdx === -1 ? body : body.slice(0, hashIdx);
       const fileId = `file:${rel}`;
       // Source file the consumer's import lives in — the `file:<consumer>`
       // side of the edge — is the useful location for the observability
       // warning ("this file's import of X was rewritten / left dangling").
+      //
+      // issue #377 — the source side used `.split("#")[0]`, cutting at the
+      // FIRST `#`, while the target side above already used `lastIndexOf`.
+      // Nine lines apart, same function, opposite behaviour on a filePath
+      // containing `#`. Both now go through one helper so they cannot drift
+      // apart again.
       const sourceFile = edge.source.startsWith("file:")
         ? edge.source.slice("file:".length)
         : edge.source.startsWith("symbol:")
-          ? edge.source.slice("symbol:".length).split("#")[0]
+          ? symbolIdOwnerPath(edge.source.slice("symbol:".length))
           : edge.source;
       if (nodes.has(fileId)) {
         edges[i] = { ...edge, target: fileId };
@@ -1580,6 +1589,19 @@ function extractSpecDir(relFilePath: string, specDirs: string[]): string {
     }
   }
   return basename(dirname(relFilePath));
+}
+
+// The repo-relative path out of a `symbol:` id's body (the part after the
+// `symbol:` prefix). issue #377 — split on the LAST `#`: a filePath may legally
+// contain `#`, so cutting at the first one truncates the path. Symbol names
+// never contain `#` (private members are dropped by the `key.type !==
+// "Identifier"` guard in parsers/typescript.ts), which is what makes the last
+// `#` the separator. Where a node's own `filePath` is in scope, prefer
+// stripping the exact `symbol:<filePath>#` prefix instead — that depends on
+// nothing outside the call site (see graph/render.ts, trace/symbol-table.ts).
+function symbolIdOwnerPath(body: string): string {
+  const hashIdx = body.lastIndexOf("#");
+  return hashIdx === -1 ? body : body.slice(0, hashIdx);
 }
 
 function remapId(id: string, idMapping: Map<string, string>, collidingIds: Set<string>): string {

--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -1111,11 +1111,16 @@ export function buildGraph(
       if (edge.kind !== "imports" || !edge.target.startsWith("symbol:")) continue;
       if (nodes.has(edge.target)) continue;
       const body = edge.target.slice("symbol:".length);
-      const rel = symbolIdOwnerPath(body);
-      // Symbol name for the message below. Deliberately the same `lastIndexOf`
-      // the helper uses, so the two halves of one id can never disagree; the
-      // `-1 + 1 === 0` case keeps a `#`-less body reported whole, as before.
-      const hashIdx = body.lastIndexOf("#");
+      // issue #377 review (finding 2) — `rel` (the file-grain degrade target,
+      // functionally load-bearing) and `symbolName` (display-only, used only
+      // in the message below) used to come from two INDEPENDENT
+      // `body.lastIndexOf("#")` calls on the same `body`. Both already agreed
+      // (both used `lastIndexOf`), but two independent computations of one
+      // split point is the same shape that let the target/source asymmetry
+      // below drift apart un-noticed before this issue's fix. Both halves now
+      // come from one `splitSymbolId` call so they cannot silently diverge if
+      // the split point itself ever changes.
+      const { ownerPath: rel, symbolName } = splitSymbolId(body);
       const fileId = `file:${rel}`;
       // Source file the consumer's import lives in — the `file:<consumer>`
       // side of the edge — is the useful location for the observability
@@ -1124,12 +1129,12 @@ export function buildGraph(
       // issue #377 — the source side used `.split("#")[0]`, cutting at the
       // FIRST `#`, while the target side above already used `lastIndexOf`.
       // Nine lines apart, same function, opposite behaviour on a filePath
-      // containing `#`. Both now go through one helper so they cannot drift
-      // apart again.
+      // containing `#`. Both now go through the same helper so they cannot
+      // drift apart again.
       const sourceFile = edge.source.startsWith("file:")
         ? edge.source.slice("file:".length)
         : edge.source.startsWith("symbol:")
-          ? symbolIdOwnerPath(edge.source.slice("symbol:".length))
+          ? splitSymbolId(edge.source.slice("symbol:".length)).ownerPath
           : edge.source;
       if (nodes.has(fileId)) {
         edges[i] = { ...edge, target: fileId };
@@ -1137,7 +1142,7 @@ export function buildGraph(
           type: "phantom-import-repaired",
           id: edge.target,
           files: [sourceFile],
-          message: `named import of "${body.slice(hashIdx + 1)}" through re-export barrel resolved to file grain (target file: ${rel})`,
+          message: `named import of "${symbolName}" through re-export barrel resolved to file grain (target file: ${rel})`,
         });
       } else {
         // File node itself is out of scan scope (target under an exclude
@@ -1591,17 +1596,35 @@ function extractSpecDir(relFilePath: string, specDirs: string[]): string {
   return basename(dirname(relFilePath));
 }
 
-// The repo-relative path out of a `symbol:` id's body (the part after the
-// `symbol:` prefix). issue #377 — split on the LAST `#`: a filePath may legally
-// contain `#`, so cutting at the first one truncates the path. Symbol names
-// never contain `#` (private members are dropped by the `key.type !==
-// "Identifier"` guard in parsers/typescript.ts), which is what makes the last
-// `#` the separator. Where a node's own `filePath` is in scope, prefer
-// stripping the exact `symbol:<filePath>#` prefix instead — that depends on
-// nothing outside the call site (see graph/render.ts, trace/symbol-table.ts).
-function symbolIdOwnerPath(body: string): string {
+// Split a `symbol:` id's body (the part after the `symbol:` prefix) into its
+// repo-relative owner path and its symbol name. issue #377 — split on the
+// LAST `#`: a filePath may legally contain `#`, so cutting at the first one
+// truncates the path. Symbol names never contain `#` (private members are
+// dropped by the `key.type !== "Identifier"` guard in parsers/typescript.ts),
+// which is what makes the last `#` the separator.
+//
+// Both halves come out of this ONE call so a caller needing both (the
+// phantom-repair warning below wants the path for the file-grain degrade AND
+// the name for its message) cannot end up computing them from two independent
+// `lastIndexOf` calls that could silently drift apart if this split point
+// ever changes — precisely how issue #377 happened in the first place.
+//
+// A `#`-less body has no separator: `ownerPath` reports the whole body
+// (pre-existing behavior, unchanged), and `symbolName` — via plain
+// `body.slice(hashIdx + 1)` where `hashIdx === -1` — happens to equal that
+// same whole body too. That fallback is a side effect of the arithmetic, not
+// a guarantee; a caller that wants a standalone symbol name for a body that
+// might lack `#` should not lean on it.
+//
+// Where a node's own `filePath` is in scope, prefer stripping the exact
+// `symbol:<filePath>#` prefix instead — that depends on nothing outside the
+// call site (see graph/render.ts, trace/symbol-table.ts).
+function splitSymbolId(body: string): { ownerPath: string; symbolName: string } {
   const hashIdx = body.lastIndexOf("#");
-  return hashIdx === -1 ? body : body.slice(0, hashIdx);
+  return {
+    ownerPath: hashIdx === -1 ? body : body.slice(0, hashIdx),
+    symbolName: body.slice(hashIdx + 1),
+  };
 }
 
 function remapId(id: string, idMapping: Map<string, string>, collidingIds: Set<string>): string {

--- a/src/trace/ingest.ts
+++ b/src/trace/ingest.ts
@@ -407,7 +407,13 @@ export function resolveTraceGraphNodeId(
   if (nodes.has(nodeId)) return nodeId;
   if (nodeId.startsWith("symbol:")) {
     const body = nodeId.slice("symbol:".length);
-    const hashIdx = body.indexOf("#");
+    // issue #377 — split on the LAST `#`, not the first. A filePath may
+    // legally contain `#`, and cutting at the first one produces a path no
+    // node carries, so the file-grain fallback below misses and the caller
+    // drops the evidence with no warning at all. No filePath is available
+    // here — deriving one from the id is this function's whole purpose — so
+    // the prefix-strip used in trace/symbol-table.ts is not an option.
+    const hashIdx = body.lastIndexOf("#");
     const relPath = hashIdx === -1 ? body : body.slice(0, hashIdx);
     const fileId = `file:${relPath}`;
     if (nodes.has(fileId)) return fileId;

--- a/src/trace/report.ts
+++ b/src/trace/report.ts
@@ -509,7 +509,13 @@ export function ownerFilePath(nodeId: string): string | undefined {
   if (nodeId.startsWith("file:")) return nodeId.slice("file:".length);
   if (nodeId.startsWith("symbol:")) {
     const rest = nodeId.slice("symbol:".length);
-    const hashIdx = rest.indexOf("#");
+    // issue #377 — split on the LAST `#`, not the first. A filePath may
+    // legally contain `#`, and cutting at the first one returns a truncated
+    // path, so the grain-crossing join this function exists for silently
+    // fails to match. No filePath is available here — deriving one from the
+    // id is the whole point — so the prefix-strip used in
+    // trace/symbol-table.ts is not an option.
+    const hashIdx = rest.lastIndexOf("#");
     return hashIdx === -1 ? rest : rest.slice(0, hashIdx);
   }
   return undefined;

--- a/src/trace/symbol-table.ts
+++ b/src/trace/symbol-table.ts
@@ -210,10 +210,16 @@ export function buildSymbolNameTable(
   }
   for (const node of nodes) {
     if (node.kind !== "symbol") continue;
-    const hashIdx = node.id.indexOf("#");
-    if (hashIdx === -1) continue;
+    // issue #377 — strip the exact `symbol:<filePath>#` prefix instead of
+    // splitting on the first `#`. A filePath may legally contain `#`, and
+    // `indexOf` then cuts inside the path, corrupting the member name.
+    // `node.filePath` is right here, so no `#`-splitting heuristic is needed
+    // at all — the technique graph/render.ts uses, and unlike `lastIndexOf` it
+    // does not lean on symbol names never containing `#`.
+    const prefix = `symbol:${node.filePath}#`;
+    if (!node.id.startsWith(prefix)) continue;
     symbolIds.add(node.id);
-    addCandidate(node.filePath, node.id.slice(hashIdx + 1), node.id);
+    addCandidate(node.filePath, node.id.slice(prefix.length), node.id);
   }
 
   // Source 2: class member names -> the MEMBER's own symbol id when one was

--- a/src/trace/symbol-table.ts
+++ b/src/trace/symbol-table.ts
@@ -216,6 +216,14 @@ export function buildSymbolNameTable(
     // `node.filePath` is right here, so no `#`-splitting heuristic is needed
     // at all — the technique graph/render.ts uses, and unlike `lastIndexOf` it
     // does not lean on symbol names never containing `#`.
+    //
+    // Not behaviorally equivalent to the old `indexOf` split for a node whose
+    // `id` and `filePath` disagree, though: the old code was fail-OPEN (still
+    // registered a wrong candidate and added to `symbolIds`); this `continue`
+    // is fail-CLOSED (drops the node from both, silently). Unreached via the
+    // current parser API — every symbol node's `id` and `filePath` are built
+    // from the same `relPath` (parsers/typescript.ts) — so this is a latent
+    // asymmetry, not a live bug.
     const prefix = `symbol:${node.filePath}#`;
     if (!node.id.startsWith(prefix)) continue;
     symbolIds.add(node.id);

--- a/tests/barrel-reexport.test.ts
+++ b/tests/barrel-reexport.test.ts
@@ -649,6 +649,50 @@ describe("#189 observability: phantom-import-repaired / dangling-import warnings
 });
 
 // ---------------------------------------------------------------------------
+// issue #377 review (finding 1) — the phantom-repair pass's `sourceFile`
+// computation (builder.ts, right above `symbol-mode fail-safe repair`) has a
+// THIRD arm that only fires when the DANGLING edge's own `source` is itself a
+// `symbol:` id, not the far more common `file:` case the tests above exercise
+// (a consumer file importing from a barrel). That shape arises when the
+// dangling edge is the barrel's OWN materialized named re-export
+// (`symbol:<barrel>#name --imports--> symbol:<origin>#name`, built directly
+// by the parser for `export { name } from "./origin"`) rather than a
+// downstream consumer's import of the barrel. No test anywhere in this repo
+// exercised that arm before this one — reverting ONLY builder.ts's #377 fix
+// left the full suite green.
+// ---------------------------------------------------------------------------
+
+describe("#377 phantom-import-repaired sourceFile when the dangling edge's SOURCE is itself a symbol: id", () => {
+  it("keeps a `#`-containing barrel path intact in `files` and `.message` (not truncated at the first `#`)", () => {
+    // `src/we#ird/star.ts` re-exports a name `src/origin.ts` does not
+    // actually export, so the barrel's OWN re-export edge dangles —
+    // `symbol:src/we#ird/star.ts#missing --imports--> symbol:src/origin.ts#missing`
+    // — and its `source` is a `symbol:` id, not `file:`. Before the fix,
+    // `sourceFile` came from `edge.source.slice("symbol:".length).split("#")[0]`,
+    // which cuts at the FIRST `#` and truncates "src/we#ird/star.ts#missing"
+    // down to just "src/we".
+    const root = makeRepo({
+      "src/origin.ts": "export function real() {}\n",
+      "src/we#ird/star.ts": 'export { missing } from "../origin";\n',
+    });
+    const { warnings } = buildGraph(root, loadConfig(root));
+    const phantom = warnings.find(
+      (w: BuildWarning) =>
+        w.type === "phantom-import-repaired" && w.id === "symbol:src/origin.ts#missing",
+    );
+    expect(phantom).toBeDefined();
+    expect(phantom!.files).toEqual(["src/we#ird/star.ts"]);
+    // Also pins finding 2: `rel` (functional, the file-grain degrade target)
+    // and the symbol name (display-only, below) now come from ONE
+    // `splitSymbolId` call instead of two independent `lastIndexOf`s that
+    // could silently drift apart if the split point ever changes.
+    expect(phantom!.message).toBe(
+      'named import of "missing" through re-export barrel resolved to file grain (target file: src/origin.ts)',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // specs/018-reexport-symbol-precision §11 — builder-integrated star expansion.
 // Phase 1 shipped the parser (S2/S3) + `expandStarReexports` pure module +
 // `starExports` side-channel. Phase 2 wires expansion into `buildGraph` so

--- a/tests/symbol-table.test.ts
+++ b/tests/symbol-table.test.ts
@@ -90,3 +90,59 @@ describe("buildSymbolNameTable survives a pathologically deep-bracket-nesting fi
     });
   });
 });
+
+// issue #377 — a repo-relative path may legally contain `#`. Four sites split a
+// `symbol:<path>#<name>` id on the FIRST `#`, which cuts inside such a path.
+//
+// These four sites masked each other: `buildSymbolNameTable` corrupted the
+// candidate NAME (`ird.ts#weird` instead of `weird`), the symbol-grain lookup
+// therefore missed, and the file-grain fallback — which uses the caller's own
+// relPath and so happened to be right — covered it up. Repairing that site
+// alone makes the now-correct `symbol:` id flow into `resolveTraceGraphNodeId`,
+// which (unrepaired) computes `file:src/we` and finds nothing, dropping the
+// evidence with no warning. So these assertions belong together: they fail if
+// any one of the sites regresses on its own.
+describe("symbol id splitting with `#` in the file path (issue #377)", () => {
+  let root: string;
+  const WEIRD = "src/we#ird.ts";
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), "artgraph-377-"));
+    write(
+      root,
+      WEIRD,
+      ["export function weird(): void {}", "export class Odd {", "  m(): void {}", "}", ""].join(
+        "\n",
+      ),
+    );
+    write(root, "src/plain.ts", ["export function fn(): void {}", ""].join("\n"));
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("resolves a top-level symbol at symbol grain, not via the file fallback", () => {
+    const { table } = buildSymbolNameTable(root, ["src/**/*.ts"], ["tests/**/*.test.ts"]);
+    // Before the fix this was {kind: "file-fallback", id: "file:src/we#ird.ts"}
+    // — accidentally the right file, but the wrong grain, and only correct
+    // because the name had been corrupted badly enough to miss entirely.
+    expect(table.resolve(WEIRD, "weird")).toEqual({
+      kind: "symbol",
+      id: `symbol:${WEIRD}#weird`,
+    });
+  });
+
+  it("still resolves class members in such a file", () => {
+    const { table } = buildSymbolNameTable(root, ["src/**/*.ts"], ["tests/**/*.test.ts"]);
+    expect(table.resolve(WEIRD, "m")).toEqual({ kind: "symbol", id: `symbol:${WEIRD}#Odd.m` });
+  });
+
+  it("leaves paths without `#` untouched", () => {
+    const { table } = buildSymbolNameTable(root, ["src/**/*.ts"], ["tests/**/*.test.ts"]);
+    expect(table.resolve("src/plain.ts", "fn")).toEqual({
+      kind: "symbol",
+      id: "symbol:src/plain.ts#fn",
+    });
+  });
+});

--- a/tests/symbol-table.test.ts
+++ b/tests/symbol-table.test.ts
@@ -94,14 +94,25 @@ describe("buildSymbolNameTable survives a pathologically deep-bracket-nesting fi
 // issue #377 — a repo-relative path may legally contain `#`. Four sites split a
 // `symbol:<path>#<name>` id on the FIRST `#`, which cuts inside such a path.
 //
-// These four sites masked each other: `buildSymbolNameTable` corrupted the
-// candidate NAME (`ird.ts#weird` instead of `weird`), the symbol-grain lookup
-// therefore missed, and the file-grain fallback — which uses the caller's own
-// relPath and so happened to be right — covered it up. Repairing that site
-// alone makes the now-correct `symbol:` id flow into `resolveTraceGraphNodeId`,
-// which (unrepaired) computes `file:src/we` and finds nothing, dropping the
-// evidence with no warning. So these assertions belong together: they fail if
-// any one of the sites regresses on its own.
+// Two of those four sites masked each other IN PRODUCTION: this file's
+// `buildSymbolNameTable` corrupted the candidate NAME (`ird.ts#weird` instead
+// of `weird`), so the symbol-grain lookup missed — and the file-grain
+// fallback (derived from the caller's own relPath, not from the corrupted
+// id, so it happened to still be right) covered the miss up. Repairing this
+// site alone would have made the now-correct `symbol:` id flow downstream
+// into `trace/ingest.ts`'s `resolveTraceGraphNodeId`, which — left
+// unrepaired — computes `file:src/we` and finds nothing, silently dropping
+// the evidence. That masking relationship is specific to the
+// symbol-table -> ingest pair; the other two sites the same bug also hit
+// (`graph/builder.ts`'s phantom-repair `sourceFile`, and `trace/report.ts`'s
+// `ownerFilePath`) are independent call sites, not links in this chain.
+//
+// Each of the four sites now has its own dedicated regression test, so
+// reverting any ONE site alone fails at least that one test: this describe
+// block for symbol-table.ts, tests/trace-ingest.test.ts's own "issue #377"
+// describe block for ingest.ts's `resolveTraceGraphNodeId` and report.ts's
+// `ownerFilePath`, and tests/barrel-reexport.test.ts's "#377
+// phantom-import-repaired sourceFile ..." describe block for builder.ts.
 describe("symbol id splitting with `#` in the file path (issue #377)", () => {
   let root: string;
   const WEIRD = "src/we#ird.ts";

--- a/tests/trace-ingest.test.ts
+++ b/tests/trace-ingest.test.ts
@@ -7,7 +7,9 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, unlinkSync } from "node:
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { loadConfig } from "../src/config.js";
-import { ingestTrace, type IngestedTrace } from "../src/trace/ingest.js";
+import { ingestTrace, resolveTraceGraphNodeId, type IngestedTrace } from "../src/trace/ingest.js";
+import { ownerFilePath } from "../src/trace/report.js";
+import type { GraphNode } from "../src/types.js";
 import { extractReqTags } from "../src/test-results.js";
 import { SCHEMA_VERSION, type ShardMetaRecord, type ShardTestRecord } from "../src/trace/schema.js";
 
@@ -462,5 +464,50 @@ describe("(f) N:M union across tests, dedup, and shuffle-determinism", () => {
         reqsByNode: [...r.reqsByNode.entries()].map(([k, v]) => [k, [...v].sort()]),
       });
     expect(serialize(forward)).toBe(serialize(reversed));
+  });
+});
+
+// issue #377 — see tests/symbol-table.test.ts for the full story. These pin the
+// two id-splitting sites that have no `filePath` in scope and therefore rely on
+// splitting at the LAST `#`.
+describe("symbol id splitting with `#` in the file path (issue #377)", () => {
+  const WEIRD = "src/we#ird.ts";
+  const fileNode = (path: string): GraphNode => ({
+    id: `file:${path}`,
+    kind: "file",
+    filePath: path,
+    contentHash: "h",
+  });
+
+  it("resolveTraceGraphNodeId falls back to the right file node", () => {
+    const nodes = new Map<string, GraphNode>([
+      [`file:${WEIRD}`, fileNode(WEIRD)],
+      ["file:src/plain.ts", fileNode("src/plain.ts")],
+    ]);
+    // Splitting at the first `#` asks for `file:src/we`, which no node carries,
+    // so this returned undefined and the caller dropped the evidence silently.
+    expect(resolveTraceGraphNodeId(`symbol:${WEIRD}#weird`, nodes)).toBe(`file:${WEIRD}`);
+    expect(resolveTraceGraphNodeId("symbol:src/plain.ts#fn", nodes)).toBe("file:src/plain.ts");
+  });
+
+  it("resolveTraceGraphNodeId still prefers an exact node match", () => {
+    const exact: GraphNode = {
+      id: `symbol:${WEIRD}#weird`,
+      kind: "symbol",
+      filePath: WEIRD,
+      contentHash: "h",
+    };
+    const nodes = new Map<string, GraphNode>([
+      [exact.id, exact],
+      [`file:${WEIRD}`, fileNode(WEIRD)],
+    ]);
+    expect(resolveTraceGraphNodeId(exact.id, nodes)).toBe(exact.id);
+  });
+
+  it("ownerFilePath returns the whole path", () => {
+    expect(ownerFilePath(`symbol:${WEIRD}#weird`)).toBe(WEIRD);
+    expect(ownerFilePath(`symbol:${WEIRD}#Odd.m`)).toBe(WEIRD);
+    expect(ownerFilePath(`file:${WEIRD}`)).toBe(WEIRD);
+    expect(ownerFilePath("symbol:src/plain.ts#fn")).toBe("src/plain.ts");
   });
 });


### PR DESCRIPTION
## Summary

A repo-relative path may legally contain `#`. Four sites split a `symbol:<path>#<name>` id on the **first** `#`, cutting inside such a path. Symbol names never contain `#` (private members are dropped by the `key.type !== "Identifier"` guard in `parsers/typescript.ts`), so the **last** `#` is the separator.

| Site | Before | After |
|---|---|---|
| `src/trace/symbol-table.ts` | `node.id.indexOf("#")` | strip the exact `symbol:${node.filePath}#` prefix |
| `src/trace/ingest.ts` (`resolveTraceGraphNodeId`) | `body.indexOf("#")` | `lastIndexOf` |
| `src/trace/report.ts` (`ownerFilePath`) | `rest.indexOf("#")` | `lastIndexOf` |
| `src/graph/builder.ts` | `.split("#")[0]` | shared file-local helper |

Closes #377

## Why all four in one commit

Two of the four masked each other **in production**. `buildSymbolNameTable` corrupted the candidate name — `ird.ts#weird` instead of `weird` — so the symbol-grain lookup missed entirely and fell through to the file-grain fallback. That fallback derives its answer from the caller's own `relPath` rather than from the corrupted id, so it happened to be right. Measured against `origin/main`:

```
resolve("src/we#ird.ts", "weird")  ->  {kind: "file-fallback", id: "file:src/we#ird.ts"}
```

Repair that one site and the now-correct `symbol:` id flows into `resolveTraceGraphNodeId`, which — unrepaired — computes `file:src/we`, finds nothing, and **drops the evidence with no warning**. The Step 0-pre for this issue measured that partial state end to end: `exercisableUncovered` loses the REQ, `impact --tests` returns `testsToRun: []`, and `staleGate` flips to a false positive.

That masking chain is specific to the `symbol-table.ts -> ingest.ts` pair. `report.ts` and `builder.ts` are independent call sites hit by the same bug, not links in the chain. Each of the four now carries its own regression test, so fixing or reverting any single one in isolation is caught — see the matrix under Testing.

## Why two different techniques

PR #376 fixed this class of bug in `graph/render.ts` by stripping the exact `symbol:${node.filePath}#` prefix rather than splitting, because `lastIndexOf` leans on an invariant owned by a *different* module (symbol names never containing `#`).

That is available wherever `filePath` is already in scope — `trace/symbol-table.ts` has `node.filePath` right there in the same loop, so it uses the prefix strip and needs no cross-module invariant. It is **not** behavior-preserving in every case, though: for a node whose `id` and `filePath` disagree, the old `indexOf` split was fail-open (registered a wrong candidate anyway) while the prefix strip is fail-closed (drops it silently from both the candidate table and `symbolIds`). Every symbol node builds its `id` and `filePath` from the same `relPath` in `parsers/typescript.ts`, so this is unreachable through the current parser API — a latent asymmetry, not a live bug. It is now noted in the code.

The two trace functions whose entire purpose is deriving a path *from* an id have no filePath to work with, so `lastIndexOf` is the realistic best there.

`graph/builder.ts` had **both forms nine lines apart in one function** — the target side already used `lastIndexOf` while the source side used `.split("#")[0]`. Both now go through one file-local `splitSymbolId` helper that returns the path and the symbol name from a single split, so a caller needing both cannot compute them twice and drift apart.

`parsers/markdown.ts` also splits on the first `#` and is deliberately untouched: it strips a URL fragment, where the first `#` is correct per the URL spec.

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass
- [x] Added tests where needed
- [x] Ran `knip` and `build`

Unit **2603 passed / 0 failed** (122 files), e2e **122 passed / 0 failed**, `typecheck` / `lint` / `format:check` clean.

Paths **without** `#` are unaffected — verified byte-identical on a frozen corpus (`git archive origin/main`, forced to symbol mode):

```
before  680a4ed5f7c2bea99e42e5aa7ee995f00b219c75
after   680a4ed5f7c2bea99e42e5aa7ee995f00b219c75
```

Seven tests added — three in `symbol-table.test.ts`, three in `trace-ingest.test.ts`, one in `barrel-reexport.test.ts`. Discriminating power, each site reverted to `origin/main` **alone** with the other three left fixed:

| Site reverted alone | Failing |
|---|---|
| `src/trace/symbol-table.ts` | 1 |
| `src/trace/ingest.ts` | 1 |
| `src/trace/report.ts` | 1 |
| `src/graph/builder.ts` | 1 |
| All four reverted | 3 |

Per check 18, the new fixtures were checked against the dogfood graph: `orphans` stays at 128 and the `coverage` status distribution is unchanged (444 untagged / 48 impl-only), and no fixture string matches `@impl` / `[ID]` / `req:`.

### End-to-end, through the CLI

Verified against real `node dist/cli.js` runs on throwaway projects, comparing a build of this branch against a build of `origin/main`.

**`trace report` reported a false negative.** A project with `// @impl REQ-100` on `doThing()` in `src/mod#a.ts`, plus a real trace shard recording a passing `[REQ-100]` test that hits it:

```
old:  UNEXERCISED CLAIM:
        REQ-100 -> symbol:src/mod#a.ts#doThing

new:  CORROBORATED:
        REQ-100 -> symbol:src/mod#a.ts#doThing
```

The test was passing and the evidence was on disk; artgraph could not see it, because the corrupted candidate name meant the lookup never matched. This is the user-visible shape of the bug.

**`impact --tests` dropped the test entirely.**

```
old:  (no "Tests to run:" section at all)
new:  Tests to run:
        tests/mod.test.ts :: does the hashed thing [REQ-100]  (REQ-100)
```

**`phantom-import-repaired` truncated the path**, matching the new unit test:

```
old:  "files": ["src/we"]
new:  "files": ["src/we#ird/star.ts"]
```

**INV-L4 holds for paths without `#`.** Both CLI builds run over this repository produce byte-identical output — `check --format json` and the 845 KB `scan --format json` both match on sha256, exit 0, empty stderr. (Verified on Linux only; cross-OS is left to CI.)

One honest limitation: in **file mode** the `ingest.ts` and `report.ts` fixes produce no observable CLI difference on a single fresh scan. `resolve()` degrades to `file:${relPath}`, built from the raw argument without splitting, so the repaired code path is not reached that way. Their unit tests call `resolveTraceGraphNodeId` / `ownerFilePath` directly for this reason.

## Breaking change

- [ ] Yes (described below)
- [x] No

Nothing changes for paths without `#`, which is every path in this repo and in any ordinary project. For paths **with** `#`, trace evidence that was previously resolved at file grain now resolves at symbol grain — more precise, and the reason the fix exists.

Two scope clarifications from review, both measured:

- **Class members were already correct before this fix.** `buildSymbolNameTable`'s class-member pass rebuilds ids from `relPath` directly and checks `symbolIds` for exact membership, so it never went through the broken split. `resolve("src/we#ird.ts", "m")` returned `symbol:src/we#ird.ts#Odd.m` on `origin/main` too. The real-world damage was confined to **top-level exports**.
- **In file mode the final graph is unchanged.** The raw `ingestTrace().trace` does differ (`reqsByNode` keys split from one `file:` entry into per-symbol entries), but `filterTraceToGraph`'s output and the final `exercises` edges are byte-identical, because `filterTraceToGraph` unions `reqsByNode` when several ids collapse onto one resolved id and `dedupEdges` folds the duplicates. That is a documented property of those functions, not an artifact of the fixture.

## Review findings addressed

Adversarial review found the original atomicity claim **false for `src/graph/builder.ts`**: reverting that file alone left the entire suite green — 2602 tests, 122 files, zero failures. Nothing anywhere exercised the bug it fixed.

The reason is narrow. builder.ts's diff touches two spots, and the target side (`rel`) already used `lastIndexOf` before this branch — that part is a pure refactor into the shared helper. The actual bug was the source side, which feeds only the `phantom-import-repaired` warning's `files` field, and its `symbol:` arm fires only when the dangling edge's own **source** is a `symbol:` id. That arises for a barrel's own materialized named re-export, not for the consumer-imports-barrel shape every existing test used. Instrumenting the branch and running unit + e2e (2724 tests) hit it zero times.

The follow-up commit adds a test for exactly that shape — a barrel at `src/we#ird/star.ts` re-exporting a name `src/origin.ts` does not export. Reverting builder.ts alone now fails it with `files: ["src/we"]` against the expected `["src/we#ird/star.ts"]`, and the test pins `.message` too, which nothing did before.

Also corrected: the `#377` comment in `tests/symbol-table.test.ts` claimed the assertions were a mutual guard. They never were — they are four independent tests, and until this commit only three of the four sites had one.

## Notes

**This is a strict improvement, not a complete fix.** `parsers/sdd-files.ts` (`Files:` sections) and `commands/shared.ts` (`impact`'s CLI `path:symbol` argument) share the regex `/^([^:\s]+\.[\w]+):([^\s,()]+)$/`, whose symbol token does not exclude `#`. Measured: `extractFiles("Files: src/foo.ts:some#name", …)` is accepted with no warning, which can construct `symbol:src/foo.ts#some#name` — two `#`, where `lastIndexOf` also splits in the wrong place. No reachable path exploits it today: `resolveStartIds` matches `graph.nodes.has(symId)` exactly and routes a miss to `unresolvedSymbols`, so the failure is visible rather than silent. Tightening those regexes is separate work; this PR does not claim to close it.

Scope grew from 2 sites to 4 during Step 0-pre. The issue originally listed only `report.ts` and `builder.ts`; the two `trace/` sites — and the fact that they cancel out — came from the investigation. #377 has been rewritten to match.

### Correction: how many `lastIndexOf` sites exist

An earlier revision of this description said "five `lastIndexOf` sites". That was wrong; there are **six files** (seven occurrences): `baseline.ts`, `builder.ts` (×2 before this branch collapsed them to one helper), `star-expansion.ts`, `parse-cache.ts`, `ingest.ts`, `report.ts`. `render.ts:103` mentions `lastIndexOf("#")` in a comment only and is not a site.

The miscount came from two independent errors that nearly cancelled:

```
rg -l 'lastIndexOf\("#"\)' src          -> 5 files
rg -l --text 'lastIndexOf\("#"\)' src   -> 7 files
```

ripgrep's default binary classification silently dropped **two** NUL-containing files — `src/graph/star-expansion.ts` and `src/trace/ingest.ts` — and the 7 it did return include `render.ts`'s comment. So `6 - 2 + 1 = 5`.

One of the two silently dropped files is `src/trace/ingest.ts`, which **this PR modifies**. The completeness audit lost a file the change was actively editing. This is the blind spot check 17 in `artgraph-graph-primitive-impact` already documents, including the `-a` / `--text` remedy — the check was accurate and simply was not applied.

Also filed **#389** from the same investigation: `git grep -- 'src/**/*.ts'` silently skips files directly under `src/` (git pathspec `*` does not cross `/`), a second, independent way a cross-file audit loses files. Two of the six sites — `baseline.ts` and `parse-cache.ts` — are invisible to that pathspec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)