### PR TITLE
fix(check): drift keys discriminate by content, not just nodeId

### DIFF
--- a/specs/017-check-gate-baseline-diff/data-model.md
+++ b/specs/017-check-gate-baseline-diff/data-model.md
@@ -117,11 +117,21 @@ export function computeBaselineIssues(
 **キー生成 (R4, SSOT)**: `src/baseline.ts` に単一の `issueKey()` 群を置き、current 側の差分計算も同じ関数を使う。
 
 ```ts
-export const driftKey = (d: DriftEntry) => `drift:${d.nodeId}`;
+export const driftKey = (d: DriftEntry) => `drift:${JSON.stringify([d.nodeId, d.currentHash])}`;
 export const orphanKey = (o: OrphanEdge) => `orphan:${formatOrphan(o)}`;
 export const uncoveredKey = (id: string) => `uncovered:${id}`;
 export const testfailKey = (id: string) => `testfail:${id}`;
 ```
+
+issue #383 (research.md R4 supersession, 2026-07-26): `driftKey` は当初の
+`drift:<nodeId>` から `nodeId`+`currentHash` の JSON ペアへ変更された —
+id-only キーでは base 時点で既に drift していたノードへの実編集が同一キーに
+畳み込まれ無期限に抑制されるバグがあったため。`lockedHash` はキーに含まない
+(baseline 側と current 側が同一 lock オブジェクトを見る前提で判別力を持たない
+— `src/baseline.ts` の `BaselineIssues.keys` JSDoc参照)。JSON エンコードにす
+る理由は、`currentHash` が常に固定長 16-hex とは限らず (読み取り不能ファイル
+の sentinel が `:` を含みうる) プレーン連結では単射性が構造的に保証できない
+ため。
 
 ---
 

--- a/specs/017-check-gate-baseline-diff/plan.md
+++ b/specs/017-check-gate-baseline-diff/plan.md
@@ -37,7 +37,7 @@
 - **baseline は global に計算する**: current issue は scoped (blast radius)。baseline は base graph 全体の orphan / uncovered / drift をキー集合化。`new = current issue のうち baseline キー集合に無いもの`。base ref 側で scope を再計算しないので単純かつ漏れがない。
 - **drift の baseline は現在の lock を基準**: `.trace.lock` は gitignore で worktree に来ないため (FR-011)。base graph を現在の lock と比較して得た drift を baseline drift とする。
 - **worktree は `git worktree add --detach <tmp> <ref>` → scan → `git worktree remove --force`**: `git stash` は使わない (FR-004)。
-- **issue 同一性キー**: `drift:<nodeId>` / `orphan:<source -> target (kind)>` / `uncovered:<reqId>` / `testfail:<reqId>`。
+- **issue 同一性キー**: `drift:["<nodeId>","<currentHash>"]` (JSON ペア。issue #383 で `drift:<nodeId>` から変更 — research.md R4 の supersession 注記参照) / `orphan:<source -> target (kind)>` / `uncovered:<reqId>` / `testfail:<reqId>`。
 - **orphan 厳密化**: orphan 文字列の source を厳密に scoped node 集合と照合 (部分文字列 `includes` を廃止)。
 - **exit code**: 0 = gate pass (new ゼロ) / 2 = gate fail (new あり, `--gate` 時) / 1 = baseline 構築不能の異常系 (`--gate` 時)。
 

--- a/specs/017-check-gate-baseline-diff/research.md
+++ b/specs/017-check-gate-baseline-diff/research.md
@@ -93,6 +93,12 @@ drift 状態に入ったか」だけでは不十分で、「どんな内容で d
 no-content` / `unreadable-file:cannot-hash`、いずれも `graph/builder.ts`) が
 `:` を含む文字列を取りうるため、素朴な `${nodeId}:${hash}` 連結では構造的な
 単射性を保証できない。詳細は data-model.md §3 のキー生成スニペットを参照。
+既知の残余リスク (issue #398): symbol/file の contentHash は EOL 正規化されて
+いない (doc/req は markdown.ts で正規化済み) ため、checkout 設定の変更
+(`core.autocrlf` / `.gitattributes` の `eol=`) で baseline worktree と実
+worktree のバイト列が割れると、独立理由で drift 済みのノードに偽の新規 drift
+が出うる。TS 側ハッシュの正規化は trace/schema.ts の SSOT pin (spec 022
+FR-006) と一体で変更する必要があるため本変更には含めず、#398 で追跡する。
 
 ---
 

--- a/specs/017-check-gate-baseline-diff/research.md
+++ b/specs/017-check-gate-baseline-diff/research.md
@@ -75,6 +75,25 @@ spec / plan の Technical Context から抽出した設計判断とその根拠�
 **Alternatives considered**:
 - *drift を hash 値まで含めてキー化*: 「base で drift、current でも drift だが別内容」を別扱いにできるが、gate 目的では「その node が新たに drift 状態に入ったか」で十分。過剰。却下。
 
+**Supersession (issue #383, 2026-07-26)**: 上記の却下は誤りだった。id-only キー
+(`drift:<nodeId>`) では「base 時点で既に drift していたノード」への実編集が
+同一キーに畳み込まれ、その後 PR がそのノードに何を行っても無期限に
+pre-existing 抑制され続ける (base 時点の drift 状態が一度 baseline 側で観測
+されると、以後そのノードの drift は形を変えても常に「既知」)。実測で確認済み
+(`tests/check-baseline-diff.test.ts` の交差セルテスト)。「その node が新たに
+drift 状態に入ったか」だけでは不十分で、「どんな内容で drift しているか」ま
+で見なければ「同じノードへの新しい編集」と「観測済みの同一 drift」を区別でき
+ない。drift のキーを `drift:${JSON.stringify([nodeId, currentHash])}` に変更
+し、hash 値をキーに含める (却下されていた代替案を採用)。`lockedHash` はキー
+に含めない — baseline 側と current 側が同一 lock オブジェクトを見る前提の下
+では nodeId から一意に定まり判別力を持たないため (この前提はコールサイト規律
+であり型では強制されない。`src/baseline.ts` の `BaselineIssues.keys` JSDoc参
+照)。プレーン文字列連結ではなく JSON エンコードを使う理由: `currentHash` は
+16-hex 固定長とは限らず、読み取り不能ファイルの sentinel (`unreadable-file:
+no-content` / `unreadable-file:cannot-hash`、いずれも `graph/builder.ts`) が
+`:` を含む文字列を取りうるため、素朴な `${nodeId}:${hash}` 連結では構造的な
+単射性を保証できない。詳細は data-model.md §3 のキー生成スニペットを参照。
+
 ---
 
 ## R5. orphan のスコープ照合を厳密 ID 一致にする (FR-006)

--- a/src/baseline.ts
+++ b/src/baseline.ts
@@ -25,6 +25,23 @@ import { getGitRenameMap } from "./diff.js";
 // see the fix markers (A1..A6, B1, B3, B8, B9) scattered through the file.
 
 export interface BaselineIssues {
+  /**
+   * issue #383 — `driftKey` folds `currentHash` into the key but deliberately
+   * leaves `lockedHash` out, which rests on an assumption this type cannot
+   * enforce by itself: the baseline side (`computeBaselineIssues`'s
+   * `currentLock` param, below) and the current side (`src/check.ts`'s own
+   * drift loop) must be evaluated against the SAME `LockFile` object for a
+   * given run. Under that assumption `lockedHash` is structurally identical
+   * for a given `nodeId` on both sides, so folding it into the key would only
+   * ever repeat information `nodeId` already carries — it has no
+   * discriminating power. `src/commands/check.ts` is the only production call
+   * site and satisfies this today (one `readLockWithMeta` call, reused for
+   * both `computeBaselineIssues` and `check()`), but that is call-site
+   * discipline, not something the type system checks: a future caller that
+   * let the two sides observe different locks would silently lose the
+   * discriminating power `currentHash` was added to restore, with no type
+   * error to catch it.
+   */
   keys: Set<string>;
   status: BaselineStatus; // "computed" | "empty" | "unavailable" (never "skipped" here)
   // spec 017 (Critical fix B1, issue #182 review) — diagnostic message
@@ -50,7 +67,35 @@ export interface BaselineIssues {
 // ── issue identity keys (SSOT, data-model §6 / R4) ──────────────────────────
 // The current-side diff calculation (src/check.ts) imports these exact
 // functions so the two sides can never disagree on how an issue is keyed.
-export const driftKey = (d: DriftEntry): string => `drift:${d.nodeId}`;
+//
+// issue #383 — `driftKey` supersedes R4's original `drift:<nodeId>` decision
+// (research.md R4 "Alternatives considered"; see that file's supersession
+// note for the full rationale). An id-only key means a node that was ALREADY
+// drifted at the base ref and is edited AGAIN by the PR keeps the exact same
+// key on both sides forever after: the pre-existing entry suppresses every
+// later edit to that node, not just the base-ref state it was actually
+// observed against. Folding `currentHash` in distinguishes "drifted like
+// THIS" from "drifted like THAT" — a genuinely new edit on a
+// pre-existing-drift node changes `currentHash`, and therefore the key, so it
+// is no longer treated as pre-existing.
+//
+// JSON-array encoding, not plain `${d.nodeId}:${d.currentHash}` concatenation:
+// `currentHash` is not always a fixed-length hex digest. An unreadable doc/
+// file/test source hashes to a sentinel string that itself contains `:`
+// (`UNREADABLE_DOC_CONTENT_HASH = "unreadable-file:no-content"` and the
+// analogous `"unreadable-file:cannot-hash"`, both in graph/builder.ts). A bare
+// template-literal join could not tell `nodeId="a:b", hash="c"` apart from
+// `nodeId="a", hash="b:c"`. None of today's concrete hash shapes actually
+// collide this way, but that is incidental — a property of what the hash
+// values happen to look like today — not a structural guarantee the key
+// format can rely on. `JSON.stringify([nodeId, currentHash])` makes the
+// encoding unambiguous by construction instead of by the current set of hash
+// shapes never colliding.
+//
+// `lockedHash` is deliberately NOT part of the key — see `BaselineIssues.keys`
+// above for why it carries no discriminating information here.
+export const driftKey = (d: DriftEntry): string =>
+  `drift:${JSON.stringify([d.nodeId, d.currentHash])}`;
 export const orphanKey = (o: OrphanEdge): string => `orphan:${formatOrphan(o)}`;
 export const uncoveredKey = (id: string): string => `uncovered:${id}`;
 export const testfailKey = (id: string): string => `testfail:${id}`;
@@ -192,6 +237,13 @@ export function resolveMergeBase(
 export function computeBaselineIssues(
   rootDir: string,
   baseRef: string,
+  // issue #383 — must be the exact same `LockFile` object/instance the caller
+  // will also pass to `check()`'s current-side drift calculation for this
+  // same run (see `BaselineIssues.keys`'s doc above). `driftKey` omits
+  // `lockedHash` from its key precisely because this coupling holds; a caller
+  // that resolved a DIFFERENT lock for the current side than the one passed
+  // here would silently break that assumption, with no type error to catch
+  // it.
   currentLock: LockFile,
   config: ArtgraphConfig,
   // spec 023 (FR-008, data-model §5 SSOT) — the rename map computed by the
@@ -313,6 +365,20 @@ export function computeBaselineIssues(
 // belong to "this test run" and can't be reconstructed from a static ref, so
 // current test failures always count as new (baseline-diff.md §1.3).
 // @impl 017-check-gate-baseline-diff/FR-011
+//
+// issue #383 — this function always computes an UNSCOPED superset: every
+// drift/orphan/uncovered issue anywhere in the base graph, never narrowed to
+// any particular scope. The current side (`src/check.ts`) is the SCOPED query
+// side — its only interaction with this set is `isPreExisting(key)`, a lookup
+// of one already-scoped issue's key. A baseline key with no matching
+// current-side issue in a given run is simply never looked up: it is inert,
+// not wrong. This asymmetry is load-bearing for the "superset" framing to
+// stay correct — if a future change made the baseline side scope-aware too
+// (e.g. to cut worktree/scan cost on a large repo), a baseline key computed
+// only for one scope could go missing for a DIFFERENT scope's query on the
+// same run, and every consumer of `keys` (starting with `driftKey`'s
+// same-lock-object assumption above) would need re-auditing against the
+// narrower contract.
 //
 // spec 017 (High fix C2, issue #182 review) — `orphanKey` embeds the
 // orphan's `source` (`file:<path>` / `symbol:<path>#<name>`), so a pure

--- a/src/baseline.ts
+++ b/src/baseline.ts
@@ -92,6 +92,23 @@ export interface BaselineIssues {
 // encoding unambiguous by construction instead of by the current set of hash
 // shapes never colliding.
 //
+// A second assumption this key surfaces (issue #398): both sides must compute
+// the SAME hash for the SAME git blob. symbol/file content hashes are not
+// EOL-normalized today (doc/req hashes are — parsers/markdown.ts folds CRLF
+// away before hashing), and the two sides hash two DIFFERENT checkouts of the
+// same content: the ephemeral baseline worktree materializes with today's git
+// config/attributes while the real working tree keeps the bytes of whenever
+// it was last checked out. A checkout-context change in between (a
+// `core.autocrlf` flip, a new `.gitattributes` `eol=` rule) splits the hashes
+// for an untouched file, and on a node that is ALSO already drifted for an
+// independent reason that splits this key pair and surfaces a false NEW
+// drift. (Pre-#383, the id-only key silently absorbed the same divergence —
+// and over-absorbed real edits with it. Opposite failure, same root.)
+// Normalizing the TS-side hash here is deliberately NOT done: the trace
+// engine's `hashContent` (src/trace/schema.ts) is pinned byte-identical to
+// the file hash (tests/hash-equivalence.test.ts, spec 022 FR-006), so the
+// two must move in one cross-spec change — tracked as issue #398.
+//
 // `lockedHash` is deliberately NOT part of the key — see `BaselineIssues.keys`
 // above for why it carries no discriminating information here.
 export const driftKey = (d: DriftEntry): string =>

--- a/tests/baseline.test.ts
+++ b/tests/baseline.test.ts
@@ -163,6 +163,14 @@ describe("computeBaselineIssues", () => {
     const staleLock = {
       "REQ-100": { contentHash: "stale-hash-value", lastReconciled: "2025-01-01T00:00:00Z" },
     };
+    // issue #383 — `driftKey` now folds `currentHash` into the key, so a
+    // placeholder value here (the old test used a bare "x") would silently
+    // stop matching: the fixture's working tree is byte-identical to HEAD (no
+    // local edits), so scanning it directly gives the exact contentHash the
+    // baseline's ephemeral HEAD worktree scan computes for REQ-100 too.
+    const { graph } = scan(dir, config);
+    const currentHash = graph.nodes.get("REQ-100")!.contentHash;
+
     const result = computeBaselineIssues(dir, "HEAD", staleLock, config);
     expect(result.status).toBe("computed");
     expect(
@@ -171,7 +179,7 @@ describe("computeBaselineIssues", () => {
           nodeId: "REQ-100",
           kind: "req",
           lockedHash: "stale-hash-value",
-          currentHash: "x",
+          currentHash,
         }),
       ),
     ).toBe(true);
@@ -203,8 +211,12 @@ describe("computeBaselineIssues", () => {
     expect(orphanKey({ source: "file:a.ts", target: "REQ-9", kind: "implements" })).toBe(
       "orphan:file:a.ts -> REQ-9 (implements)",
     );
+    // issue #383 — the key now folds in `currentHash` (JSON-pair encoded, not
+    // plain concatenation; see src/baseline.ts's `driftKey` doc comment for
+    // why) so a node's identity as an issue is tied to WHICH content it's
+    // currently drifted to, not just its nodeId.
     expect(driftKey({ nodeId: "REQ-1", kind: "req", lockedHash: "a", currentHash: "b" })).toBe(
-      "drift:REQ-1",
+      'drift:["REQ-1","b"]',
     );
   });
 });

--- a/tests/check-baseline-diff.test.ts
+++ b/tests/check-baseline-diff.test.ts
@@ -1162,3 +1162,139 @@ describe("check --diff: downstream unavailable must not hide behind the not-trac
     expect(stdout).toContain("Changed files are not tracked in the graph.");
   });
 });
+
+// ---------------------------------------------------------------------------
+// issue #383 — `driftKey` folds `currentHash` into the key (was `drift:
+// <nodeId>` alone, research.md R4). An id-only key let a node's baseline-
+// observed drift state suppress EVERY later drift on that same node forever,
+// regardless of content: once a node was seen drifted at the base ref, the PR
+// could edit it again and again and the gate would keep calling it
+// "pre-existing" — the exact sticky-suppression bug this section pins the fix
+// for. research.md's R4 supersession note (2026-07-26) carries the full
+// narrative.
+// ---------------------------------------------------------------------------
+describe("check --diff --gate drift key discriminates by content, not just nodeId (issue #383)", () => {
+  // Corrupts one lock entry's contentHash in place, simulating a node that is
+  // ALREADY drifted at the base ref for some arbitrary reason — measurement-
+  // equivalent to what a hash-algorithm upgrade would produce (the lock and
+  // the base graph simply disagree, regardless of why the disagreement
+  // happened). Requires a prior reconcile so every OTHER entry stays correct
+  // and this corruption is the only intentional discrepancy in the fixture.
+  // Precedent for writing `.trace.lock` directly: tests/init.test.ts (F7 /
+  // issue #257 fixtures).
+  function stalePreExistingDrift(dir: string, nodeId: string): void {
+    const lockPath = join(dir, ".trace.lock");
+    const lock = JSON.parse(readFileSync(lockPath, "utf-8"));
+    if (!lock[nodeId]) {
+      throw new Error(`stalePreExistingDrift: no lock entry for ${nodeId} in ${lockPath}`);
+    }
+    lock[nodeId] = { ...lock[nodeId], contentHash: "stale-hash-issue-383" };
+    writeFileSync(lockPath, JSON.stringify(lock, null, 2) + "\n");
+  }
+
+  it("(T383-c) a node already drifted at the base ref, edited again by the PR → still counted as new drift", async () => {
+    const dir = repo("artgraph-383-c-");
+    const rec = await runAt(dir, ["reconcile"]);
+    expect(rec.exitCode).toBe(0);
+    // REQ-100 is already "drifted" at HEAD relative to the (corrupted) lock —
+    // exactly the scenario an id-only key used to collapse into permanent
+    // suppression.
+    stalePreExistingDrift(dir, "REQ-100");
+
+    // The PR now makes a REAL edit to REQ-100 — a genuinely different drift
+    // than whatever was observed at the base ref.
+    writeFileSync(
+      join(dir, "specs", "debt.md"),
+      "# Debt\n\n- REQ-100: covered by the hub (edited again, issue 383)\n- REQ-200: pre-existing uncovered debt\n",
+    );
+
+    const { exitCode, json } = await checkJson(dir);
+    expect(exitCode).toBe(2);
+    expect(json.pass).toBe(false);
+    expect(json.newIssues.drifted.some((d: { nodeId: string }) => d.nodeId === "REQ-100")).toBe(
+      true,
+    );
+  });
+
+  it("(T383-d) same base-ref drift, no further edit to that node → stays suppressed (phase (i) preservation, control)", async () => {
+    const dir = repo("artgraph-383-d-");
+    const rec = await runAt(dir, ["reconcile"]);
+    expect(rec.exitCode).toBe(0);
+    stalePreExistingDrift(dir, "REQ-100");
+
+    // Pull REQ-100 into scope WITHOUT touching its own content — a harmless
+    // edit to the file that claims it, exactly like the existing "(b)
+    // harmless edit to the hub" fixture earlier in this file.
+    appendFileSync(join(dir, "src", "hub.ts"), "\n// harmless (issue 383 control)\n");
+
+    const { exitCode, json } = await checkJson(dir);
+    // Control (avoids zero discriminating power): REQ-100's drift must
+    // actually have been SCOPED and then suppressed, not merely absent from
+    // scope altogether — otherwise this test would pass trivially regardless
+    // of whether suppression works at all.
+    expect(json.drifted.some((d: { nodeId: string }) => d.nodeId === "REQ-100")).toBe(true);
+    expect(json.suppressedCount).toBeGreaterThanOrEqual(1);
+    expect(json.newIssues.drifted.some((d: { nodeId: string }) => d.nodeId === "REQ-100")).toBe(
+      false,
+    );
+    expect(exitCode).toBe(0);
+    expect(json.pass).toBe(true);
+  });
+
+  // issue #235 (doc granularity) — a doc node's contentHash hashes the WHOLE
+  // file's raw bytes (parsers/markdown.ts), so ANY edit anywhere in the file
+  // changes it, even an edit to a REQ this PR never touches. Under the
+  // pre-#383 id-only key this was accidentally neutralized: once a doc's
+  // drift was observed at the base ref, EVERY later doc-level mismatch kept
+  // matching the same `drift:<docId>` key and stayed suppressed forever, no
+  // matter which bytes actually differed. This test pins that the fix removes
+  // that accidental amnesty — this is #235's granularity noise resurfacing at
+  // the gate, not a new defect introduced here (this PR increases #235's
+  // visibility; it does not fix #235 itself — see the PR description).
+  it("(T383-e) doc already drifted at the base ref, PR edits only the OTHER req in the same file → doc still surfaces as new drift", async () => {
+    const dir = repo("artgraph-383-e-");
+    const rec = await runAt(dir, ["reconcile"]);
+    expect(rec.exitCode).toBe(0);
+    // The doc node's id strips the specDirs prefix (parsers/markdown.ts's
+    // `docRelPath`) — `specs/debt.md` becomes `doc:debt.md`, not
+    // `doc:specs/debt.md`.
+    stalePreExistingDrift(dir, "doc:debt.md");
+
+    // Only REQ-200's line changes — REQ-100 is untouched.
+    writeFileSync(
+      join(dir, "specs", "debt.md"),
+      "# Debt\n\n- REQ-100: covered by the hub\n- REQ-200: pre-existing uncovered debt (edited, issue 383)\n",
+    );
+
+    const { json } = await checkJson(dir);
+    // REQ-100's own per-requirement hash never changed — no drift on it.
+    expect(json.newIssues.drifted.some((d: { nodeId: string }) => d.nodeId === "REQ-100")).toBe(
+      false,
+    );
+    // The doc node's whole-file hash DID change (REQ-200's edit touched the
+    // same file), and it differs from whatever was staled at the base ref,
+    // so it is not suppressed — #235's granularity noise, gate-visible.
+    expect(json.newIssues.drifted.some((d: { nodeId: string }) => d.nodeId === "doc:debt.md")).toBe(
+      true,
+    );
+  });
+
+  it("(T383-f) a stale lock entry for a renamed-away id is reported as staleLockEntries, never as drift", async () => {
+    const dir = repo("artgraph-383-f-");
+    const rec = await runAt(dir, ["reconcile"]);
+    expect(rec.exitCode).toBe(0);
+    stalePreExistingDrift(dir, "doc:debt.md");
+
+    execFileSync("git", ["mv", "specs/debt.md", "specs/renamed-debt.md"], {
+      cwd: dir,
+      stdio: "pipe",
+    });
+
+    const { json } = await checkJson(dir);
+    expect(json.staleLockEntries).toContain("doc:debt.md");
+    expect(json.drifted.some((d: { nodeId: string }) => d.nodeId === "doc:debt.md")).toBe(false);
+    expect(json.newIssues.drifted.some((d: { nodeId: string }) => d.nodeId === "doc:debt.md")).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

`check --diff --gate`'s baseline suppression keyed drift by node id alone — `drift:${nodeId}`, no hash component (`src/baseline.ts:53`). Once a node was observed drifted at the base ref, *every* later drift on that same node collapsed onto the same key and kept being classified pre-existing: a PR could edit an already-drifted node and the gate would return exit 0, indefinitely, until the base ref advanced past the drift (E2E below measured that a `reconcile` alone, with the triggering edit uncommitted, left the old key suppressing). That is issue #383's ESCALATION case, and it made the exact CI form `AGENTS.md` recommends (and the Stop hook template runs unattended every turn) silently pass on real regressions.

The key is now:

```ts
export const driftKey = (d: DriftEntry): string =>
  `drift:${JSON.stringify([d.nodeId, d.currentHash])}`;
```

Two properties, both measured (probes in the investigation, pinned by tests here):

- **Unchanged where suppression is legitimate.** A node whose drift is byte-identical on both sides — the lock went stale for reasons unrelated to this PR (forgotten reconcile, or a parser-changing upgrade re-hashing everything), and the PR does not touch the node — produces the same `currentHash` on both sides, same key, still suppressed. Upgrade-only diffs keep passing exactly as spec 017 intended.
- **A real edit to an already-drifted node now fails the gate.** The edit changes `currentHash`, the key no longer matches the baseline's entry, the drift is new. Exit 2.

### Not `${nodeId}:${currentHash}` concatenation

`contentHash` is not always a 16-hex digest: unreadable doc/file/test sources hash to sentinels that themselves contain `:` (`"unreadable-file:no-content"`, `"unreadable-file:cannot-hash"`, both in `graph/builder.ts`). None of today's three hash shapes can actually collide under bare concatenation, but that is a property of what the values happen to look like, not of the format. `JSON.stringify([nodeId, currentHash])` makes injectivity structural. Keys are purely internal (consumed only via `isPreExisting`, never serialized — verified there is no path from `BaselineIssues.keys` to any output), so the format change has zero external surface.

### `lockedHash` stays out of the key

Both sides read the *same* `LockFile` object — `src/commands/check.ts` loads it once and passes it to both `computeBaselineIssues` and `check()`; that is the only production call site. For a given `nodeId`, `lockedHash` is therefore structurally identical on both sides and adds no discriminating power. This is call-site discipline, not something the type system enforces, so it is now documented as an explicit assumption on `BaselineIssues.keys` and on `computeBaselineIssues`'s `currentLock` param.

### spec 017 supersession

spec 017 considered exactly this key and rejected it: *"gate 目的では「その node が新たに drift 状態に入ったか」で十分。過剰。却下。"* (`research.md` R4, Alternatives considered). The rejection's premise is what #383 refuted — "newly entered drift state" cannot distinguish "the same drift we already observed" from "a new edit on a node that happened to be drifted already". R4 now carries a supersession note, and the two other places that stated the old key as canonical (`data-model.md` §3's code snippet, `plan.md`'s design-decision bullet) are updated in the same commit so the spec does not contradict itself.

Closes #383

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass
- [x] Added tests where needed
- [x] Ran `knip` and `build`

Unit + e2e all green (`pnpm test` 2607 passed | 22 skipped, `pnpm test:e2e` 122 passed | 3 skipped), `lint` / `format:check` / `knip` / `check:no-raw-nul` clean.

Four new tests in `tests/check-baseline-diff.test.ts`, all through the real `commands/check.ts` action handler, using a helper that corrupts one lock entry after `reconcile` (measurement-equivalent to any real pre-existing drift, upgrade-induced or not):

| Test | Scenario | Expectation |
|---|---|---|
| T383-c | already-drifted node, edited again by the PR | exit 2, in `newIssues.drifted` |
| T383-d | already-drifted node, NOT edited (control) | still suppressed, exit 0 — with `suppressedCount >= 1` asserted so the suppression provably fired rather than the node never being in scope |
| T383-e | already-drifted doc, PR edits only the sibling REQ in the same file | doc resurfaces as new drift (the #235 interaction below, pinned deliberately) |
| T383-f | stale lock entry for a renamed-away id | lands in `staleLockEntries`, never in drift — renames don't reach key comparison at all |

Discriminating power was verified directly during implementation: with `driftKey` temporarily reverted to the id-only form, T383-c and T383-e fail; T383-d and T383-f pass under both forms (they pin invariants adjacent to the fix, not the fix itself).

Two existing tests updated: the SSOT pin now asserts the exact new string (`drift:["REQ-1","b"]`), and the FR-011 test previously hardcoded `currentHash: "x"` — under the new format that placeholder would never match any real key, turning the test into a silent false negative, so it now scans the fixture for the node's real hash.

### End-to-end, through the CLI

Verified against real `node dist/cli.js` runs on throwaway `mode: "symbol"` projects, comparing this branch's build against a build of `origin/main` (pre-fix):

| Scenario | pre-fix (`origin/main`) | this branch |
|---|---|---|
| ESCALATION: already-drifted node, really edited | **exit 0**, `newIssues.drifted: []`, `suppressedCount: 2` — the bug | **exit 2**, both the req and its doc in `newIssues.drifted` |
| Phase (i): same stale lock, node untouched | exit 0 | exit 0, `suppressedCount: 2`, and the two suppressed entries' `currentHash` values are byte-identical to the reconcile-time values — direct confirmation the key only changes when content does |
| Recovery flow: `reconcile` → commit (base advances) → same edit again | exit 2 | exit 2 — the fix does not disturb the normal recover-then-merge path |
| symbol-kind node (unit tests cover file mode only): `symbol:…#hub` staled + its function body edited | exit 0, suppressed | exit 2, reported |

INV-L4 / output stability on this repository itself (no `--diff`): `scan --format json` (845,449 bytes) and `check --format json` (81,381 bytes) are sha256-identical between the two builds, exit 0, empty stderr, `.trace.lock` untouched — outside the `--diff` path the change is observably invisible, matching the internal-representation claim.

One informational E2E observation about the *old* behavior: with the triggering edit uncommitted, `reconcile` alone did not clear the old key's suppression (the base ref hadn't moved), so pre-fix stickiness was even stronger than "until reconcile" suggests. No code impact; noted for historical accuracy.

## Breaking change

- [ ] Yes (described below)
- [x] No

No API, output-schema, or exit-code surface changes: `baselineStatus` keeps its 5 values, keys were never serialized, exit semantics stay 0/1/2. Behavior narrows in one direction only: `check --diff --gate` now fails on real edits to already-drifted nodes, which is the bug being fixed. Projects relying on the old behavior were relying on a gate that ignored regressions.

## Review findings addressed

Adversarial review (clean-context) + independent meta-review (another clean context, all claims re-reproduced) on the implementation commit:

- **HIGH, verified live in both reviews — checkout-context hash divergence (now #398, documented in-code here).** symbol/file content hashes are not EOL-normalized (doc/req hashes are), and `check --diff` hashes two *different checkouts* of the same content: the ephemeral baseline worktree (materialized with today's git config/attributes) and the real working tree (bytes from whenever it was last checked out). Flip `core.autocrlf` — or merely add a `.gitattributes` `eol=` rule, reproduced with autocrlf untouched — and an untouched, independently-already-drifted symbol node splits its key pair and fails the gate falsely. The pre-#383 key silently absorbed the same divergence *and the PR's real edits with it*: opposite failure direction, same root; neither format is correct under a diverged checkout context. **Why not normalize in this PR:** measured as a no-op for CR-less repos (0-byte scan diff over this repo's 81 files / 1533 nodes), but `src/trace/schema.ts`'s `hashContent` is pinned byte-identical to the file hash (`tests/hash-equivalence.test.ts`, spec 022 FR-006, with `tests/vitest-plugin.test.ts:304` pinning CRLF-as-is as intended), so patching the parser alone would move the same split-brain into the trace engine's staleness detection. Cross-spec fix tracked as #398; this PR documents the assumption at `driftKey` and in research.md, where it is visible to the next person changing either side.
- **LOW — same-lock-object assumption is call-site discipline, not type-enforced.** Verified: single production call site, one `readLockWithMeta`, both consumers fed from it. Already documented in-PR at three anchors; meta-review concurred documentation suffices over a runtime assertion (single, adjacent call path; behavior tests would go red on violation).
- **LOW — `data-model.md` snippet omits the `: string` annotation the implementation has.** Pre-existing doc style (all four key functions, unchanged since the snippet's introduction); not introduced or worsened here. No action.

## Notes

### Known interaction with #235 (doc granularity), measured and pinned

A doc node's `contentHash` covers the whole file's raw bytes, so any edit anywhere in a spec file changes it. The old id-only key was *accidentally neutralizing* that noise: once a doc drifted, every later whole-file mismatch matched the same suppressed key. With content in the key, an edit to an unrelated REQ in an already-drifted spec file resurfaces the doc node as new drift — T383-e pins this on purpose. This is #235's granularity becoming gate-visible, not a new defect introduced here; the root fix stays with #235, whose practical priority this PR arguably raises.

### Scope decisions from the investigation (follow-up issues filed)

The Step 0-pre investigation surfaced three adjacent gaps that share #383's theme (the baseline compares things produced under different regimes) but are separate defects, deliberately not folded in — plus one from review:

- #394 — the baseline worktree is always scanned with the **current** `.artgraph.json`; a config change (e.g. `mode: file → symbol`) between base and HEAD changes the id scheme itself and can invalidate the whole comparison. spec 023 records this as a known limitation; the gate implication deserves its own treatment.
- #395 — `collectIssueKeys` calls raw `findUncovered`, but the current side rescues REQs via trace evidence (`exercisedReqIds`) before the new-issue subtraction; a rescue that lapsed between base and current is suppressed as pre-existing. Also folds in a regression pin for the (intentional, documented) exclusion of `testfail:` keys from baselines.
- #396 — an informational "your lock predates the current hash semantics, consider reconcile" nudge, recording a hash-semantics fingerprint in the lock's `_meta`. Explicitly must not reuse `LOCK_SCHEMA_VERSION` (that axis tracks JSON shape, has never been bumped, and would miss same-shape hash-semantics changes), and must not casually grow `BaselineStatus` (its 5-value enum is documented as closed and has no exhaustiveness checks at its consumers).
- #398 — the checkout-context hash divergence above (EOL asymmetry between the TS and markdown parsers, plus the reverse BOM asymmetry: TS strips BOM, markdown does not — measured).

Issue #383 itself has been rewritten to the general form: a parser-changing upgrade is an *amplifier* (it puts every node into the pre-existing-drift state at once), not the cause — the same stickiness reproduces from a single forgotten reconcile.