### PR TITLE
fix(rename): merge/split normalize CRLF at the function boundary, like rename always has

### DIFF
--- a/src/rename-executor.ts
+++ b/src/rename-executor.ts
@@ -11,6 +11,9 @@ import {
   fencedLines,
   extOf,
   escapeRegExp,
+  detectNewline,
+  normalizeNewlines,
+  restoreNewlines,
   type RewriteChange,
   type RewriteOptions,
 } from "./rename.js";
@@ -943,16 +946,27 @@ function referencesId(line: string, id: string): boolean {
  * source's definition (issue #213) — mirroring mergeMarkdown's
  * `removedAnyDefinition` gate. Without this, every enumerated markdown file
  * received one scaffold per new ID.
+ *
+ * Normalizes CRLF/CR to LF once at this function boundary and restores the
+ * original style on the returned content — the same F4 helpers `rewriteFile`
+ * (rename.ts) uses for its own pipeline, so `specDefinitionId`'s heading
+ * branch and `expandFrontmatterDependsOn`'s `FM_BLOCK_KEY_RE` see a single
+ * `\n` regardless of how the file was checked out.
+ *
+ * Exported purely for direct unit testing of that boundary — the real
+ * caller reaches this only through `executeSplit` above.
  */
-function splitMarkdown(
+export function splitMarkdown(
   relPath: string,
   content: string,
   splitId: string,
   intoIds: string[],
   opts: RewriteOptions,
 ): { content: string; changes: RewriteChange[] } {
-  const lines = content.split("\n");
-  const fenced = fencedLines(content);
+  const originalNewline = detectNewline(content);
+  const normalized = normalizeNewlines(content);
+  const lines = normalized.split("\n");
+  const fenced = fencedLines(normalized);
   const changes: RewriteChange[] = [];
 
   const kept: string[] = [];
@@ -997,7 +1011,7 @@ function splitMarkdown(
     }
   }
 
-  return { content: next, changes };
+  return { content: restoreNewlines(next, originalNewline), changes };
 }
 
 /**
@@ -1006,8 +1020,19 @@ function splitMarkdown(
  * scaffold for intoId only when it is a brand-new requirement. Crucially the
  * definition lines are removed *instead of* being rewritten, so intoId is never
  * duplicated (C1).
+ *
+ * Normalizes CRLF/CR to LF once at this function boundary and restores the
+ * original style on the returned content — the same F4 helpers `rewriteFile`
+ * (rename.ts) uses for its own pipeline, so `specDefinitionId`'s heading
+ * branch and the `rewriteFrontmatter` calls below (via `FM_BLOCK_KEY_RE`) see
+ * a single `\n` regardless of how the file was checked out. Normalizing once
+ * here — rather than per `idsToRewrite` iteration — keeps the `rewriteFrontmatter`
+ * loop itself untouched.
+ *
+ * Exported purely for direct unit testing of that boundary — the real
+ * caller reaches this only through `executeMerge` above.
  */
-function mergeMarkdown(
+export function mergeMarkdown(
   relPath: string,
   content: string,
   idsToRewrite: string[],
@@ -1015,8 +1040,10 @@ function mergeMarkdown(
   intoIsExisting: boolean,
   opts: RewriteOptions,
 ): { content: string; changes: RewriteChange[] } {
-  const lines = content.split("\n");
-  const fenced = fencedLines(content);
+  const originalNewline = detectNewline(content);
+  const normalized = normalizeNewlines(content);
+  const lines = normalized.split("\n");
+  const fenced = fencedLines(normalized);
   const changes: RewriteChange[] = [];
   const removeSet = new Set(idsToRewrite);
 
@@ -1068,7 +1095,7 @@ function mergeMarkdown(
     next = outLines.join("\n");
   }
 
-  return { content: next, changes };
+  return { content: restoreNewlines(next, originalNewline), changes };
 }
 
 // ── Lock projection ──────────────────────────────────────────────────

--- a/src/rename-executor.ts
+++ b/src/rename-executor.ts
@@ -839,7 +839,10 @@ export function executeMerge(
       }
     } else {
       // Code/test files: collapse @impl and test references onto intoId.
-      let next = content;
+      // Same normalize/restore boundary as mergeMarkdown, so the change
+      // records stay \r-free and the on-disk style survives untouched.
+      const originalNewline = detectNewline(content);
+      let next = normalizeNewlines(content);
       const fileChanges: RewriteChange[] = [];
       for (const oldId of idsToRewrite) {
         const implRes = rewriteImplTags(next, oldId, intoId);
@@ -853,7 +856,7 @@ export function executeMerge(
       }
       if (fileChanges.length > 0) {
         allChanges.push(...fileChanges);
-        filesToWrite.set(absPath, next);
+        filesToWrite.set(absPath, restoreNewlines(next, originalNewline));
       }
     }
   }
@@ -963,6 +966,11 @@ export function splitMarkdown(
   intoIds: string[],
   opts: RewriteOptions,
 ): { content: string; changes: RewriteChange[] } {
+  // executeSplit validates this before scanning; repeated here so a direct
+  // caller can't remove a definition line without leaving any replacement.
+  if (intoIds.length === 0) {
+    throw new Error(`splitMarkdown requires at least one target ID.`);
+  }
   const originalNewline = detectNewline(content);
   const normalized = normalizeNewlines(content);
   const lines = normalized.split("\n");

--- a/src/rename.ts
+++ b/src/rename.ts
@@ -845,6 +845,34 @@ export function rewriteAnnotationIds(
   return { content: lines.join("\n"), changes };
 }
 
+/**
+ * The line-ending style `content` was written with: `"\r\n"` if it contains
+ * at least one CRLF pair, `"\n"` otherwise (a file with only lone `\r` is
+ * treated as LF, matching `normalizeNewlines`'s own handling of stray `\r`
+ * below). Pair with `normalizeNewlines`/`restoreNewlines` to round-trip a
+ * rewrite pipeline through a single line ending regardless of how the file
+ * was checked out.
+ */
+export function detectNewline(content: string): "\r\n" | "\n" {
+  return content.includes("\r\n") ? "\r\n" : "\n";
+}
+
+/**
+ * Collapse CRLF and lone CR to LF so line-based regexes and annotation
+ * matching behave identically across platforms (see `rewriteFile` below).
+ */
+export function normalizeNewlines(content: string): string {
+  return content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/**
+ * Undo `normalizeNewlines`, converting every `\n` back to `newline`. A no-op
+ * when `newline` is already `"\n"`.
+ */
+export function restoreNewlines(content: string, newline: "\r\n" | "\n"): string {
+  return newline === "\n" ? content : content.replace(/\n/g, newline);
+}
+
 export function rewriteFile(
   filePath: string,
   content: string,
@@ -859,9 +887,11 @@ export function rewriteFile(
   // and annotation matching behave identically across platforms. Restore the
   // original newline style at the end (meta-review additional F4 — without
   // this, the rewriter no-ops on Windows-checked-out spec files while the
-  // parser still produces edges).
-  const originalNewline = content.includes("\r\n") ? "\r\n" : "\n";
-  let current = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  // parser still produces edges). mergeMarkdown/splitMarkdown
+  // (rename-executor.ts) share this same normalize/restore boundary via the
+  // three helpers above.
+  const originalNewline = detectNewline(content);
+  let current = normalizeNewlines(content);
 
   const apply = (fn: (c: string) => RewriteResult) => {
     const result = fn(current);
@@ -883,9 +913,5 @@ export function rewriteFile(
     change.filePath = filePath;
   }
 
-  if (originalNewline !== "\n") {
-    current = current.replace(/\n/g, originalNewline);
-  }
-
-  return { content: current, changes: allChanges };
+  return { content: restoreNewlines(current, originalNewline), changes: allChanges };
 }

--- a/tests/rename.test.ts
+++ b/tests/rename.test.ts
@@ -858,6 +858,48 @@ describe("CRLF: mergeMarkdown/splitMarkdown normalize/restore boundary", () => {
       rmSync(tmpRoot, { recursive: true, force: true });
     }
   });
+
+  it("executeMerge wiring: a CRLF code file keeps \\r\\n on disk while its impl/test-tag change records are \\r-free (same contract as the .md branch)", () => {
+    const tmpRoot = mkdtempSync(resolve(tmpdir(), "artgraph-rename-crlf-merge-code-"));
+    try {
+      mkdirSync(resolve(tmpRoot, "specs"), { recursive: true });
+      mkdirSync(resolve(tmpRoot, "src"), { recursive: true });
+      const aPath = resolve(tmpRoot, "specs", "a.md");
+      const fPath = resolve(tmpRoot, "src", "f.ts");
+      writeFileSync(aPath, ["---", "artgraph:", "  node_id: x", "---", "# A"].join("\n") + "\n");
+      writeFileSync(fPath, ["// @impl x", "export const a = 1;"].join("\r\n") + "\r\n");
+
+      const result = executeMerge({
+        dryRun: false,
+        format: "json",
+        rootDir: tmpRoot,
+        mergeIds: ["x"],
+        intoId: "doc:y",
+      });
+
+      const codeChanges = result.changes.filter((c) => c.filePath.endsWith("f.ts"));
+      expect(codeChanges.length).toBeGreaterThanOrEqual(1);
+      for (const c of codeChanges) {
+        expect(c.before).not.toContain("\r");
+        expect(c.after).not.toContain("\r");
+      }
+      const written = readFileSync(fPath, "utf-8");
+      expect(written).toBe(["// @impl doc:y", "export const a = 1;"].join("\r\n") + "\r\n");
+      expect(written).not.toContain("\r\r\n");
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("splitMarkdown called directly with no target IDs throws instead of deleting a definition without replacement", () => {
+    const input = ["# Spec", "", "- REQ-001: user login flow"].join("\n") + "\n";
+    expect(() => splitMarkdown("specs/spec.md", input, "REQ-001", [], {})).toThrow(
+      /at least one target ID/,
+    );
+    // Positive control: the same call with a target rewrites normally.
+    const ok = splitMarkdown("specs/spec.md", input, "REQ-001", ["REQ-101"], {});
+    expect(ok.changes.length).toBeGreaterThanOrEqual(1);
+  });
 });
 
 // ── renameLockKey ───────────────────────────────────────────────────

--- a/tests/rename.test.ts
+++ b/tests/rename.test.ts
@@ -13,7 +13,13 @@ import {
   rewriteFile,
 } from "../src/rename.js";
 import { buildGraph } from "../src/graph/builder.js";
-import { executeMerge } from "../src/rename-executor.js";
+import {
+  executeMerge,
+  executeSplit,
+  executeRename,
+  mergeMarkdown,
+  splitMarkdown,
+} from "../src/rename-executor.js";
 import type { ArtgraphConfig } from "../src/types.js";
 import { renameLockKey, splitLockKey, mergeLockKeys } from "../src/rename-lock.js";
 import { isValidTargetId } from "../src/rename-validate-id.js";
@@ -292,9 +298,12 @@ describe("rewriteFrontmatter", () => {
     expect(changes[0].before).toBe("  - doc:old");
   });
 
-  // CRLF regression pin (mergeMarkdown calls rewriteFrontmatter directly on
-  // un-normalized, CRLF-terminated content — see rewriteFile's own F4 comment
-  // for the *other* rewriters, which normalize first; this path does not).
+  // CRLF regression pin: calls rewriteFrontmatter directly on raw,
+  // un-normalized CRLF content, bypassing the F4 normalize/restore boundary
+  // rewriteFile applies around its own rewriters (see rewriteFile's own F4
+  // comment) — mergeMarkdown/splitMarkdown now share that same boundary too
+  // (see the wiring test below), but this pins that rewriteFrontmatter's
+  // node_id path is CRLF-tolerant even called unwrapped.
   // Must keep working exactly as it did on the old regex: node_id is
   // rewritten and every "\r\n" survives untouched.
   it("CRLF: rewrites an artgraph-nested node_id and preserves \\r\\n line endings (merge-path parity)", () => {
@@ -315,9 +324,11 @@ describe("rewriteFrontmatter", () => {
   });
 
   // Wiring test: the same CRLF node_id rewrite, exercised through the real
-  // executeMerge -> mergeMarkdown call chain (src/rename-executor.ts), which
-  // reads the file as-is off disk and calls rewriteFrontmatter on that raw,
-  // un-normalized content — unlike rewriteFile's other callers.
+  // executeMerge -> mergeMarkdown call chain (src/rename-executor.ts).
+  // mergeMarkdown normalizes/restores around its rewriteFrontmatter calls at
+  // its own function boundary (the same F4 helpers rewriteFile uses), so
+  // this pins the end-to-end on-disk result rather than the unwrapped
+  // function call above.
   it("CRLF via executeMerge/mergeMarkdown: node_id rewrite lands on disk with \\r\\n preserved", () => {
     const tmpRoot = mkdtempSync(resolve(tmpdir(), "artgraph-rename-crlf-merge-"));
     try {
@@ -542,6 +553,310 @@ describe("rewriteFile", () => {
     const { content, changes } = rewriteFile("data/config.yaml", input, "REQ-001", "REQ-100");
     expect(content).toBe(input);
     expect(changes).toHaveLength(0);
+  });
+});
+
+// ── CRLF: mergeMarkdown/splitMarkdown share rewriteFile's F4 boundary ──
+//
+// Before this wiring, mergeMarkdown/splitMarkdown (rename-executor.ts) never
+// normalized CRLF/CR to LF before their own line-based passes, so
+// FM_BLOCK_KEY_RE (depends_on/derives_from) and specDefinitionId's heading
+// branch — both anchored with an un-flagged `$` — silently failed to match a
+// CRLF-terminated line. Both functions now normalize/restore once at their
+// own function boundary via the same detectNewline/normalizeNewlines/
+// restoreNewlines helpers rewriteFile (rename.ts) uses.
+
+describe("CRLF: mergeMarkdown/splitMarkdown normalize/restore boundary", () => {
+  it("mergeMarkdown: rewrites a CRLF artgraph-nested depends_on item and preserves \\r\\n", () => {
+    const input =
+      ["---", "artgraph:", "  depends_on:", "    - x", "---", "# B"].join("\r\n") + "\r\n";
+    const { content, changes } = mergeMarkdown("specs/b.md", input, ["x"], "doc:y", false, {});
+    const expected =
+      ["---", "artgraph:", "  depends_on:", "    - doc:y", "---", "# B"].join("\r\n") + "\r\n";
+    expect(content).toBe(expected);
+    expect(/[^\r]\n/.test(content)).toBe(false);
+    // candidate-B kill: restoring inside mergeMarkdown must not double up on
+    // rewriteFile's own restore (no path currently wraps both, but pinned so
+    // a future refactor can't reintroduce it silently).
+    expect(content.includes("\r\r\n")).toBe(false);
+    expect(changes.some((c) => c.kind === "frontmatter-depends-on")).toBe(true);
+    // RewriteChange contract (report §3): merge's before/after no longer
+    // carry \r, matching rewriteFile's own (rename-path) contract.
+    expect(changes.every((c) => !c.before.includes("\r") && !c.after.includes("\r"))).toBe(true);
+  });
+
+  it("derives_from sibling: mergeMarkdown rewrites a CRLF artgraph-nested derives_from item", () => {
+    const input =
+      ["---", "artgraph:", "  derives_from:", "    - x", "---", "# B"].join("\r\n") + "\r\n";
+    const { content, changes } = mergeMarkdown("specs/b.md", input, ["x"], "doc:y", false, {});
+    const expected =
+      ["---", "artgraph:", "  derives_from:", "    - doc:y", "---", "# B"].join("\r\n") + "\r\n";
+    expect(content).toBe(expected);
+    expect(/[^\r]\n/.test(content)).toBe(false);
+    expect(content.includes("\r\r\n")).toBe(false);
+    expect(changes.some((c) => c.kind === "frontmatter-depends-on")).toBe(true);
+  });
+
+  it("lone-CR-only file: detectNewline reports LF, so the merge output is silently normalized to LF (rewriteFile parity)", () => {
+    const input = ["---", "artgraph:", "  depends_on:", "    - x", "---", "# B"].join("\r");
+    const { content, changes } = mergeMarkdown("specs/b.md", input, ["x"], "doc:y", false, {});
+    expect(content).toBe(
+      ["---", "artgraph:", "  depends_on:", "    - doc:y", "---", "# B"].join("\n"),
+    );
+    // Intentional (pre-existing rewriteFile behaviour, now shared by
+    // mergeMarkdown too): a file with no real "\r\n" pair is treated as LF,
+    // so every lone "\r" is silently dropped rather than restored.
+    expect(content.includes("\r")).toBe(false);
+    expect(changes.some((c) => c.kind === "frontmatter-depends-on")).toBe(true);
+  });
+
+  it("splitMarkdown: expands a CRLF artgraph-nested depends_on item into the new IDs", () => {
+    const input =
+      ["---", "artgraph:", "  depends_on:", "    - REQ-001", "---", "# Spec"].join("\r\n") + "\r\n";
+    const { content, changes } = splitMarkdown(
+      "specs/spec.md",
+      input,
+      "REQ-001",
+      ["REQ-101", "REQ-102"],
+      {},
+    );
+    const expected =
+      ["---", "artgraph:", "  depends_on:", "    - REQ-101", "    - REQ-102", "---", "# Spec"].join(
+        "\r\n",
+      ) + "\r\n";
+    expect(content).toBe(expected);
+    expect(/[^\r]\n/.test(content)).toBe(false);
+    expect(content.includes("\r\r\n")).toBe(false);
+    expect(changes.some((c) => c.kind === "frontmatter-depends-on")).toBe(true);
+    expect(changes.every((c) => !c.before.includes("\r") && !c.after.includes("\r"))).toBe(true);
+  });
+
+  it("executeMerge wiring: a CRLF depends_on reference across two files is rewritten and no orphan-doc warning remains (issue scenario)", () => {
+    const tmpRoot = mkdtempSync(resolve(tmpdir(), "artgraph-rename-crlf-merge-depends-"));
+    try {
+      mkdirSync(resolve(tmpRoot, "specs"), { recursive: true });
+      const aPath = resolve(tmpRoot, "specs", "a.md");
+      const bPath = resolve(tmpRoot, "specs", "b.md");
+      writeFileSync(
+        aPath,
+        ["---", "artgraph:", "  node_id: x", "---", "# A"].join("\r\n") + "\r\n",
+      );
+      writeFileSync(
+        bPath,
+        ["---", "artgraph:", "  depends_on:", "    - x", "---", "# B"].join("\r\n") + "\r\n",
+      );
+
+      const result = executeMerge({
+        dryRun: false,
+        format: "json",
+        rootDir: tmpRoot,
+        mergeIds: ["x"],
+        intoId: "doc:y",
+      });
+
+      expect(result.changes.length).toBeGreaterThanOrEqual(2);
+
+      const writtenA = readFileSync(aPath, "utf-8");
+      const writtenB = readFileSync(bPath, "utf-8");
+      expect(writtenA).toBe(
+        ["---", "artgraph:", "  node_id: doc:y", "---", "# A"].join("\r\n") + "\r\n",
+      );
+      expect(writtenB).toBe(
+        ["---", "artgraph:", "  depends_on:", "    - doc:y", "---", "# B"].join("\r\n") + "\r\n",
+      );
+      for (const written of [writtenA, writtenB]) {
+        expect(/[^\r]\n/.test(written)).toBe(false);
+        expect(written.includes("\r\r\n")).toBe(false);
+      }
+
+      const cfg: ArtgraphConfig = {
+        include: [],
+        specDirs: ["specs"],
+        testPatterns: [],
+        lockFile: ".trace.lock",
+      };
+      const { warnings } = buildGraph(tmpRoot, cfg);
+      expect(warnings.filter((w) => w.type === "orphan-doc")).toHaveLength(0);
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("executeSplit wiring: a CRLF same-file depends_on reference expands to the new IDs alongside the list-item split", () => {
+    const tmpRoot = mkdtempSync(resolve(tmpdir(), "artgraph-rename-crlf-split-depends-"));
+    try {
+      mkdirSync(resolve(tmpRoot, "specs"), { recursive: true });
+      const specPath = resolve(tmpRoot, "specs", "spec.md");
+      writeFileSync(
+        specPath,
+        [
+          "---",
+          "artgraph:",
+          "  depends_on:",
+          "    - REQ-001",
+          "---",
+          "# Spec",
+          "",
+          "- REQ-001: user login flow",
+        ].join("\r\n") + "\r\n",
+      );
+
+      const result = executeSplit({
+        dryRun: false,
+        format: "json",
+        rootDir: tmpRoot,
+        splitId: "REQ-001",
+        intoIds: ["REQ-101", "REQ-102"],
+      });
+
+      expect(result.changes.length).toBeGreaterThan(0);
+      const written = readFileSync(specPath, "utf-8");
+      expect(written).not.toContain("REQ-001");
+      expect(written).toContain("    - REQ-101");
+      expect(written).toContain("    - REQ-102");
+      expect(written).toContain("- REQ-101: (TODO: describe this requirement)");
+      expect(written).toContain("- REQ-102: (TODO: describe this requirement)");
+      expect(/[^\r]\n/.test(written)).toBe(false);
+      expect(written.includes("\r\r\n")).toBe(false);
+      // RewriteChange contract (report §3): split's before/after no longer
+      // carry \r either.
+      expect(result.changes.every((c) => !c.before.includes("\r") && !c.after.includes("\r"))).toBe(
+        true,
+      );
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("heading landmine: a CRLF heading definition (`### Requirement N: ...`) now splits instead of throwing 'ID not found'", () => {
+    const tmpRoot = mkdtempSync(resolve(tmpdir(), "artgraph-rename-crlf-split-heading-"));
+    try {
+      mkdirSync(resolve(tmpRoot, "specs"), { recursive: true });
+      const specPath = resolve(tmpRoot, "specs", "spec.md");
+      writeFileSync(
+        specPath,
+        [
+          "# Kiro spec",
+          "",
+          "### Requirement 1: user login flow",
+          "",
+          "Some description text.",
+        ].join("\r\n") + "\r\n",
+      );
+
+      const result = executeSplit({
+        dryRun: false,
+        format: "json",
+        rootDir: tmpRoot,
+        splitId: "Requirement-1",
+        intoIds: ["Requirement-2", "Requirement-3"],
+      });
+
+      expect(result.changes.length).toBeGreaterThan(0);
+      const written = readFileSync(specPath, "utf-8");
+      expect(written).not.toContain("Requirement 1");
+      expect(written).toContain("- Requirement-2: (TODO: describe this requirement)");
+      expect(written).toContain("- Requirement-3: (TODO: describe this requirement)");
+      expect(written).toContain("Some description text.");
+      expect(/[^\r]\n/.test(written)).toBe(false);
+      expect(written.includes("\r\r\n")).toBe(false);
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("executeRename wiring (candidate-A regression guard): a CRLF file's node_id + depends_on + annotation all rewrite and \\r\\n survives", () => {
+    const tmpRoot = mkdtempSync(resolve(tmpdir(), "artgraph-rename-crlf-rename-"));
+    try {
+      mkdirSync(resolve(tmpRoot, "specs"), { recursive: true });
+      const aPath = resolve(tmpRoot, "specs", "a.md");
+      const bPath = resolve(tmpRoot, "specs", "b.md");
+      writeFileSync(
+        aPath,
+        ["---", "artgraph:", "  node_id: doc:old", "---", "# A"].join("\r\n") + "\r\n",
+      );
+      writeFileSync(
+        bPath,
+        [
+          "---",
+          "artgraph:",
+          "  depends_on:",
+          "    - doc:old",
+          "---",
+          "# B",
+          "",
+          "- REQ-001: something (depends_on: doc:old)",
+        ].join("\r\n") + "\r\n",
+      );
+
+      const result = executeRename({
+        dryRun: false,
+        format: "json",
+        rootDir: tmpRoot,
+        from: "doc:old",
+        to: "doc:new",
+      });
+
+      expect(result.changes.length).toBeGreaterThanOrEqual(3);
+
+      const writtenA = readFileSync(aPath, "utf-8");
+      const writtenB = readFileSync(bPath, "utf-8");
+      expect(writtenA).toBe(
+        ["---", "artgraph:", "  node_id: doc:new", "---", "# A"].join("\r\n") + "\r\n",
+      );
+      expect(writtenB).toBe(
+        [
+          "---",
+          "artgraph:",
+          "  depends_on:",
+          "    - doc:new",
+          "---",
+          "# B",
+          "",
+          "- REQ-001: something (depends_on: doc:new)",
+        ].join("\r\n") + "\r\n",
+      );
+      for (const written of [writtenA, writtenB]) {
+        expect(/[^\r]\n/.test(written)).toBe(false);
+        expect(written.includes("\r\r\n")).toBe(false);
+      }
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("executeMerge wiring: a file with no match to the merge source is left byte-for-byte untouched even though normalize+restore alone would change its bytes (changes-count write predicate)", () => {
+    const tmpRoot = mkdtempSync(resolve(tmpdir(), "artgraph-rename-crlf-merge-nomatch-"));
+    try {
+      mkdirSync(resolve(tmpRoot, "specs"), { recursive: true });
+      const aPath = resolve(tmpRoot, "specs", "a.md");
+      const dPath = resolve(tmpRoot, "specs", "d.md");
+      writeFileSync(
+        aPath,
+        ["---", "artgraph:", "  node_id: x", "---", "# A"].join("\r\n") + "\r\n",
+      );
+      // Mixed EOL, no reference to "x" anywhere: normalizeNewlines+restoreNewlines
+      // alone (with zero substantive changes) would silently turn the lone "\r"
+      // below into "\r\n" if this file were written. Pins that the executor's
+      // write predicate is `changes.length > 0`, not a content comparison, so a
+      // file with nothing to rewrite is never even considered for writing.
+      const dOriginal =
+        ["---", "artgraph:", "  depends_on:", "    - unrelated", "---"].join("\r\n") +
+        "\r\n# D\rBody with a lone CR line break.\r\n";
+      writeFileSync(dPath, dOriginal);
+
+      executeMerge({
+        dryRun: false,
+        format: "json",
+        rootDir: tmpRoot,
+        mergeIds: ["x"],
+        intoId: "doc:y",
+      });
+
+      expect(readFileSync(dPath, "utf-8")).toBe(dOriginal);
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #403. `mergeMarkdown`/`splitMarkdown` received raw file bytes from `tryReadFile`, so every line-based rewrite inside them was blind to CRLF: `FM_BLOCK_KEY_RE` never matches a line ending in `\r` (the issue's headline — `depends_on`/`derives_from` rewrites silently no-oped on merge, leaving dangling references that `check --gate` passes), and `specDefinitionId`'s heading branch has the same `.`+`$` shape (a second landmine found by the Step 0-pre investigation: CRLF heading definitions failed split/merge with "ID not found").

`rename --from/--to` was never affected because `rewriteFile` normalizes CRLF→LF and restores it on the way out (the PR #280 "F4" fix) — a one-sided application this PR makes uniform. The F4 logic is extracted into shared `detectNewline` / `normalizeNewlines` / `restoreNewlines` helpers (1:1 semantics, `rewriteFile` refactored onto them), and `mergeMarkdown`/`splitMarkdown` — plus `executeMerge`'s code/test-file branch (adversarial-review finding) — apply them exactly once at their boundary. The regexes themselves, `tryReadFile`, and the inner rewriters are untouched — the Step 0-pre investigation measured that normalizing in `tryReadFile` would break plain rename's CRLF preservation, and normalizing inside the inner rewriters would double-restore to `\r\r\n`; both misplacements are killed by dedicated regression tests.

## Change type

- [x] fix (bug fix)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — unit / e2e / perf all green; `tests/rename.test.ts` now 107
- [x] Added tests where needed — +11: the #403 scenario end-to-end (CRLF `depends_on` via `mergeMarkdown` direct and `executeMerge` wiring, `\r\n` preserved on disk), CRLF split expansion, CRLF heading-definition split (pins the second landmine), `executeRename`-through CRLF integration (kills the `tryReadFile` misplacement), a `\r\r\n`-never-appears assert (kills the inner-rewriter misplacement), `derives_from` sibling case, `\r`-free `RewriteChange` contract on both the `.md` and code-file branches, lone-CR handling, a byte-for-byte no-write pin for changeless files (write predicate is `changes.length > 0` at all four call sites), and a direct-call guard for `splitMarkdown` with empty targets
- [x] Ran `pnpm -r knip` and `pnpm -r build` — plus `lint`, `typecheck`, `format:check`, and `artgraph check --diff` (pass, no new issues)

Adversarial review (A/B against a `git worktree` of pre-fix main): 7 of the 9 boundary tests fail on the old code; the two that pass on both are deliberate regression pins (write-predicate, `executeRename` wiring), not discriminators of this diff.

## Breaking change

- [x] No

## Notes

Intentional behavior changes, all pinned by tests:

1. CRLF merge/split now actually rewrite `depends_on`/`derives_from` blocks and heading definitions (the bug fix), with the original CRLF style restored byte-for-byte on files that do get written.
2. `RewriteChange.before/after` from merge/split no longer carry `\r` — on the `.md` branch *and* `executeMerge`'s code/test branch (review finding 2) — unified with the rename path's existing contract.
3. Lone-CR-only files follow `rewriteFile`'s existing convention (`detectNewline` only preserves `\r\n`): merge/split output becomes LF, where previously the rewrites mostly no-oped and left `\r` in place.
4. `mergeMarkdown`/`splitMarkdown` are exported purely for direct boundary testing; `splitMarkdown` revalidates non-empty target IDs itself so a direct caller can't delete a definition without replacement (review finding 3).

Known, inherited limitation (disclosed by the adversarial review, filed as #409): the F4 round-trip is file-global, so a **mixed-EOL** file is homogenized to its detected style on first substantive rewrite — fenced-code line endings included, and invisibly to `--dry-run`'s per-line change list. EOL-consistent files are unaffected (byte-lossless outside the edits). This is the rename path's long-standing behavior (PR #280) now shared by merge/split; line-wise preservation is #409's scope. Also filed from review, pre-existing: #410 (`isValidTargetId` accepts control characters in `doc:` ids).

Out of scope, filed from the Step 0-pre investigation: #405 (split can't target frontmatter-only doc IDs; source doc's `node_id` survives a split), #406 (rewriter touches `depends_on` forms the reader never consumes — deferred parser-guided rewrite), #407 (`check --gate` blind to `orphan-doc` dangling references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxwmDDksrdSBwKcvLNq2Jw