### PR TITLE
perf(graph): replace the id-remap full scans with a suffix reverse index

### DIFF
--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -569,6 +569,26 @@ export function buildGraph(
     idMapping.set(`${req.specDir}/${req.id}`, finalId);
   }
 
+  // Reverse view of `idMapping` for the suffix lookups the edge remaps below
+  // need. A qualified key ends with `/<suffix>` exactly when `<suffix>` starts
+  // right after one of that key's slashes, so indexing EVERY slash boundary
+  // (the specDir separator and any slash the raw ID carries itself, e.g. a
+  // `reqPatterns` grammar that admits `mod/FR-1`) yields the same candidates a
+  // full `endsWith` scan of `idMapping` collects — in the same registration
+  // order, so a suffix claimed by several keys still resolves to the first one.
+  // Built from `idMapping`, not from `collected`, so a raw ID registered twice
+  // under one specDir stays the single entry the scan would have seen.
+  const reverseIndex = new Map<string, string[]>();
+  for (const [qualifiedKey, finalId] of idMapping) {
+    for (let i = 0; i < qualifiedKey.length; i++) {
+      if (qualifiedKey.charCodeAt(i) !== 0x2f /* "/" */) continue;
+      const suffix = qualifiedKey.slice(i + 1);
+      const bucket = reverseIndex.get(suffix);
+      if (bucket) bucket.push(finalId);
+      else reverseIndex.set(suffix, [finalId]);
+    }
+  }
+
   // Pass 2b: register nodes and emit edges with collision-aware remapping for
   // BOTH source and target. Task-emitted edges (e.g. `T001 @impl(REQ-001)`)
   // live in `req.edges`, so without this they would stay pointing at the raw
@@ -603,7 +623,13 @@ export function buildGraph(
         // must bind to authA/FR-001 when FR-001 also exists in exportB, and
         // an ambiguous task→colliding-req with no same-dir match is dropped
         // (instead of leaking as a bare-ID orphan edge — meta-review #3).
-        const resolved = resolveAnnotationTarget(edge.target, req.specDir, idMapping, collidingIds);
+        const resolved = resolveAnnotationTarget(
+          edge.target,
+          req.specDir,
+          idMapping,
+          collidingIds,
+          reverseIndex,
+        );
         if (resolved.ambiguous) {
           // research.md R6 / meta-review #3: ambiguous targets do NOT produce
           // an edge. Emitting `ambiguous-id` warning is sufficient — a stray
@@ -628,7 +654,7 @@ export function buildGraph(
 
   // Remap non-req edge targets that reference colliding IDs
   for (const edge of nonReqEdges) {
-    const remappedTarget = remapId(edge.target, idMapping, collidingIds);
+    const remappedTarget = remapId(edge.target, reverseIndex, collidingIds);
     if (collidingIds.has(edge.target) && remappedTarget === edge.target) {
       const dirs = idToDirs.get(edge.target) ?? new Set<string>();
       warnings.push({
@@ -1627,16 +1653,15 @@ function splitSymbolId(body: string): { ownerPath: string; symbolName: string } 
   };
 }
 
-function remapId(id: string, idMapping: Map<string, string>, collidingIds: Set<string>): string {
+function remapId(
+  id: string,
+  reverseIndex: Map<string, string[]>,
+  collidingIds: Set<string>,
+): string {
   if (!collidingIds.has(id)) return id;
 
   // Try to find a unique mapping
-  const matches: string[] = [];
-  for (const [qualifiedKey, finalId] of idMapping) {
-    if (qualifiedKey.endsWith(`/${id}`)) {
-      matches.push(finalId);
-    }
-  }
+  const matches = reverseIndex.get(id) ?? [];
 
   // If ambiguous, return as-is (warning already emitted or will be)
   return matches.length === 1 ? matches[0] : id;
@@ -1651,6 +1676,7 @@ function resolveAnnotationTarget(
   reqSpecDir: string,
   idMapping: Map<string, string>,
   collidingIds: Set<string>,
+  reverseIndex: Map<string, string[]>,
 ): { target: string; ambiguous: boolean } {
   const sameDirFinal = idMapping.get(`${reqSpecDir}/${target}`);
   if (collidingIds.has(target)) {
@@ -1658,10 +1684,10 @@ function resolveAnnotationTarget(
     return { target, ambiguous: true };
   }
   if (sameDirFinal) return { target: sameDirFinal, ambiguous: false };
-  // Not colliding, not in same specDir — find the unique mapping anywhere.
-  for (const [key, finalId] of idMapping) {
-    if (key.endsWith(`/${target}`)) return { target: finalId, ambiguous: false };
-  }
+  // Not colliding, not in same specDir — take the mapping registered first
+  // under this suffix anywhere.
+  const matches = reverseIndex.get(target);
+  if (matches && matches.length > 0) return { target: matches[0], ambiguous: false };
   // Not registered at all → leave as-is; orphan-edge will be raised downstream.
   return { target, ambiguous: false };
 }

--- a/src/graph/builder.ts
+++ b/src/graph/builder.ts
@@ -571,21 +571,35 @@ export function buildGraph(
 
   // Reverse view of `idMapping` for the suffix lookups the edge remaps below
   // need. A qualified key ends with `/<suffix>` exactly when `<suffix>` starts
-  // right after one of that key's slashes, so indexing EVERY slash boundary
-  // (the specDir separator and any slash the raw ID carries itself, e.g. a
+  // right after one of that key's slashes, so indexing slash boundaries (the
+  // specDir separator and any slash the raw ID carries itself, e.g. a
   // `reqPatterns` grammar that admits `mod/FR-1`) yields the same candidates a
   // full `endsWith` scan of `idMapping` collects — in the same registration
   // order, so a suffix claimed by several keys still resolves to the first one.
-  // Built from `idMapping`, not from `collected`, so a raw ID registered twice
-  // under one specDir stays the single entry the scan would have seen.
+  // Within one key every boundary yields a distinct-length suffix, so a key
+  // contributes at most one entry per bucket and the iteration direction here
+  // does not affect any bucket's order.
+  //
+  // Only the last MAX_INDEXED_SUFFIXES boundaries of a key are indexed (walking
+  // from the end = shortest suffix first); deeper queries fall back to the
+  // uncapped scan. See `suffixMatches` for the cap and why it is exact.
+  //
+  // Built from `idMapping`, not from `collected`: it makes the loop mirror the
+  // scan it replaces one-for-one. Registering a raw ID twice under one specDir
+  // would only duplicate an entry inside a bucket, and bucket multiplicity is
+  // never observable (both readers look at `matches[0]` or at a `.length` that
+  // `remapId`'s colliding precondition already forces above 1), so this is a
+  // readability choice, not a behavioral one.
   const reverseIndex = new Map<string, string[]>();
   for (const [qualifiedKey, finalId] of idMapping) {
-    for (let i = 0; i < qualifiedKey.length; i++) {
+    let indexed = 0;
+    for (let i = qualifiedKey.length - 1; i >= 0; i--) {
       if (qualifiedKey.charCodeAt(i) !== 0x2f /* "/" */) continue;
       const suffix = qualifiedKey.slice(i + 1);
       const bucket = reverseIndex.get(suffix);
       if (bucket) bucket.push(finalId);
       else reverseIndex.set(suffix, [finalId]);
+      if (++indexed >= MAX_INDEXED_SUFFIXES) break;
     }
   }
 
@@ -654,7 +668,7 @@ export function buildGraph(
 
   // Remap non-req edge targets that reference colliding IDs
   for (const edge of nonReqEdges) {
-    const remappedTarget = remapId(edge.target, reverseIndex, collidingIds);
+    const remappedTarget = remapId(edge.target, reverseIndex, idMapping, collidingIds);
     if (collidingIds.has(edge.target) && remappedTarget === edge.target) {
       const dirs = idToDirs.get(edge.target) ?? new Set<string>();
       warnings.push({
@@ -1653,17 +1667,63 @@ function splitSymbolId(body: string): { ownerPath: string; symbolName: string } 
   };
 }
 
+// How many slash boundaries of one `idMapping` key the reverse index above
+// holds, counted from the end of the key. Indexing every boundary costs
+// `O(Σ_key Σ_slash suffix-length)`, which stays invisible under the default
+// grammar (a key is `specDir/BARE-ID`, so one boundary) but turns quadratic
+// once a custom `reqPatterns.listItem` admits `/` inside the raw ID: one
+// pasted line carrying thousands of slashes then adds minutes to every
+// `artgraph scan` / `check`, twice over for `check --diff --base`. Real
+// namespaced IDs sit at 2-3 segments; 32 leaves that untouched while capping
+// the per-key work at a constant.
+const MAX_INDEXED_SUFFIXES = 32;
+
+// Every `finalId` whose `idMapping` key ends in `/<id>`, in key registration
+// order — exactly what a full `endsWith` scan of `idMapping` produces, which
+// is what the first-match tie-breaks in the two callers below depend on.
+//
+// A query of `s` slash-separated segments can only ever be the suffix that
+// starts at a key's s-th slash boundary counted from the end, so the capped
+// index answers it in full whenever `s <= MAX_INDEXED_SUFFIXES`. Queries at or
+// past that depth run the uncapped scan the index replaced, which is the
+// pre-index behavior verbatim — `s === MAX_INDEXED_SUFFIXES` is still indexed
+// and takes the scan anyway, one boundary of margin so that this guard and the
+// cap cannot drift into an off-by-one.
+function suffixMatches(
+  id: string,
+  reverseIndex: Map<string, string[]>,
+  idMapping: Map<string, string>,
+): string[] {
+  let slashes = 0;
+  for (let i = 0; i < id.length; i++) {
+    if (id.charCodeAt(i) !== 0x2f /* "/" */) continue;
+    if (++slashes < MAX_INDEXED_SUFFIXES - 1) continue;
+    const needle = "/" + id;
+    const scanned: string[] = [];
+    for (const [key, finalId] of idMapping) {
+      if (key.endsWith(needle)) scanned.push(finalId);
+    }
+    return scanned;
+  }
+  return reverseIndex.get(id) ?? [];
+}
+
 function remapId(
   id: string,
   reverseIndex: Map<string, string[]>,
+  idMapping: Map<string, string>,
   collidingIds: Set<string>,
 ): string {
   if (!collidingIds.has(id)) return id;
 
   // Try to find a unique mapping
-  const matches = reverseIndex.get(id) ?? [];
+  const matches = suffixMatches(id, reverseIndex, idMapping);
 
-  // If ambiguous, return as-is (warning already emitted or will be)
+  // If ambiguous, return as-is (warning already emitted or will be). The
+  // `=== 1` arm is unreachable in practice and kept only as a safety net:
+  // `id` collides, so two distinct specDirs `d1`/`d2` both registered a key
+  // `d/id`, and each of those keys ends in `/id` — the candidate list is
+  // therefore always ≥2 and this function is the identity.
   return matches.length === 1 ? matches[0] : id;
 }
 
@@ -1686,8 +1746,8 @@ function resolveAnnotationTarget(
   if (sameDirFinal) return { target: sameDirFinal, ambiguous: false };
   // Not colliding, not in same specDir — take the mapping registered first
   // under this suffix anywhere.
-  const matches = reverseIndex.get(target);
-  if (matches && matches.length > 0) return { target: matches[0], ambiguous: false };
+  const matches = suffixMatches(target, reverseIndex, idMapping);
+  if (matches.length > 0) return { target: matches[0], ambiguous: false };
   // Not registered at all → leave as-is; orphan-edge will be raised downstream.
   return { target, ambiguous: false };
 }

--- a/tests/builder-id-resolution.test.ts
+++ b/tests/builder-id-resolution.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { buildGraph, type BuildWarning } from "../src/graph/builder.js";
+import type { ArtgraphConfig } from "../src/types.js";
+
+// Pins the collision-aware ID resolution buildGraph applies to edge targets:
+// the frontmatter (`nonReqEdges`) remap and the specDir-aware annotation /
+// task-tag resolution, including the cross-specDir suffix lookup that neither
+// path had a fixture for before.
+//
+// Bracketed IDs are assembled at runtime rather than written literally: the
+// TypeScript parser scans a *test* file's whole text for `[<id>]` markers
+// (parsers/typescript.ts `testReqRe`), so a bracketed ID spelled out here —
+// in a fixture string or in this very comment — would emit a real `verifies`
+// edge into artgraph's own graph.
+const tag = (id: string) => "[" + id + "]";
+
+const TMP_BASE = resolve(import.meta.dirname, "fixtures/_id_resolution_tmp");
+
+function setupTmp(files: Record<string, string>): string {
+  if (existsSync(TMP_BASE)) rmSync(TMP_BASE, { recursive: true, force: true });
+  mkdirSync(TMP_BASE, { recursive: true });
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = resolve(TMP_BASE, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content, "utf-8");
+  }
+  return TMP_BASE;
+}
+
+const baseConfig: ArtgraphConfig = {
+  include: [],
+  specDirs: ["specs"],
+  testPatterns: [],
+  lockFile: ".trace.lock",
+};
+
+// Raw IDs that carry their own `/` are reachable only through a custom
+// `reqPatterns.listItem`, and they are what makes a qualified key hold more
+// than one slash boundary.
+const compoundConfig: ArtgraphConfig = {
+  ...baseConfig,
+  reqPatterns: { listItem: "^((?:[a-z]+/){1,2}[A-Z][A-Za-z]*-\\d+)[:\\s]" },
+};
+
+const optionalNsConfig: ArtgraphConfig = {
+  ...baseConfig,
+  reqPatterns: { listItem: "^((?:[a-z]+/)?[A-Z][A-Za-z]*-\\d+)[:\\s]" },
+};
+
+function ambiguousFor(warnings: BuildWarning[], id: string) {
+  return warnings.filter((w) => w.type === "ambiguous-id" && w.id === id);
+}
+
+describe("buildGraph: frontmatter edge target remap", () => {
+  afterEach(() => {
+    if (existsSync(TMP_BASE)) rmSync(TMP_BASE, { recursive: true, force: true });
+  });
+
+  it("keeps a colliding frontmatter target unqualified and warns once", () => {
+    setupTmp({
+      "specs/010-a/spec.md": "- AUTH-001: alpha\n",
+      "specs/010-b/spec.md": "- AUTH-001: beta\n",
+      "specs/010-c/design.md": `---
+artgraph:
+  node_id: "design-c"
+  depends_on:
+    - AUTH-001
+---
+# Design C
+`,
+    });
+    const { graph, warnings } = buildGraph(TMP_BASE, baseConfig);
+
+    const fmEdges = graph.edges.filter(
+      (e) => e.source === "design-c" && e.provenances?.includes("frontmatter"),
+    );
+    expect(fmEdges).toHaveLength(1);
+    expect(fmEdges[0].kind).toBe("depends_on");
+    // Two spec dirs claim AUTH-001, so the target stays bare — no dir wins.
+    expect(fmEdges[0].target).toBe("AUTH-001");
+    expect(graph.nodes.has("AUTH-001")).toBe(false);
+
+    const ambiguous = ambiguousFor(warnings, "AUTH-001");
+    expect(ambiguous).toHaveLength(1);
+    expect(ambiguous[0].files).toEqual(["010-a", "010-b"]);
+  });
+
+  it("counts an unrelated compound ID that ends in the colliding ID", () => {
+    // `010-z/zz/AUTH-001` also ends in `/AUTH-001`, so the remap sees three
+    // candidates instead of two. The extra candidate must not turn the
+    // ambiguous target into a unique one, and must not reach the warning's
+    // file list (which is keyed on the raw ID's own spec dirs).
+    setupTmp({
+      "specs/010-a/spec.md": "- AUTH-001: alpha\n",
+      "specs/010-b/spec.md": "- AUTH-001: beta\n",
+      "specs/010-z/spec.md": "- zz/AUTH-001: unrelated\n",
+      "specs/010-c/design.md": `---
+artgraph:
+  node_id: "design-c"
+  depends_on:
+    - AUTH-001
+---
+# Design C
+`,
+    });
+    const { graph, warnings } = buildGraph(TMP_BASE, optionalNsConfig);
+
+    expect(graph.nodes.has("zz/AUTH-001")).toBe(true);
+    const fmEdges = graph.edges.filter(
+      (e) => e.source === "design-c" && e.provenances?.includes("frontmatter"),
+    );
+    expect(fmEdges).toHaveLength(1);
+    expect(fmEdges[0].target).toBe("AUTH-001");
+
+    const ambiguous = ambiguousFor(warnings, "AUTH-001");
+    expect(ambiguous).toHaveLength(1);
+    expect(ambiguous[0].files).toEqual(["010-a", "010-b"]);
+  });
+
+  it("lists every spec dir on a three-way collision", () => {
+    setupTmp({
+      "specs/010-a/spec.md": "- AUTH-001: alpha\n",
+      "specs/010-b/spec.md": "- AUTH-001: beta\n",
+      "specs/010-c/spec.md": "- AUTH-001: gamma\n",
+      "specs/010-d/design.md": `---
+artgraph:
+  node_id: "design-d"
+  derives_from:
+    - AUTH-001
+---
+# Design D
+`,
+    });
+    const { graph, warnings } = buildGraph(TMP_BASE, baseConfig);
+
+    const fmEdges = graph.edges.filter(
+      (e) => e.source === "design-d" && e.provenances?.includes("frontmatter"),
+    );
+    expect(fmEdges).toHaveLength(1);
+    expect(fmEdges[0].kind).toBe("derives_from");
+    expect(fmEdges[0].target).toBe("AUTH-001");
+
+    const ambiguous = ambiguousFor(warnings, "AUTH-001");
+    expect(ambiguous).toHaveLength(1);
+    expect(ambiguous[0].files).toEqual(["010-a", "010-b", "010-c"]);
+  });
+});
+
+describe("buildGraph: annotation and task-tag target resolution", () => {
+  afterEach(() => {
+    if (existsSync(TMP_BASE)) rmSync(TMP_BASE, { recursive: true, force: true });
+  });
+
+  it("resolves a non-colliding annotation target declared in another spec dir", () => {
+    setupTmp({
+      "specs/010-a/spec.md": "- SUP-100: supporting\n",
+      "specs/010-b/spec.md": "- AUTH-001: beta (depends_on: SUP-100)\n",
+    });
+    const { graph, warnings } = buildGraph(TMP_BASE, baseConfig);
+
+    const annEdges = graph.edges.filter(
+      (e) => e.source === "AUTH-001" && e.provenances?.includes("annotation"),
+    );
+    expect(annEdges).toHaveLength(1);
+    expect(annEdges[0].target).toBe("SUP-100");
+    expect(graph.nodes.has("SUP-100")).toBe(true);
+    expect(warnings.filter((w) => w.type === "ambiguous-id")).toHaveLength(0);
+  });
+
+  it("routes spec-kit bracket tags by spec dir", () => {
+    setupTmp({
+      "specs/ns-a/spec.md": "- FR-1: alpha\n",
+      "specs/ns-b/spec.md": "- FR-1: beta\n",
+      "specs/ns-a/tasks.md": `- T001 cross dir ${tag("ns-b/FR-1")}\n- T002 same dir ${tag("FR-1")}\n`,
+      "specs/010-c/tasks.md": `- T003 no home dir ${tag("FR-1")}\n`,
+    });
+    const { graph, warnings } = buildGraph(TMP_BASE, baseConfig);
+
+    const verifies = (source: string) =>
+      graph.edges.filter((e) => e.source === source && e.kind === "verifies");
+
+    // Already qualified: passes through untouched and lands on a real node.
+    expect(verifies("T001").map((e) => e.target)).toEqual(["ns-b/FR-1"]);
+    expect(graph.nodes.has("ns-b/FR-1")).toBe(true);
+    // Bare and colliding: the task's own spec dir wins.
+    expect(verifies("T002").map((e) => e.target)).toEqual(["ns-a/FR-1"]);
+    // Bare, colliding, and no same-dir candidate: no edge at all.
+    expect(verifies("T003")).toHaveLength(0);
+
+    const ambiguous = ambiguousFor(warnings, "FR-1");
+    expect(ambiguous).toHaveLength(1);
+    expect(ambiguous[0].files).toEqual(["ns-a", "ns-b"]);
+  });
+
+  it("resolves a tag naming a trailing segment of a compound colliding ID", () => {
+    // `mod/sub/FR-1` collides, so both nodes are spec-dir qualified. The tag
+    // names `sub/FR-1`, which is a slash-boundary suffix of both qualified
+    // keys but is not itself a declared ID: the first key in registration
+    // order wins, with no ambiguity warning.
+    setupTmp({
+      "specs/010-a/spec.md": "- mod/sub/FR-1: alpha\n",
+      "specs/010-b/spec.md": "- mod/sub/FR-1: beta\n",
+      "specs/010-c/tasks.md": `- T001 trailing segment ${tag("sub/FR-1")}\n`,
+    });
+    const { graph, warnings } = buildGraph(TMP_BASE, compoundConfig);
+
+    expect(graph.nodes.has("010-a/mod/sub/FR-1")).toBe(true);
+    expect(graph.nodes.has("010-b/mod/sub/FR-1")).toBe(true);
+
+    const verifies = graph.edges.filter((e) => e.source === "T001" && e.kind === "verifies");
+    expect(verifies).toHaveLength(1);
+    expect(verifies[0].target).toBe("010-a/mod/sub/FR-1");
+    expect(warnings.filter((w) => w.type === "ambiguous-id")).toHaveLength(0);
+  });
+
+  it("prefers the same spec dir over a trailing-segment match", () => {
+    setupTmp({
+      "specs/010-a/spec.md": "- mod/FR-1: alpha\n",
+      "specs/010-b/spec.md": "- mod/FR-1: beta\n- ex/CROSS-1: gamma (depends_on: mod/FR-1)\n",
+    });
+    const { graph } = buildGraph(TMP_BASE, {
+      ...compoundConfig,
+      reqPatterns: { ...compoundConfig.reqPatterns, codeId: "(?:[a-z]+/){1,2}[A-Z][A-Za-z]*-\\d+" },
+    });
+
+    const annEdges = graph.edges.filter(
+      (e) => e.source === "ex/CROSS-1" && e.provenances?.includes("annotation"),
+    );
+    expect(annEdges).toHaveLength(1);
+    expect(annEdges[0].target).toBe("010-b/mod/FR-1");
+  });
+});

--- a/tests/builder-id-resolution.test.ts
+++ b/tests/builder-id-resolution.test.ts
@@ -345,8 +345,9 @@ describe("buildGraph: annotation and task-tag target resolution", () => {
     // `SUP-100` is unique, so its node keeps the bare ID and the qualified form
     // the task wrote is not a key of anything. Only a key's *proper* trailing
     // segments are candidates — the whole key is not one of them — so the
-    // reference stays verbatim and surfaces downstream as an orphan edge
-    // instead of quietly binding to the bare node.
+    // reference stays verbatim as a dangling edge instead of quietly binding
+    // to the bare node. (Nothing downstream reports that dangling today:
+    // orphan-edge warnings are annotation-provenance only.)
     setupTmp({
       "specs/010-a/spec.md": "- SUP-100: only here\n",
       "specs/010-c/tasks.md": `- T001 qualified ref ${tag("010-a/SUP-100")}\n`,

--- a/tests/builder-id-resolution.test.ts
+++ b/tests/builder-id-resolution.test.ts
@@ -6,8 +6,14 @@ import type { ArtgraphConfig } from "../src/types.js";
 
 // Pins the collision-aware ID resolution buildGraph applies to edge targets:
 // the frontmatter (`nonReqEdges`) remap and the specDir-aware annotation /
-// task-tag resolution, including the cross-specDir suffix lookup that neither
-// path had a fixture for before.
+// task-tag resolution.
+//
+// The suffix lookup itself — a target that matches an `idMapping` key only at
+// a slash boundary — is pinned by the trailing-segment cases below, which are
+// the ones whose expected target differs from the raw text of the reference.
+// When a non-colliding ID resolves to itself, hitting the lookup and skipping
+// it produce the same edge, so such a case is an integration smoke test rather
+// than a pin on the lookup.
 //
 // Bracketed IDs are assembled at runtime rather than written literally: the
 // TypeScript parser scans a *test* file's whole text for `[<id>]` markers
@@ -38,10 +44,22 @@ const baseConfig: ArtgraphConfig = {
 
 // Raw IDs that carry their own `/` are reachable only through a custom
 // `reqPatterns.listItem`, and they are what makes a qualified key hold more
-// than one slash boundary.
+// than one slash boundary. These patterns are deliberately ones `loadConfig`
+// accepts: `validateReqPatterns` rejects nested quantifiers, so a grammar
+// written as `(?:[a-z]+/){1,2}...` would describe a project that cannot exist.
+const COMPOUND_LIST_ITEM = "^([A-Za-z0-9/_-]+):";
+// Whole-match ID shape for annotation targets, widened the same way so a
+// `(depends_on: mod/FR-1)` target isn't rejected as an invalid annotation ID.
+const COMPOUND_CODE_ID = "^[A-Za-z0-9/_-]+$";
+
 const compoundConfig: ArtgraphConfig = {
   ...baseConfig,
-  reqPatterns: { listItem: "^((?:[a-z]+/){1,2}[A-Z][A-Za-z]*-\\d+)[:\\s]" },
+  reqPatterns: { listItem: COMPOUND_LIST_ITEM },
+};
+
+const compoundAnnotationConfig: ArtgraphConfig = {
+  ...baseConfig,
+  reqPatterns: { listItem: COMPOUND_LIST_ITEM, codeId: COMPOUND_CODE_ID },
 };
 
 const optionalNsConfig: ArtgraphConfig = {
@@ -153,6 +171,10 @@ describe("buildGraph: annotation and task-tag target resolution", () => {
     if (existsSync(TMP_BASE)) rmSync(TMP_BASE, { recursive: true, force: true });
   });
 
+  // Smoke test, not a lookup pin: `SUP-100` is unique, so its mapping is the
+  // identity and the edge lands on `SUP-100` whether the cross-dir lookup fires
+  // or the target passes through unregistered. The trailing-segment cases below
+  // are what pin the lookup.
   it("resolves a non-colliding annotation target declared in another spec dir", () => {
     setupTmp({
       "specs/010-a/spec.md": "- SUP-100: supporting\n",
@@ -215,20 +237,128 @@ describe("buildGraph: annotation and task-tag target resolution", () => {
     expect(warnings.filter((w) => w.type === "ambiguous-id")).toHaveLength(0);
   });
 
-  it("prefers the same spec dir over a trailing-segment match", () => {
+  it("resolves an annotation naming a segment deep inside a compound colliding ID", () => {
+    // Same shape as the case above, one level deeper: the reference is the
+    // third slash boundary counted from the end of `010-a/mod/sub/deep/FR-1`.
+    // An index that only remembers a key's last boundaries would drop the
+    // candidate and leak the raw text through as an orphan target.
+    setupTmp({
+      "specs/010-a/spec.md": "- mod/sub/deep/FR-1: alpha\n",
+      "specs/010-b/spec.md": "- mod/sub/deep/FR-1: beta\n",
+      "specs/010-c/spec.md": "- CROSS-1: gamma (depends_on: sub/deep/FR-1)\n",
+    });
+    const { graph, warnings } = buildGraph(TMP_BASE, compoundAnnotationConfig);
+
+    expect(graph.nodes.has("010-a/mod/sub/deep/FR-1")).toBe(true);
+    expect(graph.nodes.has("010-b/mod/sub/deep/FR-1")).toBe(true);
+
+    const annEdges = graph.edges.filter(
+      (e) => e.source === "CROSS-1" && e.provenances?.includes("annotation"),
+    );
+    expect(annEdges).toHaveLength(1);
+    expect(annEdges[0].target).toBe("010-a/mod/sub/deep/FR-1");
+    expect(warnings.filter((w) => w.type === "ambiguous-id")).toHaveLength(0);
+  });
+
+  it("resolves a trailing segment far deeper than any ordinary namespace", () => {
+    // 40 namespace segments ahead of the ID, with the reference naming the last
+    // 35 of them. Depth on its own must not change the answer — this is the
+    // same trailing-segment resolution as above, past any depth a pre-computed
+    // suffix index would keep on hand.
+    const segs = Array.from({ length: 40 }, (_, i) => `s${i}`);
+    const rawId = [...segs, "FR-1"].join("/");
+    const ref = [...segs.slice(6), "FR-1"].join("/");
+    setupTmp({
+      "specs/010-a/spec.md": `- ${rawId}: alpha\n`,
+      "specs/010-b/spec.md": `- ${rawId}: beta\n`,
+      "specs/010-c/spec.md": `- CROSS-1: gamma (depends_on: ${ref})\n`,
+    });
+    const { graph } = buildGraph(TMP_BASE, compoundAnnotationConfig);
+
+    const annEdges = graph.edges.filter(
+      (e) => e.source === "CROSS-1" && e.provenances?.includes("annotation"),
+    );
+    expect(annEdges).toHaveLength(1);
+    expect(annEdges[0].target).toBe(`010-a/${rawId}`);
+  });
+
+  it("treats an empty segment in a compound ID as two ordinary boundaries", () => {
+    // `mod//FR-1` puts two slashes back to back, so the qualified key offers
+    // both `/FR-1` and `FR-1` as trailing-segment references. An `endsWith`
+    // scan matches both; skipping either as a degenerate boundary would strand
+    // that reference on the raw text.
+    setupTmp({
+      "specs/010-a/spec.md": "- mod//FR-1: alpha\n",
+      "specs/010-b/spec.md": "- mod//FR-1: beta\n",
+      "specs/010-c/spec.md":
+        "- CROSS-1: gamma (depends_on: /FR-1)\n- CROSS-2: delta (depends_on: FR-1)\n",
+    });
+    const { graph } = buildGraph(TMP_BASE, compoundAnnotationConfig);
+
+    const annTarget = (source: string) =>
+      graph.edges
+        .filter((e) => e.source === source && e.provenances?.includes("annotation"))
+        .map((e) => e.target);
+
+    expect(annTarget("CROSS-1")).toEqual(["010-a/mod//FR-1"]);
+    expect(annTarget("CROSS-2")).toEqual(["010-a/mod//FR-1"]);
+  });
+
+  it("prefers the same spec dir when a compound ID collides across dirs", () => {
+    // Colliding target with a same-dir definition: resolution stops at that
+    // definition, so no trailing-segment candidate is ever consulted.
     setupTmp({
       "specs/010-a/spec.md": "- mod/FR-1: alpha\n",
       "specs/010-b/spec.md": "- mod/FR-1: beta\n- ex/CROSS-1: gamma (depends_on: mod/FR-1)\n",
     });
-    const { graph } = buildGraph(TMP_BASE, {
-      ...compoundConfig,
-      reqPatterns: { ...compoundConfig.reqPatterns, codeId: "(?:[a-z]+/){1,2}[A-Z][A-Za-z]*-\\d+" },
-    });
+    const { graph } = buildGraph(TMP_BASE, compoundAnnotationConfig);
 
     const annEdges = graph.edges.filter(
       (e) => e.source === "ex/CROSS-1" && e.provenances?.includes("annotation"),
     );
     expect(annEdges).toHaveLength(1);
     expect(annEdges[0].target).toBe("010-b/mod/FR-1");
+  });
+
+  it("prefers the same spec dir over another dir's trailing-segment match", () => {
+    // `FR-1` is unique (only 010-b declares it), so the colliding branch never
+    // runs. It is still a trailing segment of `010-a/mod/FR-1`, which registers
+    // first — without the same-dir shortcut the task would silently verify the
+    // other dir's requirement instead of its own.
+    setupTmp({
+      "specs/010-a/spec.md": "- mod/FR-1: alpha\n",
+      "specs/010-b/spec.md": "- FR-1: beta\n",
+      "specs/010-b/tasks.md": `- T001 same dir ${tag("FR-1")}\n`,
+    });
+    const { graph, warnings } = buildGraph(TMP_BASE, compoundConfig);
+
+    expect(graph.nodes.has("mod/FR-1")).toBe(true);
+    expect(graph.nodes.has("FR-1")).toBe(true);
+
+    const verifies = graph.edges.filter((e) => e.source === "T001" && e.kind === "verifies");
+    expect(verifies).toHaveLength(1);
+    expect(verifies[0].target).toBe("FR-1");
+    expect(warnings.filter((w) => w.type === "ambiguous-id")).toHaveLength(0);
+  });
+
+  it("leaves a spec-dir-qualified reference to a unique ID unresolved", () => {
+    // `SUP-100` is unique, so its node keeps the bare ID and the qualified form
+    // the task wrote is not a key of anything. Only a key's *proper* trailing
+    // segments are candidates — the whole key is not one of them — so the
+    // reference stays verbatim and surfaces downstream as an orphan edge
+    // instead of quietly binding to the bare node.
+    setupTmp({
+      "specs/010-a/spec.md": "- SUP-100: only here\n",
+      "specs/010-c/tasks.md": `- T001 qualified ref ${tag("010-a/SUP-100")}\n`,
+    });
+    const { graph, warnings } = buildGraph(TMP_BASE, baseConfig);
+
+    expect(graph.nodes.has("SUP-100")).toBe(true);
+    expect(graph.nodes.has("010-a/SUP-100")).toBe(false);
+
+    const verifies = graph.edges.filter((e) => e.source === "T001" && e.kind === "verifies");
+    expect(verifies).toHaveLength(1);
+    expect(verifies[0].target).toBe("010-a/SUP-100");
+    expect(warnings.filter((w) => w.type === "ambiguous-id")).toHaveLength(0);
   });
 });

--- a/tests/perf/graph-suffix-index.perf.test.ts
+++ b/tests/perf/graph-suffix-index.perf.test.ts
@@ -1,0 +1,67 @@
+// Perf regression for the reverse suffix index `buildGraph` uses to resolve
+// edge targets against collision-qualified requirement IDs.
+//
+// The index answers "which `idMapping` keys end in `/<id>`" by registering a
+// key's slash boundaries up front. Registering every boundary costs
+// O(Σ_key Σ_slash suffix-length): invisible under the default grammar, where a
+// key is `specDir/BARE-ID` and has exactly one boundary, but quadratic per key
+// as soon as a custom `reqPatterns.listItem` admits `/` inside the raw ID.
+// `scan` / `check` build the graph on every run — twice over for
+// `check --diff --base` — so one generated or pasted spec line is enough to
+// add minutes to a CI gate. Capping the boundaries kept per key (and falling
+// back to the uncapped scan for queries deeper than the cap) keeps the build
+// proportional to the input instead.
+//
+// The shape below is ~0.6 MB of markdown, small enough that parsing is a
+// rounding error and nearly all of the wall clock is index construction.
+// Measured under this config: uncapped 5.1-5.3s, capped 0.48-0.51s. The 2000ms
+// budget therefore fails an uncapped build by ~2.6x while leaving the capped
+// build ~4x of headroom for a slow CI runner.
+//
+// Runs in the dedicated perf config (singleFork, no fileParallelism, retry: 1)
+// so the wall-clock assertion owns the CPU during measurement.
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { buildGraph } from "../../src/graph/builder.js";
+import type { ArtgraphConfig } from "../../src/types.js";
+
+// A grammar `loadConfig` accepts (no nested quantifiers) that lets a raw
+// requirement ID carry its own slashes.
+const config: ArtgraphConfig = {
+  include: [],
+  specDirs: ["specs"],
+  testPatterns: [],
+  lockFile: ".trace.lock",
+  reqPatterns: { listItem: "^([A-Za-z0-9/_-]+):" },
+};
+
+const REQ_COUNT = 40;
+const SEGMENTS_PER_ID = 8000;
+
+describe("buildGraph suffix index — deep compound ID perf regression", () => {
+  let tmp: string | undefined;
+
+  afterEach(() => {
+    if (tmp) rmSync(tmp, { recursive: true, force: true });
+    tmp = undefined;
+  });
+
+  it("builds a graph of pathologically deep compound IDs without a quadratic blowup", () => {
+    tmp = mkdtempSync(join(tmpdir(), "artgraph-suffix-index-"));
+    mkdirSync(resolve(tmp, "specs/010-a"), { recursive: true });
+    const namespace = "a/".repeat(SEGMENTS_PER_ID);
+    const lines = Array.from({ length: REQ_COUNT }, (_, i) => `- ${namespace}FR-${i}: text`);
+    writeFileSync(resolve(tmp, "specs/010-a/spec.md"), lines.join("\n") + "\n", "utf-8");
+
+    const start = performance.now();
+    const { graph } = buildGraph(tmp, config);
+    const elapsed = performance.now() - start;
+
+    // Sanity: the deep IDs really did become nodes, so the index really was
+    // fed the keys this test means to measure.
+    expect(graph.nodes.has(`${namespace}FR-${REQ_COUNT - 1}`)).toBe(true);
+    expect(elapsed).toBeLessThan(2000);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #161 (item 3, the last of its three hot spots — items 1 and 2 landed in #386). `remapId` and `resolveAnnotationTarget`'s cross-dir fallback each walked the **entire** `idMapping` per edge (`qualifiedKey.endsWith("/" + id)`), O(edges × reqs) once colliding targets exist. They now share a reverse index built once alongside `idMapping`: every slash-boundary suffix of each qualified key → its finalIds, in registration order.

**Bounded by design** (adversarial-review finding): only the last 32 slash boundaries per key are indexed, and a query at that depth runs the original uncapped `endsWith` scan verbatim — a query of `s` segments can only match the suffix at a key's `s`-th boundary from the end, so resolution is exactly unchanged while a pathological slash-dense ID under a custom `/`-admitting `reqPatterns` grammar no longer costs minutes of unconditional construction (the unbounded build fails the new perf guard at 2.5×; the bounded one passes with 4× margin).

Equivalence was measured at every stage: 293,739 Step 0-pre differential probes for the index construction; the fixtures written first and pinned green against the **unmodified** implementation; a 4,880-node synthetic graph dumping byte-identical `nodes+edges+warnings`; the adversarial review's 2,012,498-query fuzz plus 500 random repos (0 mismatches); after bounding, another 1.6M-probe / 400-repo differential against the unbounded version (0 mismatches); and an E2E round comparing three built CLIs (this PR, the uncapped intermediate, and `origin/main`) across 6 scenario fixtures, a 46-point depth sweep across the cap boundary, 420 random fixtures, and the artgraph repo itself — stdout/stderr/exit byte-identical throughout.

**Test hardening via a 13-mutant kill matrix** (meta-review findings): the original 7 fixtures let 5 index-corrupting mutants survive; the set is now 12, killing all 13 mutants except two proven observationally-equivalent ones (bucket-multiplicity variants — proof in the review record). This surfaced and pinned two previously unguarded behaviors that were breakable with every existing test green: the resolver's same-dir tier (deleting it mis-links a same-dir `[FR-1]` to another dir's `mod/FR-1` — no test noticed), and spec-dir-qualified references staying dangling rather than resolving. The one previously-discriminating fixture also depended on a `reqPatterns` shape `validateReqPatterns` rejects; it now uses a config users can actually write.

The `matches.length === 1` branch in `remapId` is kept although provably unreachable (colliding ⟹ ≥2 suffix matches — now noted in a code comment; the proof survives the bounding): removing a safety net is a behavior change outside this PR's behavior-preserving scope. The fallback's silent first-match tie-break is likewise preserved bug-for-bug (#411 tracks whether it should warn).

Perf on a synthetic collision-heavy graph: `buildGraph` median 1401.6ms → 529.5ms (~2.6×); lookup-heavy E2E fixtures show 1.6-2.9× at the CLI; the pathological custom-grammar construction shape drops from ~5.1s to ~0.5s (with memory back to baseline, 154→83MB peak RSS).

## Change type

- [x] refactor (no behavior change)

## Testing

- [x] Existing tests pass (`pnpm -r test`) — unit 2645 / e2e 122 / perf 8, all green; the issue's Definition-of-done pins verified explicitly: double-build determinism (`tests/builder.test.ts`) and lock byte-identity (`tests/lock.test.ts` INV-L4 suite) pass
- [x] Added tests where needed — `tests/builder-id-resolution.test.ts` (+12, mutant-matrix-driven): colliding frontmatter targets (bare + `ambiguous-id`, 2/3-way), unrelated compound ID inflating the match count, cross-dir fallback smoke, spec-kit bracket routing, trailing-segment rewrite (custom grammar, the live fallback case), same-dir beating a trailing-segment match (tier-3 pin), qualified reference staying dangling, deep/doubled-slash/beyond-cap boundary cases; plus `tests/perf/graph-suffix-index.perf.test.ts` pinning the bounded construction
- [x] Ran `pnpm -r knip` and `pnpm -r build` — plus `lint`, `typecheck`, `format:check`, and `artgraph check --diff` (pass; dogfood byte-stable at every commit)

## Breaking change

- [x] No

## Notes

- With the default grammar, the fallback path is outcome-neutral (raw IDs carry no `/`, so a suffix HIT returns the same string a MISS would) — it only rewrites when a custom `reqPatterns` grammar admits compound raw IDs; the trailing-segment fixture pins that live case. `remapId` itself is provably the identity (its colliding precondition forces ≥2 candidates), so the resolver fallback is the index's only live consumer; the fixtures pin the *contract*, not incidental coverage.
- One measured trade-off on doubly-pathological inputs (custom compound grammar **and** references ≥31 segments deep): such queries bypass the index and pay construction + the original scan, landing ~25-33% slower than `origin/main` on that shape while outputs stay byte-identical. Normal shapes are unaffected (repo dogfood: within noise of main, byte-identical output).
- Known pre-existing flake, unrelated to this PR (measured on a clean tree, now tracked as #414 with a 1.55× contention datapoint): `tests/perf/trace-overhead-import-heavy.perf.test.ts`.
- Filed from the investigation and reviews, pre-existing: #411 (fallback's silent first-match on multi-candidate ties), #412 (spec 010 research.md drift), #415 (dangling task-tag references reported nowhere — the E2E round's discovery; a test comment claiming otherwise was corrected in-PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RxwmDDksrdSBwKcvLNq2Jw