### PR TITLE
fix(rename): replace both polynomial-backtracking rewrite regexes with linear parses

### DIFF
--- a/src/parsers/markdown.ts
+++ b/src/parsers/markdown.ts
@@ -174,7 +174,7 @@ export function parseMarkdownContent(
   // Normalize line endings so downstream offsets, regexes, and hashes see a
   // single `\n` regardless of how the file was checked out (CRLF on Windows
   // git workspaces, lone CR from legacy editors). Without this, an authored
-  // `(depends_on: X)\r\n` line bypasses ANNOTATION_RE_LINE in the rewriter
+  // `(depends_on: X)\r\n` line bypasses the rewriter's annotation matcher
   // while still being parsed as an annotation here — i.e. parser/rewriter
   // parity breaks on CRLF files (meta-review additional F4).
   const raw = source.replace(/\r\n/g, "\n").replace(/\r/g, "\n");

--- a/src/rename.ts
+++ b/src/rename.ts
@@ -1,3 +1,4 @@
+import { parse as parseYaml, parseDocument, isMap, isScalar, Scalar } from "yaml";
 import type { ReqPatternConfig, TaskConventionPreset } from "./types.js";
 import {
   BUILTIN_TASK_PRESETS,
@@ -373,7 +374,6 @@ export function rewriteTestTags(content: string, oldId: string, newId: string): 
 // ── Frontmatter ──────────────────────────────────────────────────────
 
 const FM_BLOCK_KEY_RE = /^(\s*)(depends_on|derives_from)\s*:(.*)$/;
-const FM_NODE_ID_RE = /^(\s*node_id:\s*["']?)(.+?)(["']?\s*)$/;
 
 /**
  * True for a line that is part of an active `depends_on`/`derives_from` block
@@ -382,6 +382,122 @@ const FM_NODE_ID_RE = /^(\s*node_id:\s*["']?)(.+?)(["']?\s*)$/;
 function isBlockItemLine(line: string): boolean {
   const t = line.trim();
   return t === "" || t.startsWith("-");
+}
+
+// IDs whose characters are safe to embed verbatim in any of the three scalar
+// styles (nothing to escape inside quotes, no flow indicators that would end
+// a plain scalar early in `{ … }` frontmatter). Whether the *plain* style
+// additionally survives re-parsing is checked per value in requoteNodeId;
+// anything outside this set is JSON-escaped wholesale.
+const SAFE_UNQUOTED_ID_RE = /^[A-Za-z0-9_:/.-]+$/;
+
+/**
+ * Re-serialize `newId` in the scalar style `type` the author wrote, so a
+ * rename doesn't gratuitously change how the value is quoted.
+ */
+function requoteNodeId(newId: string, type: string | undefined): string {
+  if (!SAFE_UNQUOTED_ID_RE.test(newId)) return JSON.stringify(newId);
+  if (type === Scalar.QUOTE_SINGLE) return `'${newId}'`;
+  if (type === Scalar.QUOTE_DOUBLE) return `"${newId}"`;
+  // Plain style survives only when the bare text re-parses as this exact
+  // string — `123`, `1.1`, `true`, or a trailing `:` would come back as a
+  // number/bool/map, and the reader's typeof check would then drop the id.
+  try {
+    if (parseYaml(newId, { resolveKnownTags: false }) === newId) return newId;
+  } catch {
+    // fall through to quoting
+  }
+  return JSON.stringify(newId);
+}
+
+// Character offset of the start of `lines[index]` within `lines.join("\n")`.
+function lineStartOffset(lines: string[], index: number): number {
+  let offset = 0;
+  for (let i = 0; i < index; i++) offset += lines[i].length + 1;
+  return offset;
+}
+
+/**
+ * Rewrite `artgraph.node_id` inside YAML frontmatter via a structural parse
+ * (`parseDocument`, the same `resolveKnownTags: false` option as the reader's
+ * `parseFrontmatter` in src/parsers/markdown.ts) instead of a regex over the
+ * raw text. The value only lives under the `artgraph` key — the same key the
+ * reader consumes — and a frontmatter body the reader would fail to parse is
+ * left untouched here too, rather than guessing at a value inside malformed
+ * YAML (parser/rewriter parity).
+ *
+ * Returns the spliced content and, on the one rewrite path, its change
+ * record; every skip path below returns `content` untouched and `change:
+ * null`.
+ */
+function rewriteFrontmatterNodeId(
+  content: string,
+  oldId: string,
+  newId: string,
+): { content: string; change: RewriteChange | null } {
+  const bounds = findFrontmatterBounds(content);
+  if (!bounds) return { content, change: null };
+
+  const lines = content.split("\n");
+  // yamlBody is the exact frontmatter body substring of `content` (including
+  // whatever line endings it holds) — sliced from the string itself rather
+  // than lines.slice(...).join("\n"), which would drop the real "\n" that
+  // terminates the last body line, corrupting a CRLF file's last line (its
+  // trailing "\r" would dangle at the parsed string's end with no "\n" after
+  // it, which the YAML tokenizer does not accept as a line break).
+  const bodyOffset = lineStartOffset(lines, 1);
+  const fenceOffset = lineStartOffset(lines, bounds.end);
+  const yamlBody = content.slice(bodyOffset, fenceOffset);
+
+  const doc = parseDocument(yamlBody, { resolveKnownTags: false });
+  if (doc.errors.length > 0) return { content, change: null };
+
+  const root = doc.contents;
+  if (root == null || !isMap(root)) return { content, change: null };
+  const artgraphNode = root.get("artgraph", true);
+  if (!isMap(artgraphNode)) return { content, change: null };
+  const nodeIdNode = artgraphNode.get("node_id", true);
+  if (!isScalar(nodeIdNode)) return { content, change: null };
+  if (typeof nodeIdNode.value !== "string" || nodeIdNode.value !== oldId) {
+    return { content, change: null };
+  }
+
+  const type = nodeIdNode.type;
+  if (type !== Scalar.PLAIN && type !== Scalar.QUOTE_SINGLE && type !== Scalar.QUOTE_DOUBLE) {
+    // Block scalars (`|`, `>`) and anything else outside these three styles
+    // are left alone, same as the old regex (its value group couldn't
+    // produce these shapes either).
+    return { content, change: null };
+  }
+  const range = nodeIdNode.range;
+  if (!range) return { content, change: null };
+  const [rangeStart, rangeEnd] = range;
+  // A quoted scalar's raw span can itself fold across lines; skip rather than
+  // collapse that into the single-line before/after a RewriteChange assumes.
+  if (yamlBody.slice(rangeStart, rangeEnd).includes("\n")) return { content, change: null };
+
+  const spliceStart = bodyOffset + rangeStart;
+  const spliceEnd = bodyOffset + rangeEnd;
+  const replacement = requoteNodeId(newId, type);
+
+  const lineStart = content.lastIndexOf("\n", spliceStart - 1) + 1;
+  const nextNewline = content.indexOf("\n", spliceEnd);
+  const lineEnd = nextNewline === -1 ? content.length : nextNewline;
+  const before = content.slice(lineStart, lineEnd);
+  const after =
+    before.slice(0, spliceStart - lineStart) + replacement + before.slice(spliceEnd - lineStart);
+  const lineNumber = content.slice(0, lineStart).split("\n").length;
+
+  return {
+    content: content.slice(0, spliceStart) + replacement + content.slice(spliceEnd),
+    change: {
+      filePath: "",
+      line: lineNumber,
+      kind: "frontmatter-depends-on",
+      before,
+      after,
+    },
+  };
 }
 
 /**
@@ -394,12 +510,14 @@ function isBlockItemLine(line: string): boolean {
  * Body content outside the frontmatter delimiters is never touched.
  */
 export function rewriteFrontmatter(content: string, oldId: string, newId: string): RewriteResult {
-  const lines = content.split("\n");
-  const changes: RewriteChange[] = [];
-
   const bounds = findFrontmatterBounds(content);
-  if (!bounds) return { content, changes };
+  if (!bounds) return { content, changes: [] };
 
+  const changes: RewriteChange[] = [];
+  const nodeIdResult = rewriteFrontmatterNodeId(content, oldId, newId);
+  if (nodeIdResult.change) changes.push(nodeIdResult.change);
+
+  const lines = nodeIdResult.content.split("\n");
   const idRe = idBoundaryRegex(oldId);
   let inBlock = false;
 
@@ -407,22 +525,6 @@ export function rewriteFrontmatter(content: string, oldId: string, newId: string
   // sit at 1..bounds.end-1.
   for (let i = 1; i < bounds.end; i++) {
     const line = lines[i];
-
-    // node_id: "<id>"
-    const nm = line.match(FM_NODE_ID_RE);
-    if (nm && nm[2] === oldId) {
-      const before = line;
-      lines[i] = nm[1] + newId + nm[3];
-      changes.push({
-        filePath: "",
-        line: i + 1,
-        kind: "frontmatter-depends-on",
-        before,
-        after: lines[i],
-      });
-      inBlock = false;
-      continue;
-    }
 
     // depends_on: / derives_from: key (with optional inline value)
     const bm = line.match(FM_BLOCK_KEY_RE);
@@ -466,6 +568,11 @@ export function rewriteFrontmatter(content: string, oldId: string, newId: string
       }
     }
   }
+
+  // The node_id change (found via a standalone parse, not the line-ordered
+  // loop above) can land anywhere in the frontmatter body, so re-sort by line
+  // to preserve the ascending-line-number order callers rely on.
+  changes.sort((a, b) => a.line - b.line);
 
   return { content: lines.join("\n"), changes };
 }
@@ -548,7 +655,114 @@ export function expandFrontmatterDependsOn(
 // a paren expression outside those positions is harmless because the parser
 // won't have emitted an edge for it anyway, and duplicating the position
 // gate in the rewriter would mean two sources of truth.
-const ANNOTATION_RE_LINE = /(\(\s*(?:depends_on|derives_from)\s*:\s*)([^()]*?)(\s*\))/g;
+
+// `\s` exactly as the regex engine's character class defines it (including
+// the Unicode whitespace it covers) — tested one character at a time so
+// findNextAnnotationMatch agrees with the grammar below byte-for-byte without
+// re-deriving that class by hand.
+function isRegexSpace(ch: string): boolean {
+  return /\s/.test(ch);
+}
+
+// A single `(depends_on: …)` / `(derives_from: …)` match within one line —
+// the (head, body, tail, start, end) a callback would receive from
+// `line.replace(/(\(\s*(?:depends_on|derives_from)\s*:\s*)([^()]*?)(\s*\))/g, cb)`.
+interface AnnotationMatch {
+  head: string;
+  body: string;
+  tail: string;
+  start: number;
+  end: number;
+}
+
+/**
+ * Find the next depends_on/derives_from annotation in `line` at or after
+ * `from`, or null if there is none. Linear-time replacement for the regex
+ * above: its `[^()]*?` lazy body backtracking against `\s*` runs on both
+ * sides was ReDoS-able on an adversarial (e.g. unclosed) annotation.
+ *
+ * - From a candidate `(`: skip `\s*`, match the `depends_on`/`derives_from`
+ *   keyword, skip `\s*`, require `:`, then skip `\s*` greedily — that span is
+ *   `head`. A failure at any of these steps means this `(` cannot start a
+ *   match; retry from the character right after it (so `((depends_on: X)`
+ *   still matches starting at the second `(`).
+ * - From the end of `head`, scan forward for `(`, `)`, or end of line —
+ *   there is no `[^()]` alternative that reaches a close paren once another
+ *   `(` (or the line end) is hit, so that also fails the candidate and
+ *   retries the same way.
+ * - Hitting `)` completes the match. The run of whitespace directly before it
+ *   is `tail` (mirrors `(\s*\))`); everything between `head` and that run is
+ *   `body`.
+ */
+function findNextAnnotationMatch(line: string, from: number): AnnotationMatch | null {
+  let searchFrom = from;
+  while (true) {
+    const open = line.indexOf("(", searchFrom);
+    if (open === -1) return null;
+
+    let p = open + 1;
+    while (p < line.length && isRegexSpace(line[p])) p++;
+    let keyword: string | null = null;
+    if (line.startsWith("depends_on", p)) keyword = "depends_on";
+    else if (line.startsWith("derives_from", p)) keyword = "derives_from";
+    if (keyword === null) {
+      searchFrom = open + 1;
+      continue;
+    }
+    p += keyword.length;
+    while (p < line.length && isRegexSpace(line[p])) p++;
+    if (line[p] !== ":") {
+      searchFrom = open + 1;
+      continue;
+    }
+    p += 1;
+    while (p < line.length && isRegexSpace(line[p])) p++;
+    const headEnd = p;
+
+    let q = headEnd;
+    while (q < line.length && line[q] !== "(" && line[q] !== ")") q++;
+    if (q >= line.length || line[q] === "(") {
+      searchFrom = open + 1;
+      continue;
+    }
+
+    let tailStart = q;
+    while (tailStart > headEnd && isRegexSpace(line[tailStart - 1])) tailStart--;
+
+    return {
+      head: line.slice(open, headEnd),
+      body: line.slice(headEnd, tailStart),
+      tail: line.slice(tailStart, q + 1),
+      start: open,
+      end: q + 1,
+    };
+  }
+}
+
+/**
+ * `line.replace(<the annotation regex>, cb)` reimplemented over
+ * findNextAnnotationMatch: same left-to-right, non-overlapping match
+ * semantics (each match's end becomes the next search start) and the same
+ * (match, head, body, tail, offset) callback shape.
+ */
+function replaceAnnotations(
+  line: string,
+  cb: (match: string, head: string, body: string, tail: string, offset: number) => string,
+): string {
+  let out = "";
+  let cursor = 0;
+  let searchFrom = 0;
+  while (true) {
+    const m = findNextAnnotationMatch(line, searchFrom);
+    if (!m) break;
+    out += line.slice(cursor, m.start);
+    out += cb(line.slice(m.start, m.end), m.head, m.body, m.tail, m.start);
+    cursor = m.end;
+    searchFrom = m.end;
+  }
+  out += line.slice(cursor);
+  return out;
+}
 
 export function rewriteAnnotationIds(
   content: string,
@@ -592,7 +806,7 @@ export function rewriteAnnotationIds(
     // masked copy at each match position to decide whether the match sits
     // inside a protected span.
     const masked = maskInlineProtectedSpans(original);
-    const rewritten = original.replace(ANNOTATION_RE_LINE, (match, head, body, tail, offset) => {
+    const rewritten = replaceAnnotations(original, (match, head, body, tail, offset) => {
       const slice = masked.slice(offset, offset + match.length);
       // If the same span in the masked copy is entirely whitespace, the
       // match overlaps a protected region — leave it untouched.

--- a/src/rename.ts
+++ b/src/rename.ts
@@ -458,6 +458,11 @@ function rewriteFrontmatterNodeId(
   if (!isMap(artgraphNode)) return { content, change: null };
   const nodeIdNode = artgraphNode.get("node_id", true);
   if (!isScalar(nodeIdNode)) return { content, change: null };
+  // An explicit tag (`!!str "…"`) or anchor (`&a …`) sits between the key and
+  // the value, so the scalar's range covers the value token only — a splice
+  // would keep the tag/anchor while swapping the text under it. The old regex
+  // never extracted a bare value from these shapes either; leave them alone.
+  if (nodeIdNode.tag != null || nodeIdNode.anchor != null) return { content, change: null };
   if (typeof nodeIdNode.value !== "string" || nodeIdNode.value !== oldId) {
     return { content, change: null };
   }

--- a/tests/perf/rename-redos.perf.test.ts
+++ b/tests/perf/rename-redos.perf.test.ts
@@ -1,0 +1,37 @@
+// Perf regression for the two rename-path ReDoS fixes: the parser-driven
+// node_id rewrite and the linear annotation scanner. Attack strings are the
+// corrected constructions confirmed to reproduce catastrophic backtracking
+// on the OLD regex-based implementations (the originally reported strings
+// did not — they completed in ~0ms):
+//   - FM_NODE_ID_RE measured ~1.3-1.8s at n=40000 (O(n^2) backtracking)
+//   - ANNOTATION_RE_LINE measured ~2.5-2.8s at n=2000
+// Runs in the dedicated perf config (singleFork, no fileParallelism,
+// retry: 1) so the wall-clock assertions own the CPU during measurement.
+import { describe, it, expect } from "vitest";
+import { rewriteAnnotationIds, rewriteFrontmatter } from "../../src/rename.js";
+
+describe("rename rewriters — ReDoS perf regression", () => {
+  it("rewriteFrontmatter completes well under the old quadratic-backtracking blowup", () => {
+    const n = 40000;
+    const attackLine = "node_id:a" + " ".repeat(n) + "b";
+    const content = ["---", attackLine, "---", "# Body"].join("\n");
+
+    const start = performance.now();
+    rewriteFrontmatter(content, "doc:old", "doc:new");
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it("rewriteAnnotationIds completes well under the old super-linear backtracking blowup", () => {
+    const n = 2000;
+    const attackLine = "(depends_on: " + " ".repeat(n) + "a".repeat(n); // no closing paren
+    const content = ["# spec", "", `- X: y ${attackLine}`].join("\n");
+
+    const start = performance.now();
+    rewriteAnnotationIds(content, "AUTH-001", "AUTH-100");
+    const elapsed = performance.now() - start;
+
+    expect(elapsed).toBeLessThan(500);
+  });
+});

--- a/tests/rename.test.ts
+++ b/tests/rename.test.ts
@@ -229,6 +229,20 @@ describe("rewriteFrontmatter", () => {
     }
   });
 
+  it("leaves an explicitly tagged or anchored node_id scalar alone (the old regex never unwrapped these)", () => {
+    const tagged = ["---", "artgraph:", '  node_id: !!str "doc:old"', "---"].join("\n");
+    const anchored = ["---", "artgraph:", "  node_id: &keep doc:old", "---"].join("\n");
+    for (const input of [tagged, anchored]) {
+      const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
+      expect(content).toBe(input);
+      expect(changes).toHaveLength(0);
+    }
+    // Positive control: the same document shape minus the tag/anchor rewrites,
+    // so the skips above exercise the guard rather than a failed parse.
+    const plain = ["---", "artgraph:", "  node_id: doc:old", "---"].join("\n");
+    expect(rewriteFrontmatter(plain, "doc:old", "doc:new").content).toContain("node_id: doc:new");
+  });
+
   it("rewrites node_id with a trailing inline comment, preserving the comment", () => {
     const input = ["---", "artgraph:", "  node_id: doc:old # keep me", "---"].join("\n");
     const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
@@ -1014,41 +1028,6 @@ describe("rewriteAnnotationIds", () => {
     const { content, changes } = rewriteAnnotationIds(input, "AUTH-001", "AUTH-100");
     expect(content).toBe("- X: y (depends_on: AUTH-002) and (depends_on: AUTH-100)");
     expect(changes).toHaveLength(1);
-  });
-});
-
-// ── Perf regression: ReDoS fixed by the parser-driven node_id rewrite and
-// the linear annotation scanner (issue-tracked; see plan). Attack strings
-// below are the corrected constructions confirmed to actually reproduce
-// catastrophic backtracking on the OLD regex-based implementations (the
-// originally reported strings did not — they completed in ~0ms).
-describe("rewriteFrontmatter / rewriteAnnotationIds — ReDoS perf regression", () => {
-  it("rewriteFrontmatter completes well under the old quadratic-backtracking blowup", () => {
-    const n = 40000;
-    const attackLine = "node_id:a" + " ".repeat(n) + "b";
-    const content = ["---", attackLine, "---", "# Body"].join("\n");
-
-    const start = performance.now();
-    rewriteFrontmatter(content, "doc:old", "doc:new");
-    const elapsed = performance.now() - start;
-
-    // Old regex (FM_NODE_ID_RE) measured ~1.3-1.8s at this size (O(n^2)
-    // backtracking); the new parser-driven rewrite is O(n).
-    expect(elapsed).toBeLessThan(500);
-  });
-
-  it("rewriteAnnotationIds completes well under the old super-linear backtracking blowup", () => {
-    const n = 2000;
-    const attackLine = "(depends_on: " + " ".repeat(n) + "a".repeat(n); // no closing paren
-    const content = ["# spec", "", `- X: y ${attackLine}`].join("\n");
-
-    const start = performance.now();
-    rewriteAnnotationIds(content, "AUTH-001", "AUTH-100");
-    const elapsed = performance.now() - start;
-
-    // Old regex (ANNOTATION_RE_LINE) measured ~2.5-2.8s at this size; the new
-    // linear scanner is O(n).
-    expect(elapsed).toBeLessThan(500);
   });
 });
 

--- a/tests/rename.test.ts
+++ b/tests/rename.test.ts
@@ -13,6 +13,7 @@ import {
   rewriteFile,
 } from "../src/rename.js";
 import { buildGraph } from "../src/graph/builder.js";
+import { executeMerge } from "../src/rename-executor.js";
 import type { ArtgraphConfig } from "../src/types.js";
 import { renameLockKey, splitLockKey, mergeLockKeys } from "../src/rename-lock.js";
 import { isValidTargetId } from "../src/rename-validate-id.js";
@@ -187,11 +188,148 @@ describe("rewriteTestTags", () => {
 
 describe("rewriteFrontmatter", () => {
   it("rewrites node_id inside frontmatter", () => {
-    const input = ["---", 'node_id: "doc:old"', "---", "# Body content"].join("\n");
+    // Contract shape (specs/008-document-graph/contracts/frontmatter-schema.md):
+    // `node_id` lives under the `artgraph` key — the reader (markdown.ts)
+    // only ever consumes `frontmatter.artgraph.node_id`.
+    const input = ["---", "artgraph:", '  node_id: "doc:old"', "---", "# Body content"].join("\n");
     const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
-    expect(content).toBe(["---", 'node_id: "doc:new"', "---", "# Body content"].join("\n"));
+    expect(content).toBe(
+      ["---", "artgraph:", '  node_id: "doc:new"', "---", "# Body content"].join("\n"),
+    );
     expect(changes).toHaveLength(1);
     expect(changes[0].kind).toBe("frontmatter-depends-on");
+  });
+
+  it("preserves node_id scalar style (plain / single-quoted / double-quoted) across the rewrite", () => {
+    for (const [before, after] of [
+      ["node_id: doc:old", "node_id: doc:new"],
+      ["node_id: 'doc:old'", "node_id: 'doc:new'"],
+      ['node_id: "doc:old"', 'node_id: "doc:new"'],
+    ]) {
+      const input = ["---", "artgraph:", `  ${before}`, "---"].join("\n");
+      const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
+      expect(content).toBe(["---", "artgraph:", `  ${after}`, "---"].join("\n"));
+      expect(changes).toHaveLength(1);
+    }
+  });
+
+  it("quotes a plain-style rewrite when the bare newId would re-parse as a non-string (number / bool / trailing colon)", () => {
+    for (const [newId, expected] of [
+      ["123", '"123"'],
+      ["1.1", '"1.1"'],
+      ["true", '"true"'],
+      ["doc:", '"doc:"'],
+    ]) {
+      const input = ["---", "artgraph:", "  node_id: doc:old", "---"].join("\n");
+      const { content, changes } = rewriteFrontmatter(input, "doc:old", newId);
+      // Bare, these would come back from YAML as 123 / 1.1 / true / { doc: null }
+      // and the reader's typeof check would drop the id entirely.
+      expect(content).toBe(["---", "artgraph:", `  node_id: ${expected}`, "---"].join("\n"));
+      expect(changes).toHaveLength(1);
+    }
+  });
+
+  it("rewrites node_id with a trailing inline comment, preserving the comment", () => {
+    const input = ["---", "artgraph:", "  node_id: doc:old # keep me", "---"].join("\n");
+    const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
+    expect(content).toBe(["---", "artgraph:", "  node_id: doc:new # keep me", "---"].join("\n"));
+    expect(changes).toHaveLength(1);
+  });
+
+  it("rewrites node_id written as a flow map (`artgraph: { node_id: ... }`)", () => {
+    const input = ["---", "artgraph: { node_id: doc:old, depends_on: [] }", "---"].join("\n");
+    const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
+    expect(content).toContain("node_id: doc:new");
+    expect(changes).toHaveLength(1);
+  });
+
+  it("does NOT rewrite a top-level (non-artgraph-nested) node_id — only frontmatter.artgraph.node_id is a reference", () => {
+    // Positive control (artgraph.node_id below) proves the parse path is
+    // actually reached; the top-level key sitting right next to it is the
+    // negative assertion.
+    const input = ["---", "node_id: doc:old", "artgraph:", "  node_id: doc:old", "---"].join("\n");
+    const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
+    expect(content).toBe(
+      ["---", "node_id: doc:old", "artgraph:", "  node_id: doc:new", "---"].join("\n"),
+    );
+    expect(changes).toHaveLength(1);
+  });
+
+  it("does NOT rewrite node_id inside YAML the reader would fail to parse, but the depends_on loop still runs (parity)", () => {
+    // node_id: "doc:old' — asymmetric quotes; parseDocument reports an error
+    // (unterminated double-quoted scalar), matching parseFrontmatter's own
+    // throw-and-ignore-whole-frontmatter behaviour for this file.
+    // Positive control: the depends_on block below is untouched by the
+    // node_id logic (#403 scope) and must still be rewritten, proving the
+    // loop ran rather than bailing out entirely.
+    const input = [
+      "---",
+      "artgraph:",
+      "  node_id: \"doc:old'",
+      "depends_on:",
+      "  - doc:old",
+      "---",
+    ].join("\n");
+    const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
+    expect(content).toBe(
+      ["---", "artgraph:", "  node_id: \"doc:old'", "depends_on:", "  - doc:new", "---"].join("\n"),
+    );
+    expect(changes).toHaveLength(1);
+    expect(changes[0].before).toBe("  - doc:old");
+  });
+
+  // CRLF regression pin (mergeMarkdown calls rewriteFrontmatter directly on
+  // un-normalized, CRLF-terminated content — see rewriteFile's own F4 comment
+  // for the *other* rewriters, which normalize first; this path does not).
+  // Must keep working exactly as it did on the old regex: node_id is
+  // rewritten and every "\r\n" survives untouched.
+  it("CRLF: rewrites an artgraph-nested node_id and preserves \\r\\n line endings (merge-path parity)", () => {
+    for (const [before, after] of [
+      ["node_id: doc:old", "node_id: doc:new"],
+      ['node_id: "doc:old"', 'node_id: "doc:new"'],
+    ]) {
+      const input = ["---", "artgraph:", `  ${before}`, "---", "# Body"].join("\r\n") + "\r\n";
+      const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
+      expect(content).toBe(
+        ["---", "artgraph:", `  ${after}`, "---", "# Body"].join("\r\n") + "\r\n",
+      );
+      expect(content).toContain("\r\n");
+      // No line ending was silently converted to a bare LF anywhere.
+      expect(/[^\r]\n/.test(content)).toBe(false);
+      expect(changes).toHaveLength(1);
+    }
+  });
+
+  // Wiring test: the same CRLF node_id rewrite, exercised through the real
+  // executeMerge -> mergeMarkdown call chain (src/rename-executor.ts), which
+  // reads the file as-is off disk and calls rewriteFrontmatter on that raw,
+  // un-normalized content — unlike rewriteFile's other callers.
+  it("CRLF via executeMerge/mergeMarkdown: node_id rewrite lands on disk with \\r\\n preserved", () => {
+    const tmpRoot = mkdtempSync(resolve(tmpdir(), "artgraph-rename-crlf-merge-"));
+    try {
+      mkdirSync(resolve(tmpRoot, "specs"), { recursive: true });
+      const specPath = resolve(tmpRoot, "specs", "a.md");
+      const original =
+        ["---", "artgraph:", "  node_id: doc:old", "---", "# A"].join("\r\n") + "\r\n";
+      writeFileSync(specPath, original);
+
+      const result = executeMerge({
+        dryRun: false,
+        format: "json",
+        rootDir: tmpRoot,
+        mergeIds: ["doc:old"],
+        intoId: "doc:new",
+      });
+
+      expect(result.changes.some((c) => c.kind === "frontmatter-depends-on")).toBe(true);
+      const written = readFileSync(specPath, "utf-8");
+      expect(written).toBe(
+        ["---", "artgraph:", "  node_id: doc:new", "---", "# A"].join("\r\n") + "\r\n",
+      );
+      expect(/[^\r]\n/.test(written)).toBe(false);
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
   });
 
   it("rewrites id inside depends_on in frontmatter", () => {
@@ -262,7 +400,7 @@ describe("rewriteFrontmatter", () => {
   });
 
   it("still accepts trailing whitespace on fences (gray-matter parity)", () => {
-    const input = ["--- ", 'node_id: "doc:old"', "---\t", "# Body"].join("\n");
+    const input = ["--- ", "artgraph:", '  node_id: "doc:old"', "---\t", "# Body"].join("\n");
     const { content, changes } = rewriteFrontmatter(input, "doc:old", "doc:new");
     expect(content).toContain('node_id: "doc:new"');
     expect(changes).toHaveLength(1);
@@ -833,6 +971,84 @@ describe("rewriteAnnotationIds", () => {
     const input = "- X: y (depends_on: AUTH-0010)";
     const { content } = rewriteAnnotationIds(input, "AUTH-001", "AUTH-100");
     expect(content).toBe(input);
+  });
+
+  // Linear-scanner equivalence edge cases (the scanner replaces a ReDoS-able
+  // regex — see the perf suite below — so these pin the same behaviour the
+  // old regex had, fixed via direct comparison against it before the swap).
+  it("double-paren: the outer `(` fails to open an annotation, the inner one succeeds", () => {
+    const input = "- X: y ((depends_on: AUTH-001))";
+    const { content, changes } = rewriteAnnotationIds(input, "AUTH-001", "AUTH-100");
+    expect(content).toBe("- X: y ((depends_on: AUTH-100))");
+    expect(changes).toHaveLength(1);
+  });
+
+  it("empty body is a no-op (no ID token for idTokenRE to match)", () => {
+    const input = "- X: y (depends_on: )";
+    const { content, changes } = rewriteAnnotationIds(input, "AUTH-001", "AUTH-100");
+    expect(content).toBe(input);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("an unclosed annotation (no closing paren) is left unchanged", () => {
+    const input = "- X: y (depends_on: AUTH-001";
+    const { content, changes } = rewriteAnnotationIds(input, "AUTH-001", "AUTH-100");
+    expect(content).toBe(input);
+    expect(changes).toHaveLength(0);
+  });
+
+  it("tab whitespace around the keyword/colon/close-paren is preserved", () => {
+    const input = "- X: y (depends_on\t:\tAUTH-001\t)";
+    const { content } = rewriteAnnotationIds(input, "AUTH-001", "AUTH-100");
+    expect(content).toBe("- X: y (depends_on\t:\tAUTH-100\t)");
+  });
+
+  it("extra spaces around the keyword/colon are preserved", () => {
+    const input = "- X: y (   depends_on   :   AUTH-001   )";
+    const { content } = rewriteAnnotationIds(input, "AUTH-001", "AUTH-100");
+    expect(content).toBe("- X: y (   depends_on   :   AUTH-100   )");
+  });
+
+  it("two separate annotations on one line: only the one containing oldId changes", () => {
+    const input = "- X: y (depends_on: AUTH-002) and (depends_on: AUTH-001)";
+    const { content, changes } = rewriteAnnotationIds(input, "AUTH-001", "AUTH-100");
+    expect(content).toBe("- X: y (depends_on: AUTH-002) and (depends_on: AUTH-100)");
+    expect(changes).toHaveLength(1);
+  });
+});
+
+// ── Perf regression: ReDoS fixed by the parser-driven node_id rewrite and
+// the linear annotation scanner (issue-tracked; see plan). Attack strings
+// below are the corrected constructions confirmed to actually reproduce
+// catastrophic backtracking on the OLD regex-based implementations (the
+// originally reported strings did not — they completed in ~0ms).
+describe("rewriteFrontmatter / rewriteAnnotationIds — ReDoS perf regression", () => {
+  it("rewriteFrontmatter completes well under the old quadratic-backtracking blowup", () => {
+    const n = 40000;
+    const attackLine = "node_id:a" + " ".repeat(n) + "b";
+    const content = ["---", attackLine, "---", "# Body"].join("\n");
+
+    const start = performance.now();
+    rewriteFrontmatter(content, "doc:old", "doc:new");
+    const elapsed = performance.now() - start;
+
+    // Old regex (FM_NODE_ID_RE) measured ~1.3-1.8s at this size (O(n^2)
+    // backtracking); the new parser-driven rewrite is O(n).
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  it("rewriteAnnotationIds completes well under the old super-linear backtracking blowup", () => {
+    const n = 2000;
+    const attackLine = "(depends_on: " + " ".repeat(n) + "a".repeat(n); // no closing paren
+    const content = ["# spec", "", `- X: y ${attackLine}`].join("\n");
+
+    const start = performance.now();
+    rewriteAnnotationIds(content, "AUTH-001", "AUTH-100");
+    const elapsed = performance.now() - start;
+
+    // Old regex (ANNOTATION_RE_LINE) measured ~2.5-2.8s at this size; the new
+    // linear scanner is O(n).
+    expect(elapsed).toBeLessThan(500);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #402. Removes both polynomial-backtracking regexes from the rename rewrite path — the CodeQL-flagged one and a worse one CodeQL missed (found by the Step 0-pre investigation, measured, and recorded in #402's update):

- **`FM_NODE_ID_RE`** (quadratic, `js/polynomial-redos`): replaced by a structural rewrite. `rewriteFrontmatterNodeId` parses the frontmatter body with `parseDocument` (same `resolveKnownTags: false` option as the reader's `parseFrontmatter`), navigates to `artgraph.node_id` — the one location the reader consumes (`src/parsers/markdown.ts:219-227`, contract `specs/008-document-graph/contracts/frontmatter-schema.md`) — and splices the scalar's source range in place, preserving quote style, inline comments, surrounding bytes, and CRLF.
- **`ANNOTATION_RE_LINE`** (~cubic on an unclosed annotation, reached by every `rename --from/--to` incl. `--dry-run` on every scanned `.md`): replaced by `findNextAnnotationMatch`/`replaceAnnotations`, a linear scanner computing the same `(match, head, body, tail, offset)` the regex callback received. The masked-span protection and `idTokenRE` body rewriting are reused unchanged; equivalence was additionally fuzz-checked (~700k cases, byte-for-byte against the old regex).

The `depends_on`/`derives_from` line loop (`FM_BLOCK_KEY_RE`) is deliberately untouched — its separate CRLF defect is #403.

## Change type

- [x] fix (bug fix)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — unit + e2e + perf suites green; `tests/rename.test.ts` now 97 tests
- [x] Added tests where needed — +16: scalar-style preservation, inline comment, flow map, top-level-`node_id` negative (with in-test positive control), malformed-YAML negative (with `depends_on`-loop positive control), CRLF direct + through `mergeMarkdown` (merge-path regression pins), non-string requote guard, annotation-scanner edges, and two ReDoS perf regressions
- [x] Ran `pnpm -r knip` and `pnpm -r build` — plus `lint`, `typecheck`, `format:check`, and `artgraph check --diff` (pass, no new issues)

Perf regression tests use attack shapes re-measured against the old compiled code (the shapes originally written in #402 complete in ~0ms and prove nothing — corrected in the issue):

| path | n | old | new | test threshold |
|---|---|---|---|---|
| `rewriteFrontmatter` node_id line `"node_id:a" + " ".repeat(n) + "b"` | 40000 | ~1.4-1.8s | ~2ms | &lt;500ms |
| `rewriteAnnotationIds` line `"(depends_on: " + " ".repeat(n) + "a".repeat(n)`, unclosed | 2000 | ~2.5-2.8s | ~0.4ms | &lt;500ms |

## Breaking change

- [x] No

Edge-case behavior does change on inputs outside the documented frontmatter contract, in the reader's direction (all pinned by tests, see Notes).

## Notes

Intentional behavior changes (reader/contract parity):

1. Only `frontmatter.artgraph.node_id` is rewritten. A top-level `node_id:` is a location the reader never consumes; two existing test fixtures written in that shape were updated to the contract form.
2. Malformed YAML frontmatter (asymmetric/unclosed quotes, duplicate keys) no longer gets a node_id rewrite — the reader throws and ignores the whole block, so the old regex was editing a value nothing reads. The `depends_on` loop still runs there (pinned).
3. Flow-map form (`artgraph: { node_id: x }`) and inline comments (`node_id: x # note`) are now handled correctly (old regex missed the former and mis-took `x # note` as the value).
4. A plain-style rewrite re-quotes when the bare `newId` would re-parse as a non-string (`123`, `1.1`, `true`, trailing `:`) — previously such a rename silently produced a value the reader's `typeof` check drops.
5. Annotation rewriting is behavior-identical; only the engine changed.

Follow-ups filed/accepted: #403 (CRLF no-op in merge/split `depends_on` rewrites, discovered by the same investigation); `req:` test-tag quote asymmetry left as-is (consistency note only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxwmDDksrdSBwKcvLNq2Jw

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxwmDDksrdSBwKcvLNq2Jw)_