### PR TITLE
fix(markdown): keep GFM task-list checkbox state out of the doc contentHash

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,7 +209,7 @@ lock ファイル（`.trace.lock`, JSON）— 承認済み状態
 
 drift = 現在の hash ≠ lock の hash。
 
-hash 前の正規化（NON-NEGOTIABLE 原則 I のノイズ抑制、上記の `stripAnnotations` と同じ狙い）: req は注釈括弧を除去し、doc は GFM task-list checkbox の状態文字（`[x]` / `[X]`）を `[ ]` に正規化する。checkbox の状態は doc の content ではないので、tasks.md やレビュー用 checklist のチェックを付ける操作だけでは drift しない（チェック行の文面を変えれば drift する）。
+hash 前の正規化（NON-NEGOTIABLE 原則 I のノイズ抑制、上記の `stripAnnotations` と同じ狙い）: req は注釈括弧を除去し、doc は GFM task-list checkbox の状態文字（`[x]` / `[X]`）を `[ ]` に正規化する。checkbox の状態は doc の content ではないので、tasks.md やレビュー用 checklist のチェックを付ける操作だけでは **doc ノードは** drift しない（チェック行の文面を変えれば drift する）。正規化が掛かるのは doc ノードの hash だけで、req ノードは自分の subtree / 節を（注釈括弧の除去以外は）逐語ハッシュするため、req 配下にネストした checkbox は tick だけで **req ノードを** drift させる（粒度間の既知の非対称。本リポジトリの spec.md には該当形が無く、下流プロジェクトで起こりうる形として #418 で追跡）。
 
 ## 7. CLI / MCP サーフェス
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,6 +209,8 @@ lock ファイル（`.trace.lock`, JSON）— 承認済み状態
 
 drift = 現在の hash ≠ lock の hash。
 
+hash 前の正規化（NON-NEGOTIABLE 原則 I のノイズ抑制、上記の `stripAnnotations` と同じ狙い）: req は注釈括弧を除去し、doc は GFM task-list checkbox の状態文字（`[x]` / `[X]`）を `[ ]` に正規化する。checkbox の状態は doc の content ではないので、tasks.md やレビュー用 checklist のチェックを付ける操作だけでは drift しない（チェック行の文面を変えれば drift する）。
+
 ## 7. CLI / MCP サーフェス
 
 | コマンド                                                            | 役割                                                                                                  |
@@ -302,7 +304,7 @@ MVP: データモデルは最初から型付きアーティファクトグラフ
 - リンクの自己申告問題: エージェントが `@impl` を自己 claim する。緩和 = 仕様所有 ID（捏造不可）＋ drift ハッシュ＋ impl＋通るテスト＋意味は人（D5）。ここが設計の根。
 - doc エッジも自己申告: `depends_on` は著者/エージェント宣言。貼り忘れ＝見えない影響。緩和は `@impl` と同じ（解決と drift を検証）。「prose で REQ/doc に言及あるが `depends_on` 無し→提案」lint は任意・既定オフ。
 - barrel / re-export の symbol 解決の残存課題。named / aliased / type / `default as` の barrel は PR #180（issue #177）で per-symbol 解決済み、`export * from` (#179) と `export default <ImportedName>` / `import { x } from "./m"; export { x };` (#188) は specs/018 で per-symbol 化済み（parser が S2/S3 を実体化 / builder が star を展開）。残る fail-safe 依存: (a) 曖昧 star（同名を供給する star が複数）、(b) diamond 束縛同一性の非比較（究極 origin が同一でも 2 直近供給元があれば drop）、(c) `export =` origin（#187、file 粒度確定）、(d) fatal syntax error ファイル内の star、(e) exclude glob で origin が scan 外、(f) `// @impl REQ` を `export * from "./o"` 直上に配置した場合（`@impl` は symbol 本体内配置でしか symbol に付かないため、star statement 直上に書いても file 到達しかしない。init 既定 symbol + bootstrap 上配置で全 named import が fail-open する原因 — 詳細は #177 project memory と #197 の修正結果）、(g) ~~parser-side unresolved-reexport の silent skip~~（#189 partial の残項目 — **#333 で解消**。`export { x } from "./missing"` 等の specifier 解決失敗時、parser が `unresolved-reexport` / `unresolved-import` 型の `TsParseWarning` を発火するようになった。`scan --format json` の `warnings[]` で観測（SILENT_WARNING_TYPES 登録のためデフォルト stdout は抑制）。`phantom-import-repaired` / `dangling-import` は builder 側で発火する既存経路のまま）。いずれも file 粒度 fail-safe で REQ 到達は保つ（fail-open にはならない）が per-symbol 精度は失う。詳細は specs/018 §10 と設計 doc を参照。
-- drift 粒度: doc/仕様を丸ごとハッシュは小編集で全下流点灯（ノイズ）、節単位は安定アンカーが要る。まず丸ごと、後で節単位（コードの file/symbol と同じ綱引きが一段上で再現）。
+- drift 粒度: doc/仕様を丸ごとハッシュは小編集で全下流点灯（ノイズ）、節単位は安定アンカーが要る。まず丸ごと、後で節単位（コードの file/symbol と同じ綱引きが一段上で再現）。粒度とは別の第三の軸として「hash 前の正規化」がある: content ではない差分（GFM checkbox の状態など）は粒度を細かくせずに正規化で落とす。節単位化は未着手のまま残っている。
 - PreToolUse のレイテンシ予算（デーモン必須）。
 - 未カバー = TODO か漏れか: 未カバーは Plan 信号に留め、ゲートは変更一貫性のみ。
 - 既存プロジェクトへの導入（ブラウンフィールド）: `@impl` タグが無い既存プロジェクトにどう導入するか。調査で判明した重要知見: 仕様を書く文化自体が未定着のプロジェクトが多数派。→ タグゼロでも import グラフだけで file-level impact は出せる設計にし、`@impl` タグは段階的に付与していける必要がある。新しく書く Spec から徐々に入れる段階的導入 ＋ それ用の Skill 提供が鍵。

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -308,10 +308,27 @@ pair always wins over an inline link.
 A doc node's `contentHash` covers the whole file, so any prose edit drifts it.
 One thing is deliberately excluded: the state character of a GFM task-list
 checkbox is canonicalized to `[ ]` before hashing, so ticking a box is not a
-document change. This is a property of the file's shape, not of
-`taskConventions` — it applies to every `- [x]` list item in a file under
-`specDirs`, whether that is a `tasks.md` task or a review checklist. The text
-after the box is still content: reword the task and the doc drifts as usual.
+document change. Unticking one is not either — clearing a signed-off review
+checklist is as invisible to `check` as filling it in. This is a property of the
+file's shape, not of `taskConventions`: it applies to `- [x]` list items in any
+file under `specDirs`, whether that is a `tasks.md` task or a review checklist,
+and there is no key that turns it off. The text after the box is still content:
+reword the task and the doc drifts as usual.
+
+Two limits are worth knowing:
+
+- **A leading byte-order mark disables it.** A `U+FEFF` at the very start of the
+  file shifts every parsed offset by one, and the canonicalization becomes a
+  no-op for that whole file — a tick drifts the doc the way it did before this
+  behaviour existed. Write spec markdown without a BOM.
+- **Nothing else records the state.** A checklist with no task IDs in it (e.g.
+  `specs/<feature>/checklists/requirements.md` under Spec Kit) produces only a
+  doc node, and the lock stores `req` / `doc` / `symbol` entries only — so for
+  such a file the checkbox state is not tracked anywhere in the graph. Where a
+  `tasks.md` task ID *is* present, the task node still hashes its own checkbox
+  verbatim (that is what makes `- [ ] T001` → `- [x] T001` a change to the
+  task), but task nodes are not written to the lock either, so no `check`
+  verdict consumes it.
 
 #### Upgrade note
 
@@ -320,7 +337,13 @@ Docs that already contain a ticked box hash to a new value once, so the first
 (the Stop hook / CI PR gate) is not affected — it is scoped to the diff, and a
 doc that does land in the diff hashes identically on both sides of the
 comparison and is suppressed as pre-existing. Only an unscoped `check --gate`
-surfaces it. Run `artgraph reconcile` to refresh the lock baseline.
+surfaces it — including the Spec Kit `before_implement` gate, if you enabled
+blocking gates via `artgraph integrate speckit --gate`.
+
+Run `artgraph check` first and confirm the drifted list contains only docs whose
+tick state you expect to have changed, then `artgraph reconcile` to refresh the
+lock baseline. `reconcile` rebuilds the whole lock, so it also approves any
+unrelated drift that happened to be pending.
 
 ### Opting out
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -303,6 +303,25 @@ queries are stripped; links inside code fences and inline code are ignored. A
 frontmatter relation (`derives_from` / `depends_on`) on the same `(source, target)`
 pair always wins over an inline link.
 
+### Doc drift and task-list checkbox state
+
+A doc node's `contentHash` covers the whole file, so any prose edit drifts it.
+One thing is deliberately excluded: the state character of a GFM task-list
+checkbox is canonicalized to `[ ]` before hashing, so ticking a box is not a
+document change. This is a property of the file's shape, not of
+`taskConventions` — it applies to every `- [x]` list item in a file under
+`specDirs`, whether that is a `tasks.md` task or a review checklist. The text
+after the box is still content: reword the task and the doc drifts as usual.
+
+#### Upgrade note
+
+Docs that already contain a ticked box hash to a new value once, so the first
+`artgraph check` after upgrading reports them as drifted. `check --diff --gate`
+(the Stop hook / CI PR gate) is not affected — it is scoped to the diff, and a
+doc that does land in the diff hashes identically on both sides of the
+comparison and is suppressed as pre-existing. Only an unscoped `check --gate`
+surfaces it. Run `artgraph reconcile` to refresh the lock baseline.
+
 ### Opting out
 
 ```jsonc

--- a/specs/008-document-graph/spec.md
+++ b/specs/008-document-graph/spec.md
@@ -128,7 +128,7 @@ Acceptance Scenarios:
 
 ### Key Entities
 
-- doc ノード: Markdown ファイルを表すグラフノード。frontmatter の有無に関わらず各 md ファイルに 1 個生成される。ファイル全体のハッシュを contentHash として保持し、ドキュメント変更の drift 検知に使用する
+- doc ノード: Markdown ファイルを表すグラフノード。frontmatter の有無に関わらず各 md ファイルに 1 個生成される。ファイル全体のハッシュを contentHash として保持し、ドキュメント変更の drift 検知に使用する。ハッシュ前に GFM task-list checkbox の状態文字（`[x]` / `[X]`）は `[ ]` へ正規化される（checkbox の状態は doc の content ではない）
 - contains エッジ: doc ノードとその中で定義された req ノードの間の所属関係を表すエッジ。doc グラフと req/実装グラフを接続する役割を持つ
 - derives_from エッジ: 下流ドキュメントから上流ドキュメントへの派生関係（例: design.md が requirements.md から派生）。frontmatter の `artgraph.derives_from` キーで定義する
 - depends_on エッジ: ドキュメント間の一般的な依存関係。frontmatter の `artgraph.depends_on` キーで定義する
@@ -144,7 +144,7 @@ Acceptance Scenarios:
 - SC-004: `artgraph graph` コマンドの text / JSON 出力が依存構造を正しく表現する
 - SC-005: 依存先の存在しないドキュメント参照に対して `orphan-doc` 警告が出力される
 - SC-006: req ID の予約プレフィクス使用に対して名前空間衝突の警告が出力される
-- SC-007: doc ノードの contentHash はファイル全体で計算され、散文変更時に doc のみ drift し req は独立して drift 検知される
+- SC-007: doc ノードの contentHash はファイル全体（GFM task-list checkbox の状態文字は正規化）で計算され、散文変更時に doc のみ drift し req は独立して drift 検知される
 
 ## Assumptions
 

--- a/specs/008-document-graph/tasks.md
+++ b/specs/008-document-graph/tasks.md
@@ -68,14 +68,14 @@ Independent Test: frontmatter を含まない散文のみの md ファイルを�
 
 - [ ] T020 [US1] `tests/markdown.test.ts` に doc ノード自動生成テストを追加する: frontmatter なしの `prose-only.md` をパースし `{ id: "doc:prose-only.md", kind: "doc" }` ノードが返ること
 - [ ] T021 [P] [US1] `tests/markdown.test.ts` に frontmatter `node_id` 指定テストを追加する: `artgraph.node_id: "custom-id"` が指定された場合に `{ id: "custom-id", kind: "doc" }` ノードが返ること
-- [ ] T022 [P] [US1] `tests/markdown.test.ts` に doc ノードの contentHash テストを追加する: ファイル全体のハッシュが doc ノードの contentHash に設定されること
+- [ ] T022 [P] [US1] `tests/markdown.test.ts` に doc ノードの contentHash テストを追加する: ファイル全体のハッシュが doc ノードの contentHash に設定されること（ハッシュ前に GFM task-list checkbox の状態文字は `[ ]` へ正規化される — spec.md Key Entities / SC-007 参照）
 - [ ] T023 [P] [US1] `tests/markdown.test.ts` に doc + req 併存テストを追加する: 要求 ID を含む md から doc ノードと req ノードの両方が返ること
 - [ ] T024 [P] [US1] `tests/builder.test.ts` に `docGraph.autoNodes: false` テストを追加する: 設定で無効化時に frontmatter `node_id` がない md からは doc ノードが生成されないこと
 - [ ] T025 [P] [US1] `tests/builder.test.ts` に doc ノード ID 自動採番テストを追加する: `doc:<specDir からの相対パス>` 形式で ID が生成されること
 
 ### Implementation for User Story 1
 
-- [ ] T026 [US1] `src/parsers/markdown.ts` の `parseMarkdown` を変更し、全ての md ファイルで doc ノードを常時生成する: frontmatter `artgraph.node_id` がある場合はその値を ID に、無い場合は `doc:<relPath>` を ID にする。contentHash はファイル全体のハッシュ
+- [ ] T026 [US1] `src/parsers/markdown.ts` の `parseMarkdown` を変更し、全ての md ファイルで doc ノードを常時生成する: frontmatter `artgraph.node_id` がある場合はその値を ID に、無い場合は `doc:<relPath>` を ID にする。contentHash はファイル全体のハッシュ（ハッシュ前に GFM task-list checkbox の状態文字は `[ ]` へ正規化される — spec.md Key Entities / SC-007 参照）
 - [ ] T027 [US1] `src/graph/builder.ts` の `buildGraph` に `docGraph.autoNodes` 設定チェックを追加する: `autoNodes === false` かつ frontmatter `node_id` が無い場合、doc ノードを除外する
 - [ ] T028 [US1] `src/graph/builder.ts` に `reserved-prefix` 警告を追加する: req ID が `doc:` / `file:` / `test:` / `symbol:` で始まる場合に `BuildWarning` を発行する
 

--- a/src/parse-cache.ts
+++ b/src/parse-cache.ts
@@ -134,7 +134,16 @@ export interface ParseCacheData {
 //       `warnings` field — reusing it on a warm hit would silently keep
 //       hiding the same unresolved specifier forever, diverging from a cold
 //       rebuild on the new code (INV-L4), exactly like v7's rationale above.
-const SCHEMA_VERSION = 8;
+// v9 (issue #235): a doc node's `contentHash` now canonicalizes GFM task-list
+// checkbox state before hashing, and an `MdFragment` carries that hash
+// verbatim. The md cache key is the file's RAW bytes, so an untouched file
+// HITS — a pre-fix fragment would keep replaying the old whole-file hash
+// (checkbox state and all) for as long as the file is not edited, diverging
+// from a cold rebuild of the very same content (INV-L4), exactly like v7/v8.
+// `computeCacheFingerprint` folds in `artgraphVersion()`, but that only
+// cold-invalidates across a release: within one package version (a PR's own
+// dogfood runs, CI vs. a local checkout) nothing else would.
+const SCHEMA_VERSION = 9;
 const CACHE_RELDIR = join("node_modules", ".cache", "artgraph");
 const CACHE_FILENAME = "parse-cache.json";
 

--- a/src/parsers/markdown.ts
+++ b/src/parsers/markdown.ts
@@ -212,7 +212,17 @@ export function parseMarkdownContent(
   const edges: GraphEdge[] = [];
   const warnings: ParseWarning[] = [];
 
-  const fileHash = hash(raw);
+  // The doc node's hash is the only place task-list checkbox state is
+  // canonicalized: `raw`, `content` and `tree` stay exactly as parsed, so a
+  // task node still hashes (and labels) its own checkbox. The canonicalized
+  // body is spliced back at the offset it came from, which keeps a file with
+  // no checkbox hashing byte-identically to `hash(raw)`. The splice requires
+  // `content` to be a suffix of `raw`: that is how `parseFrontmatter` returns
+  // it, and the parse-error fallback above sets `content` to `raw` itself.
+  const bodyOffset = raw.length - content.length;
+  const fileHash = raw.endsWith(content)
+    ? hash(raw.slice(0, bodyOffset) + canonicalizeTaskCheckboxes(content, tree))
+    : hash(raw);
 
   const VALID_ARTGRAPH_KEYS = new Set(["node_id", "derives_from", "depends_on"]);
 
@@ -371,6 +381,9 @@ export function parseMarkdownContent(
           // req と揃え、listItem subtree 全体をハッシュ化する。
           // labelText だけだと `_Requirements:` / `@impl(...)` の差替えが
           // hash に反映されず、グラフ/lock diff から消える。
+          // Verbatim, checkbox included: ticking a box IS a change to the
+          // task. Only the doc node's hash canonicalizes that state
+          // (`canonicalizeTaskCheckboxes`).
           contentHash: hash(toString(node)),
         });
 
@@ -759,6 +772,59 @@ function extractFirstParagraphAfterHeading(
 
 function hash(content: string): string {
   return createHash("sha256").update(content).digest("hex").slice(0, 16);
+}
+
+// Rewrite the state character of every GFM task-list checkbox in `body` to the
+// canonical `[ ]`, so a doc's `contentHash` treats "this box is ticked" as
+// state rather than as document content — the same reason `stripAnnotations`
+// runs before a req is hashed. Only the single character between the brackets
+// is touched; the task text after it, and every other byte, still hashes
+// verbatim. The result has the same length as `body`, so a caller can splice
+// it back at the offset `body` came from.
+//
+// The positions come from the parsed `tree`, not from a line regex, because
+// "is this line a task-list item?" is a block-structure question and the mdast
+// is where that answer already lives. A `- [x]` written inside a fenced or
+// indented code block is not a list item and has to keep hashing as the
+// content it is, while an item nested under another one — or quoted inside a
+// blockquote — is one and must not. A `^[ \t]*[-*+]`-shaped regex gets both
+// families wrong, in opposite directions, and would also reach into the
+// frontmatter this function never sees.
+//
+// `body` is the post-frontmatter text `tree` was parsed from, so mdast offsets
+// index straight into it (they count UTF-16 code units, like a JS string
+// index). `[-]` / `[~]` / `[P]` are not GFM checkbox states and are left
+// alone — this repo's own specs give them meanings of their own.
+function canonicalizeTaskCheckboxes(body: string, tree: any): string {
+  const offsets: number[] = [];
+  visit(tree, "listItem", (node: any) => {
+    // The marker has to OPEN the list item, so only a leading paragraph child
+    // qualifies — deliberately `children[0]`, not the `find(paragraph)` label
+    // extraction uses, which would also accept a later paragraph that happens
+    // to begin with `[x]` as running text.
+    const first = node.children?.[0];
+    if (first?.type !== "paragraph") return;
+    const off = first.position?.start?.offset;
+    if (off == null) return;
+    if (body[off] !== "[" || body[off + 2] !== "]") return;
+    const state = body[off + 1];
+    if (state !== "x" && state !== "X") return;
+    // A checkbox is followed by whitespace (or ends the item). A `[x]` that
+    // runs straight into the next character is link text — `- [x](/href)` and
+    // `- [x][ref]` are links whose text happens to be one `x`.
+    const after = body[off + 3];
+    if (after !== undefined && !/\s/.test(after)) return;
+    offsets.push(off + 1);
+  });
+  if (offsets.length === 0) return body;
+  offsets.sort((a, b) => a - b);
+  let out = "";
+  let prev = 0;
+  for (const off of offsets) {
+    out += body.slice(prev, off) + " ";
+    prev = off + 1;
+  }
+  return out + body.slice(prev);
 }
 
 // Remove inline req→req annotations from `text`, normalising the whitespace

--- a/tests/builder.test.ts
+++ b/tests/builder.test.ts
@@ -91,6 +91,44 @@ describe("buildGraph: doc node auto-generation (US1)", () => {
     const node = graph.nodes.get("doc:prose-only.md")!;
     expect(node.kind).toBe("doc");
   });
+
+  // issue #235 — a doc that survives `autoNodes: false` is the one remaining
+  // shape a doc node can take (a frontmatter `node_id` instead of the
+  // auto-generated `doc:<relPath>`). Its contentHash comes off the same parser
+  // path, so the task-list checkbox canonicalization has to hold there too.
+  it("a frontmatter-node_id doc keeps checkbox state out of its hash under autoNodes=false", () => {
+    const dir = mkdtempSync(join(tmpdir(), "artgraph-235-autonodes-"));
+    try {
+      mkdirSync(join(dir, "specs"), { recursive: true });
+      const write = (state: string, text = "wire the hub") =>
+        writeFileSync(
+          join(dir, "specs", "tasks.md"),
+          [
+            "---",
+            "artgraph:",
+            '  node_id: "doc:custom-tasks"',
+            "---",
+            "# Tasks",
+            "",
+            `- [${state}] T001 ${text}`,
+            "",
+          ].join("\n"),
+        );
+      const noAutoConfig: ArtgraphConfig = { ...config, docGraph: { autoNodes: false } };
+      const hashOf = (state: string, text?: string): string => {
+        write(state, text);
+        const node = buildGraph(dir, noAutoConfig).graph.nodes.get("doc:custom-tasks");
+        if (!node) throw new Error("custom-node_id doc node was filtered out");
+        return node.contentHash;
+      };
+
+      expect(hashOf("x")).toBe(hashOf(" "));
+      // Control: the task text is still content.
+      expect(hashOf("x")).not.toBe(hashOf("x", "wire the login hub"));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("buildGraph: doc->doc dependency chain (US2)", () => {

--- a/tests/check-baseline-diff.test.ts
+++ b/tests/check-baseline-diff.test.ts
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
 import { runAt } from "./helpers.js";
 import {
   makeRepoWithBaseBranch,
@@ -1241,16 +1242,17 @@ describe("check --diff --gate drift key discriminates by content, not just nodeI
     expect(json.pass).toBe(true);
   });
 
-  // issue #235 (doc granularity) — a doc node's contentHash hashes the WHOLE
-  // file's raw bytes (parsers/markdown.ts), so ANY edit anywhere in the file
-  // changes it, even an edit to a REQ this PR never touches. Under the
+  // Doc granularity — a doc node's contentHash covers the WHOLE file (its
+  // EOL-normalized text, with GFM task-list checkbox state canonicalized; see
+  // parsers/markdown.ts), so ANY other edit anywhere in the file changes it,
+  // even an edit to a REQ this PR never touches. The fixture's `specs/debt.md`
+  // has no checkbox, so its hash here is the plain whole-file one. Under the
   // pre-#383 id-only key this was accidentally neutralized: once a doc's
   // drift was observed at the base ref, EVERY later doc-level mismatch kept
   // matching the same `drift:<docId>` key and stayed suppressed forever, no
   // matter which bytes actually differed. This test pins that the fix removes
-  // that accidental amnesty — this is #235's granularity noise resurfacing at
-  // the gate, not a new defect introduced here (this PR increases #235's
-  // visibility; it does not fix #235 itself — see the PR description).
+  // that accidental amnesty — whole-file granularity noise resurfacing at the
+  // gate, not a new defect introduced here.
   it("(T383-e) doc already drifted at the base ref, PR edits only the OTHER req in the same file → doc still surfaces as new drift", async () => {
     const dir = repo("artgraph-383-e-");
     const rec = await runAt(dir, ["reconcile"]);
@@ -1296,5 +1298,116 @@ describe("check --diff --gate drift key discriminates by content, not just nodeI
     expect(json.newIssues.drifted.some((d: { nodeId: string }) => d.nodeId === "doc:debt.md")).toBe(
       false,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// issue #235 — a GFM task-list checkbox's state is not doc content. Ticking a
+// box in tasks.md used to flip the doc node's whole-file contentHash and fail
+// `check --diff --gate` with exit 2, on what is the most ordinary SDD
+// operation there is. These pin the gate-level contract: the tick is
+// invisible, everything else in the file still is not, and a lock written
+// before the canonicalization existed migrates without ever touching the
+// standard gate.
+// ---------------------------------------------------------------------------
+describe("check --gate and task-list checkbox state (issue #235)", () => {
+  const TASKS_REL = join("specs", "tasks.md");
+  const tasksMd = (state: string, text = "wire the hub"): string =>
+    ["# Tasks", "", `- [${state}] T001 ${text}`, "- [ ] T002 pay the debt", ""].join("\n");
+  const driftedIds = (entries: Array<{ nodeId: string }>): string[] => entries.map((d) => d.nodeId);
+
+  function repoWithTasks(prefix: string): string {
+    const dir = repo(prefix);
+    writeFileSync(join(dir, TASKS_REL), tasksMd(" "));
+    gitCommitAll(dir, "add tasks.md");
+    return dir;
+  }
+
+  // The debt fixture above always fails an UNSCOPED gate on its pre-existing
+  // uncovered REQ, which would mask the drift signal the migration test is
+  // about. This one is issue-free at HEAD, so `check --gate` (no `--diff`)
+  // reads exit 0 / exit 2 as "the doc drifted" and nothing else.
+  function cleanRepoWithTasks(prefix: string): string {
+    const dir = track(mkdtempSync(join(tmpdir(), prefix)));
+    writeFileSync(join(dir, ".gitignore"), ".trace.lock\nnode_modules/\n");
+    writeFileSync(
+      join(dir, ".artgraph.json"),
+      JSON.stringify({
+        include: ["src/**/*.ts"],
+        specDirs: ["specs"],
+        testPatterns: ["tests/**/*.ts"],
+        lockFile: ".trace.lock",
+      }),
+    );
+    mkdirSync(join(dir, "specs"), { recursive: true });
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "specs", "spec.md"), "# Spec\n\n- REQ-001: covered requirement\n");
+    writeFileSync(join(dir, "src", "impl.ts"), "// @impl REQ-001\nexport const impl = 1;\n");
+    writeFileSync(join(dir, TASKS_REL), tasksMd(" "));
+    gitInit(dir);
+    gitCommitAll(dir, "init, no outstanding issues");
+    return dir;
+  }
+
+  it("a tick passes the gate; the same tick plus one word of task text fails it", async () => {
+    const dir = repoWithTasks("artgraph-235-gate-");
+    expect((await runAt(dir, ["reconcile"])).exitCode).toBe(0);
+
+    writeFileSync(join(dir, TASKS_REL), tasksMd("x"));
+    const ticked = await checkJson(dir);
+    expect(ticked.exitCode).toBe(0);
+    expect(ticked.json.pass).toBe(true);
+    expect(driftedIds(ticked.json.drifted)).not.toContain("doc:tasks.md");
+    // Reachability: the tick really did land in the diff. An empty diff would
+    // short-circuit to `baselineStatus: "skipped"` and pass for free.
+    expect(ticked.json.baselineStatus).toBe("computed");
+
+    // Control — the SAME tick, plus one word of T001's text. Only the prose
+    // differs from the passing case above, so this is what separates "the
+    // state character is not content" from "the file is not content".
+    writeFileSync(join(dir, TASKS_REL), tasksMd("x", "wire the login hub"));
+    const edited = await checkJson(dir);
+    expect(edited.exitCode).toBe(2);
+    expect(driftedIds(edited.json.newIssues.drifted)).toContain("doc:tasks.md");
+  });
+
+  it("a lock predating the canonicalization is out of scope for --diff --gate and clears with one reconcile", async () => {
+    const dir = cleanRepoWithTasks("artgraph-235-migrate-");
+    // Commit the file WITH the box ticked, so the pre-canonicalization hash
+    // and the current one actually differ.
+    writeFileSync(join(dir, TASKS_REL), tasksMd("x"));
+    gitCommitAll(dir, "tick T001");
+    expect((await runAt(dir, ["reconcile"])).exitCode).toBe(0);
+    const absoluteGate = async (): Promise<{ exitCode: number; drifted: string[] }> => {
+      const { stdout, exitCode } = await runAt(dir, ["check", "--gate", "--format", "json"]);
+      return { exitCode, drifted: driftedIds(JSON.parse(stdout).drifted) };
+    };
+    // Baseline: with a lock this CLI wrote, the unscoped gate is clean.
+    expect(await absoluteGate()).toEqual({ exitCode: 0, drifted: [] });
+
+    // Rewrite that one entry to the value the pre-canonicalization whole-file
+    // hash produced — exactly what an in-place upgrade leaves behind.
+    const lockPath = join(dir, ".trace.lock");
+    const lock = JSON.parse(readFileSync(lockPath, "utf-8"));
+    const preCanonical = createHash("sha256")
+      .update(readFileSync(join(dir, TASKS_REL), "utf-8"))
+      .digest("hex")
+      .slice(0, 16);
+    expect(lock["doc:tasks.md"].contentHash).not.toBe(preCanonical);
+    lock["doc:tasks.md"] = { ...lock["doc:tasks.md"], contentHash: preCanonical };
+    writeFileSync(lockPath, JSON.stringify(lock, null, 2) + "\n");
+
+    // The standard gate is scoped to the diff and the working tree is clean,
+    // so the stale entry is never asked about mid-PR.
+    const gated = await checkJson(dir);
+    expect(gated.exitCode).toBe(0);
+    expect(gated.json.pass).toBe(true);
+
+    // The whole-repo gate does surface it — once.
+    expect(await absoluteGate()).toEqual({ exitCode: 2, drifted: ["doc:tasks.md"] });
+
+    // ...and one reconcile is the whole migration.
+    expect((await runAt(dir, ["reconcile"])).exitCode).toBe(0);
+    expect(await absoluteGate()).toEqual({ exitCode: 0, drifted: [] });
   });
 });

--- a/tests/check-baseline-diff.test.ts
+++ b/tests/check-baseline-diff.test.ts
@@ -1307,13 +1307,14 @@ describe("check --diff --gate drift key discriminates by content, not just nodeI
 // `check --diff --gate` with exit 2, on what is the most ordinary SDD
 // operation there is. These pin the gate-level contract: the tick is
 // invisible, everything else in the file still is not, and a lock written
-// before the canonicalization existed migrates without ever touching the
-// standard gate.
+// before the canonicalization existed migrates without ever failing the
+// standard gate — whether the doc stays out of the diff or lands in it and is
+// suppressed as pre-existing.
 // ---------------------------------------------------------------------------
 describe("check --gate and task-list checkbox state (issue #235)", () => {
   const TASKS_REL = join("specs", "tasks.md");
-  const tasksMd = (state: string, text = "wire the hub"): string =>
-    ["# Tasks", "", `- [${state}] T001 ${text}`, "- [ ] T002 pay the debt", ""].join("\n");
+  const tasksMd = (state: string, text = "wire the hub", state2 = " "): string =>
+    ["# Tasks", "", `- [${state}] T001 ${text}`, `- [${state2}] T002 pay the debt`, ""].join("\n");
   const driftedIds = (entries: Array<{ nodeId: string }>): string[] => entries.map((d) => d.nodeId);
 
   function repoWithTasks(prefix: string): string {
@@ -1402,6 +1403,11 @@ describe("check --gate and task-list checkbox state (issue #235)", () => {
     const gated = await checkJson(dir);
     expect(gated.exitCode).toBe(0);
     expect(gated.json.pass).toBe(true);
+    // ...and pin what that pass does NOT mean. With an empty diff no baseline
+    // is built at all, so the stale entry went unlooked-at rather than looked
+    // at and forgiven — "suppressed as pre-existing" is the next test's job.
+    expect(gated.json.baselineStatus).toBe("skipped");
+    expect(gated.json.suppressedCount).toBe(0);
 
     // The whole-repo gate does surface it — once.
     expect(await absoluteGate()).toEqual({ exitCode: 2, drifted: ["doc:tasks.md"] });
@@ -1409,5 +1415,48 @@ describe("check --gate and task-list checkbox state (issue #235)", () => {
     // ...and one reconcile is the whole migration.
     expect((await runAt(dir, ["reconcile"])).exitCode).toBe(0);
     expect(await absoluteGate()).toEqual({ exitCode: 0, drifted: [] });
+  });
+
+  it("a lock predating the canonicalization is suppressed as pre-existing when the doc DOES land in the diff", async () => {
+    const dir = cleanRepoWithTasks("artgraph-235-migrate-scoped-");
+    writeFileSync(join(dir, TASKS_REL), tasksMd("x"));
+    gitCommitAll(dir, "tick T001");
+    expect((await runAt(dir, ["reconcile"])).exitCode).toBe(0);
+
+    // Same in-place-upgrade shape as the test above: that one lock entry now
+    // holds the value the pre-canonicalization whole-file hash produced.
+    const lockPath = join(dir, ".trace.lock");
+    const lock = JSON.parse(readFileSync(lockPath, "utf-8"));
+    const preCanonical = createHash("sha256")
+      .update(readFileSync(join(dir, TASKS_REL), "utf-8"))
+      .digest("hex")
+      .slice(0, 16);
+    expect(lock["doc:tasks.md"].contentHash).not.toBe(preCanonical);
+    lock["doc:tasks.md"] = { ...lock["doc:tasks.md"], contentHash: preCanonical };
+    writeFileSync(lockPath, JSON.stringify(lock, null, 2) + "\n");
+
+    // Tick the OTHER box. That edit is what drags tasks.md into the diff, so
+    // the stale entry is compared and does mismatch — and then has to be
+    // forgiven: the base ref canonicalizes to the same value, so #397's
+    // content-bearing drift key matches and the drift is pre-existing debt.
+    writeFileSync(join(dir, TASKS_REL), tasksMd("x", "wire the hub", "x"));
+    const scoped = await checkJson(dir);
+    expect(scoped.exitCode).toBe(0);
+    expect(scoped.json.pass).toBe(true);
+    expect(scoped.json.baselineStatus).toBe("computed");
+    // Seen and forgiven, not skipped — this is the assertion the sibling test
+    // structurally cannot make.
+    expect(driftedIds(scoped.json.drifted)).toEqual(["doc:tasks.md"]);
+    expect(driftedIds(scoped.json.newIssues.drifted)).toEqual([]);
+    expect(scoped.json.suppressedCount).toBe(1);
+
+    // Control — reword T001 on top of the very same stale lock entry. The
+    // mismatch now carries bytes the base ref does not have, so the drift key
+    // differs, nothing is suppressed, and the gate fails.
+    writeFileSync(join(dir, TASKS_REL), tasksMd("x", "wire the login hub"));
+    const edited = await checkJson(dir);
+    expect(edited.exitCode).toBe(2);
+    expect(driftedIds(edited.json.newIssues.drifted)).toEqual(["doc:tasks.md"]);
+    expect(edited.json.suppressedCount).toBe(0);
   });
 });

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, afterAll } from "vitest";
 import { resolve } from "node:path";
-import { writeFileSync, unlinkSync, mkdirSync, rmdirSync, rmSync } from "node:fs";
+import { writeFileSync, unlinkSync, mkdirSync, rmdirSync, rmSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import {
   parseMarkdown,
+  parseMarkdownContent,
   parseFrontmatter,
   findFrontmatterBounds,
   stripAnnotations,
@@ -145,14 +147,20 @@ describe("parseMarkdown", () => {
   });
 
   describe("T022: doc node contentHash", () => {
-    it("should compute contentHash from entire file content", () => {
-      const result = parseMarkdown(resolve(FIXTURE_DIR, "specs/prose-only.md"), {
-        rootDir: FIXTURE_DIR,
-      });
+    it("should hash the entire file, byte for byte, when it carries no task-list checkbox", () => {
+      const file = resolve(FIXTURE_DIR, "specs/prose-only.md");
+      const result = parseMarkdown(file, { rootDir: FIXTURE_DIR });
       const doc = result.nodes.find((n) => n.kind === "doc");
 
-      expect(doc?.contentHash).toBeDefined();
-      expect(doc!.contentHash.length).toBe(16);
+      // Pin the VALUE, not just the shape: a file with no GFM task-list
+      // checkbox has to hash exactly the way it always has — the checkbox
+      // canonicalization (see the doc-contentHash suite at the end of this
+      // file) is the identity on such a file. Asserting only
+      // `contentHash.length === 16` here would also hold for `hash("")`.
+      const raw = readFileSync(file, "utf-8");
+      expect(raw).not.toContain("\r"); // LF-only fixture: the EOL normalization is a no-op
+      expect(raw).not.toMatch(/\[[xX ]\]/); // and there is no checkbox to canonicalize
+      expect(doc!.contentHash).toBe(createHash("sha256").update(raw).digest("hex").slice(0, 16));
     });
   });
 
@@ -1455,4 +1463,204 @@ describe("parseFrontmatter / findFrontmatterBounds parity (#44)", () => {
       expect(lines.slice(fb.end + 1).join("\n")).toBe(pf.content);
     },
   );
+});
+
+// ── doc contentHash: a GFM task-list checkbox's state is not doc content ──
+//
+// The state character of every GFM task-list checkbox (`[x]` / `[X]`) is
+// canonicalized to `[ ]` before the doc node's contentHash is taken, so
+// ticking a box does not read as a document change. This is a property of the
+// file's shape, not of any config: it covers `tasks.md` task lists and the
+// review checklists under `specs/*/checklists/` alike. Everything else — the
+// task text after the box, and any bracket state that is not a GFM checkbox
+// (`[-]`, `[~]`, `[P]`) — still hashes verbatim.
+describe("parseMarkdownContent — doc contentHash and task-list checkbox state", () => {
+  const root = resolve(import.meta.dirname, "fixtures");
+
+  // Parse `source` as if it lived at `<fixtures>/specs/feat/<stem>.md`.
+  // Nothing is written to disk: the path only decides the doc node's id and
+  // which task-convention presets apply (the `tasks` stem activates
+  // spec-kit's `T\d+`, so the fixtures below produce task nodes too).
+  function parse(source: string, stem = "tasks") {
+    return parseMarkdownContent(source, resolve(root, "specs", "feat", `${stem}.md`), {
+      rootDir: root,
+      specDirPrefix: "specs",
+    });
+  }
+
+  function docHash(source: string, stem = "tasks"): string {
+    const doc = parse(source, stem).nodes.find((n) => n.kind === "doc");
+    if (!doc) throw new Error("no doc node in parsed result");
+    return doc.contentHash;
+  }
+
+  function taskNode(source: string, id: string, stem = "tasks") {
+    return parse(source, stem).nodes.find((n) => n.kind === "task" && n.id === id);
+  }
+
+  const taskDoc = (lines: string[]): string => ["# Tasks", "", ...lines, ""].join("\n");
+
+  it("ticks do not move the doc hash, prose edits do, and the task node still sees the box", () => {
+    const unchecked = taskDoc(["- [ ] T001 wire the login handler", "- [ ] T002 add the store"]);
+    const checked = unchecked.replace("- [ ] T001", "- [x] T001");
+    const proseEdited = unchecked.replace("login handler", "logout handler");
+
+    expect(docHash(checked)).toBe(docHash(unchecked));
+    // Control — without it the assertion above is also satisfied by an
+    // implementation that discards the body before hashing.
+    expect(docHash(proseEdited)).not.toBe(docHash(unchecked));
+    // The canonicalization feeds the hash call ONLY; the text every other
+    // consumer reads is untouched. A task node hashes its own checkbox on
+    // purpose (see the task branch in src/parsers/markdown.ts) and its label
+    // still quotes the box as authored.
+    const before = taskNode(unchecked, "T001")!;
+    const after = taskNode(checked, "T001")!;
+    expect(before.label).toContain("[ ]");
+    expect(after.label).toContain("[x]");
+    expect(after.contentHash).not.toBe(before.contentHash);
+  });
+
+  it("treats a checkbox inside a fenced code block as content", () => {
+    const src = (state: string) =>
+      [
+        "# Tasks",
+        "",
+        "```sh",
+        `- [${state}] T900 documented example`,
+        "```",
+        "",
+        "- [ ] T001 real task",
+        "",
+      ].join("\n");
+    expect(docHash(src("x"))).not.toBe(docHash(src(" ")));
+    // The fence really is a fence: the quoted line is not a list item at all,
+    // which is why the canonicalization never reaches it.
+    expect(taskNode(src("x"), "T900")).toBeUndefined();
+    expect(taskNode(src("x"), "T001")).toBeDefined();
+  });
+
+  it("treats a checkbox inside an indented code block as content", () => {
+    const src = (state: string) =>
+      [
+        "# Tasks",
+        "",
+        "Example:",
+        "",
+        `    - [${state}] T901 indented example`,
+        "",
+        "- [ ] T001 real task",
+        "",
+      ].join("\n");
+    expect(docHash(src("x"))).not.toBe(docHash(src(" ")));
+    expect(taskNode(src("x"), "T901")).toBeUndefined();
+    expect(taskNode(src("x"), "T001")).toBeDefined();
+  });
+
+  it("treats a YAML flow sequence in the frontmatter as content", () => {
+    const src = (state: string) =>
+      ["---", "tags:", `  - [${state}]`, "---", "# Tasks", "", "- [ ] T001 real task", ""].join(
+        "\n",
+      );
+    expect(docHash(src("x"))).not.toBe(docHash(src(" ")));
+    expect(taskNode(src("x"), "T001")).toBeDefined();
+  });
+
+  it("canonicalizes a checkbox inside a blockquote", () => {
+    const src = (state: string) => taskDoc([`> - [${state}] T010 quoted task`]);
+    expect(docHash(src("x"))).toBe(docHash(src(" ")));
+    // Reachability: the quoted item IS a task list item, so the two hashes can
+    // only agree because the canonicalization descended into the blockquote.
+    expect(taskNode(src("x"), "T010")).toBeDefined();
+    // Control: the quoted text is still content.
+    expect(docHash(src("x"))).not.toBe(docHash(taskDoc(["> - [x] T010 quoted task, reworded"])));
+  });
+
+  // Every list-item shape the parser accepts as a task must also be reached by
+  // the canonicalization — a shape it misses puts the checkbox noise straight
+  // back into the doc hash.
+  const markerVariants: Array<{ name: string; lines: (state: string) => string[]; id: string }> = [
+    { name: "dash marker", lines: (s) => [`- [${s}] T801 variant`], id: "T801" },
+    { name: "star marker", lines: (s) => [`* [${s}] T802 variant`], id: "T802" },
+    { name: "plus marker", lines: (s) => [`+ [${s}] T803 variant`], id: "T803" },
+    { name: "ordered dot marker", lines: (s) => [`1. [${s}] T804 variant`], id: "T804" },
+    { name: "ordered paren marker", lines: (s) => [`2) [${s}] T805 variant`], id: "T805" },
+    {
+      name: "three-space nesting",
+      lines: (s) => ["- [ ] T800 parent", `   - [${s}] T806 variant`],
+      id: "T806",
+    },
+    {
+      name: "four-space nesting",
+      lines: (s) => ["- [ ] T800 parent", `    - [${s}] T807 variant`],
+      id: "T807",
+    },
+    { name: "tab after the box", lines: (s) => [`- [${s}]\tT808 variant`], id: "T808" },
+    { name: "double space after the marker", lines: (s) => [`-  [${s}] T809 variant`], id: "T809" },
+    {
+      name: "no-break space after the box",
+      lines: (s) => [`- [${s}]\u00a0T810 variant`],
+      id: "T810",
+    },
+  ];
+
+  it.each(markerVariants)("canonicalizes the state with a $name", ({ lines, id }) => {
+    const checked = taskDoc(lines("x"));
+    expect(docHash(checked)).toBe(docHash(taskDoc(lines(" "))));
+    // Reachability: this shape really is a task list item.
+    expect(taskNode(checked, id)).toBeDefined();
+    // Control: the text after the box is still content.
+    expect(docHash(checked)).not.toBe(docHash(checked.replace("variant", "variant, reworded")));
+  });
+
+  it("leaves bracket states that are not GFM checkboxes verbatim", () => {
+    const src = (state: string) => taskDoc([`- [${state}] T001 in progress`]);
+    // `[-]`, `[~]` and `[P]` carry project-specific meaning in this repo's own
+    // specs; swapping one for another is a content change.
+    expect(docHash(src("-"))).not.toBe(docHash(src("~")));
+    expect(docHash(src("P"))).not.toBe(docHash(src("Q")));
+    // ...and none of them collapses onto the canonical empty box.
+    expect(docHash(src("-"))).not.toBe(docHash(src(" ")));
+    expect(docHash(src("~"))).not.toBe(docHash(src(" ")));
+    expect(docHash(src("P"))).not.toBe(docHash(src(" ")));
+    // A marker needs whitespace after it, so a one-character link text is not
+    // a checkbox: `[x](/href)` and `[x][ref]` are links, `[x]tight` is text.
+    const linked = (state: string) => taskDoc([`- [${state}](/notes) release notes`]);
+    const reffed = (state: string) => taskDoc([`- [${state}][notes] release notes`]);
+    const tight = (state: string) => taskDoc([`- [${state}]tight`]);
+    expect(docHash(linked("x"))).not.toBe(docHash(linked(" ")));
+    expect(docHash(reffed("x"))).not.toBe(docHash(reffed(" ")));
+    expect(docHash(tight("x"))).not.toBe(docHash(tight(" ")));
+    // Control: the two states that ARE GFM checkbox states do collapse.
+    expect(docHash(src("x"))).toBe(docHash(src(" ")));
+    expect(docHash(src("X"))).toBe(docHash(src(" ")));
+  });
+
+  it("canonicalizes EOL style and checkbox state together, whichever way the file is written", () => {
+    const lf = taskDoc(["- [ ] T001 wire the login handler"]);
+    const crlfTicked = taskDoc(["- [x] T001 wire the login handler"]).replace(/\n/g, "\r\n");
+    expect(docHash(crlfTicked)).toBe(docHash(lf));
+    // Control: prose still survives both normalizations.
+    const crlfEdited = taskDoc(["- [x] T001 wire the logout handler"]).replace(/\n/g, "\r\n");
+    expect(docHash(crlfEdited)).not.toBe(docHash(lf));
+  });
+
+  it("handles degenerate checkbox and file shapes", () => {
+    // A box with nothing after it is still a box.
+    expect(docHash(taskDoc(["- [x]"]))).toBe(docHash(taskDoc(["- [ ]"])));
+    // No trailing newline at EOF.
+    expect(docHash("- [x] T001 tail")).toBe(docHash("- [ ] T001 tail"));
+    // A two-character state is not a state — the closing bracket is not where
+    // a checkbox has to put it, so both spellings stay verbatim.
+    expect(docHash(taskDoc(["- [xx] T001 tail"]))).not.toBe(docHash(taskDoc(["- [Xx] T001 tail"])));
+    // Truncated at EOF: nothing to read where the closing bracket would be.
+    expect(() => docHash("- [x")).not.toThrow();
+    // Frontmatter and nothing else — the body is the empty string, where the
+    // splice back into the file has to be the identity.
+    const frontmatterOnly = ["---", "title: empty", "---", ""].join("\n");
+    expect(docHash(frontmatterOnly)).toBe(
+      createHash("sha256").update(frontmatterOnly).digest("hex").slice(0, 16),
+    );
+    // Empty file.
+    expect(docHash("")).toBe(createHash("sha256").update("").digest("hex").slice(0, 16));
+  });
 });

--- a/tests/markdown.test.ts
+++ b/tests/markdown.test.ts
@@ -1575,9 +1575,13 @@ describe("parseMarkdownContent — doc contentHash and task-list checkbox state"
     expect(docHash(src("x"))).not.toBe(docHash(taskDoc(["> - [x] T010 quoted task, reworded"])));
   });
 
-  // Every list-item shape the parser accepts as a task must also be reached by
-  // the canonicalization — a shape it misses puts the checkbox noise straight
-  // back into the doc hash.
+  // Every shape in which the marker OPENS a list item must be reached by the
+  // canonicalization — one it misses puts the checkbox noise straight back into
+  // the doc hash. That is narrower than "every shape the parser calls a task":
+  // task detection reads the first paragraph found ANYWHERE in the item, so an
+  // item that opens with some other block still yields a task node while the
+  // canonicalization correctly declines it (next test). The looseness is on the
+  // detection side and predates this behaviour.
   const markerVariants: Array<{ name: string; lines: (state: string) => string[]; id: string }> = [
     { name: "dash marker", lines: (s) => [`- [${s}] T801 variant`], id: "T801" },
     { name: "star marker", lines: (s) => [`* [${s}] T802 variant`], id: "T802" },
@@ -1610,6 +1614,25 @@ describe("parseMarkdownContent — doc contentHash and task-list checkbox state"
     expect(taskNode(checked, id)).toBeDefined();
     // Control: the text after the box is still content.
     expect(docHash(checked)).not.toBe(docHash(checked.replace("variant", "variant, reworded")));
+  });
+
+  it("leaves a marker that opens a LATER block of the item as content", () => {
+    // The item opens with an HTML comment, so the `[x]` lands in the item's
+    // second block. GFM only calls the FIRST block's leading marker a checkbox,
+    // which is why the canonicalization reads `children[0]` and not the first
+    // paragraph it can find anywhere in the item.
+    const src = (state: string) =>
+      taskDoc(["- <!-- planning note -->", "", `  [${state}] T820 after the comment`]);
+    expect(docHash(src("x"))).not.toBe(docHash(src(" ")));
+    // Reachability: nothing here went unrecognized — task detection IS the
+    // looser `find(paragraph)` and mints a task node for this very shape, so
+    // the hashes differ because the canonicalization declined it, not because
+    // the parser saw no task.
+    expect(taskNode(src("x"), "T820")).toBeDefined();
+    // Control: move the same marker into the item's first block and it is a
+    // checkbox again — which block it opens is the only difference.
+    const opens = (state: string) => taskDoc([`- [${state}] T820 after the comment`]);
+    expect(docHash(opens("x"))).toBe(docHash(opens(" ")));
   });
 
   it("leaves bracket states that are not GFM checkboxes verbatim", () => {
@@ -1647,11 +1670,26 @@ describe("parseMarkdownContent — doc contentHash and task-list checkbox state"
   it("handles degenerate checkbox and file shapes", () => {
     // A box with nothing after it is still a box.
     expect(docHash(taskDoc(["- [x]"]))).toBe(docHash(taskDoc(["- [ ]"])));
+    // ...including when the FILE ends at the closing bracket, so there is no
+    // following character at all for the "whitespace after the box" rule to
+    // read. That rule has to treat "end of item" as a pass, not a reject.
+    expect(docHash("- [x]")).toBe(docHash("- [ ]"));
     // No trailing newline at EOF.
     expect(docHash("- [x] T001 tail")).toBe(docHash("- [ ] T001 tail"));
     // A two-character state is not a state — the closing bracket is not where
     // a checkbox has to put it, so both spellings stay verbatim.
     expect(docHash(taskDoc(["- [xx] T001 tail"]))).not.toBe(docHash(taskDoc(["- [Xx] T001 tail"])));
+    // Same rule, but resting on the closing bracket ALONE: `[x  ]` is followed
+    // by whitespace, so only "is `]` the third character?" can reject it. Take
+    // that half away and every spelling here collapses onto `[   ]`.
+    const wide = (state: string) => taskDoc([`- [${state}  ] T001 tail`]);
+    expect(docHash(wide("x"))).not.toBe(docHash(wide("X")));
+    expect(docHash(wide("x"))).not.toBe(docHash(wide(" ")));
+    // Reachability of that rejection: artgraph's own task preset requires
+    // `[xX ]` between the brackets too, so it mints no task node for `[x  ]`
+    // while the same line with a real box does.
+    expect(taskNode(wide("x"), "T001")).toBeUndefined();
+    expect(taskNode(taskDoc(["- [x] T001 tail"]), "T001")).toBeDefined();
     // Truncated at EOF: nothing to read where the closing bracket would be.
     expect(() => docHash("- [x")).not.toThrow();
     // Frontmatter and nothing else — the body is the empty string, where the

--- a/tests/parse-cache.test.ts
+++ b/tests/parse-cache.test.ts
@@ -249,7 +249,33 @@ describe("parse cache", () => {
     expect(snapshotGraph(graph)).toBe(buildWithoutCache(tmp, symbolCfg));
   });
 
-  it("rejects a cache file with a stale schemaVersion (SCHEMA_VERSION was bumped 7→8 in issues #323/#333)", () => {
+  // issue #235 — the doc node's contentHash now canonicalizes GFM task-list
+  // checkbox state, but the cache key stays the file's RAW bytes. That split is
+  // what makes a tick observable exactly where it should be: the fragment is
+  // invalidated (so the task node, which hashes its checkbox on purpose, is
+  // re-derived instead of served stale) while the doc node's hash comes out
+  // unchanged. Keying the cache on the canonicalized text instead would stop a
+  // tick from busting the fragment at all, and a warm build would keep
+  // replaying the pre-tick task hash and label forever.
+  it("issue #235: a checkbox tick invalidates the fragment — the task hash moves, the doc hash does not", () => {
+    const tasksMd = (state: string) =>
+      ["# Tasks", "", `- [${state}] T001 wire the login handler`, ""].join("\n");
+    const tasksPath = join(tmp, "specs", "feat", "tasks.md");
+
+    writeFileSync(tasksPath, tasksMd(" "));
+    const first = buildGraph(tmp, config).graph; // cold: populates the cache
+    const taskBefore = first.nodes.get("T001")!.contentHash;
+    const docBefore = first.nodes.get("doc:feat/tasks.md")!.contentHash;
+
+    writeFileSync(tasksPath, tasksMd("x"));
+    const { graph } = buildGraph(tmp, config); // warm
+    expect(graph.nodes.get("T001")!.contentHash).not.toBe(taskBefore);
+    expect(graph.nodes.get("doc:feat/tasks.md")!.contentHash).toBe(docBefore);
+    // ...and the warm rebuild is still indistinguishable from a cold one.
+    expect(snapshotGraph(graph)).toBe(buildWithoutCache(tmp));
+  });
+
+  it("rejects a cache file with a stale schemaVersion (SCHEMA_VERSION was bumped 8→9 in issue #235)", () => {
     // spec 021 (T016, issue #218) bumped 4→5 for class-method-grain symbols;
     // PR #242 review A bumped 5→6 when `TsFragment` gained the `warnings`
     // field (a v5 fragment has no `warnings` key at all, so a warm hit on it
@@ -262,25 +288,29 @@ describe("parse cache", () => {
     // so a pre-fix fragment's `kind` may not match what the new logic would
     // produce, and (b) the parser now emits `unresolved-reexport` /
     // `unresolved-import` warnings a pre-fix fragment's `warnings` field
-    // never recorded. Populate the cache normally, then hand-edit its
-    // schemaVersion down to the previous value. `readParseCache` must reject
-    // it and force a cold path — otherwise a warm build could serve a
-    // fragment that predates the current parser output, silently diverging
-    // from a cold rebuild (INV-L4 breach).
+    // never recorded; issue #235 bumped 8→9 because an `MdFragment` carries
+    // its doc node's `contentHash` verbatim while the cache key is the file's
+    // raw bytes — an untouched file HITS, so a pre-#235 fragment would keep
+    // replaying the old whole-file hash (checkbox state included) forever.
+    // Populate the cache normally, then hand-edit its schemaVersion down to
+    // the previous value. `readParseCache` must reject it and force a cold
+    // path — otherwise a warm build could serve a fragment that predates the
+    // current parser output, silently diverging from a cold rebuild (INV-L4
+    // breach).
     buildGraph(tmp, config); // populate cache
     const rawPath = join(tmp, CACHE_REL);
     const cache = JSON.parse(readFileSync(rawPath, "utf-8"));
-    expect(cache.schemaVersion).toBe(8);
-    cache.schemaVersion = 7;
+    expect(cache.schemaVersion).toBe(9);
+    cache.schemaVersion = 8;
     writeFileSync(rawPath, JSON.stringify(cache));
 
     // The next build sees a schema-mismatched cache and must fall back to
     // a cold parse. Behaviorally identical to a cache-disabled build.
     const { graph } = buildGraph(tmp, config);
     expect(snapshotGraph(graph)).toBe(buildWithoutCache(tmp));
-    // The rewritten cache carries the current schemaVersion (=8).
+    // The rewritten cache carries the current schemaVersion (=9).
     const rewritten = JSON.parse(readFileSync(rawPath, "utf-8"));
-    expect(rewritten.schemaVersion).toBe(8);
+    expect(rewritten.schemaVersion).toBe(9);
   });
 
   // PR #242 review A — the headline fix: the class-member collision warning


### PR DESCRIPTION
## Summary

Closes #235.

A doc node hashed its whole file, so ticking `- [ ]` → `- [x]` in a `tasks.md` drifted `doc:tasks.md` with no change to any REQ or task text. Since #397 gave drift a content-bearing suppression key, that noise reaches **gate verdicts**: `check --diff --gate` exits 2 on the tick alone — which an SDD loop hits on every implement step.

This canonicalizes the state character of each GFM task-list checkbox to `[ ]` before hashing the doc node, the same way `stripAnnotations` runs before a req is hashed (specs/010 R3).

**Marker positions come from the parsed mdast, not a line regex.** "Is this line a task-list item?" is a block-structure question, and a `^[ \t]*[-*+]`-shaped regex answers it wrongly in both directions:

| shape | line regex | mdast (this PR) |
|---|---|---|
| `- [x]` inside a fenced code block | rewrites it → an edit to real content **stops drifting** (fail-open) | left as content |
| `- [x]` inside an indented code block | rewrites it | left as content |
| `- [x]` in YAML frontmatter | rewrites it | never seen (operates on the post-frontmatter body) |
| `> - [x] T010` in a blockquote | misses it → #235's noise remains | canonicalized |

The fenced-code case is not hypothetical: **6 such lines exist in this repo's own specs today** (`specs/005-speckit-remaining/quickstart.md`, heredoc examples).

Only the single character between the brackets is touched, so **a file with no checkbox hashes byte-identically to before**.

### Scope of the contract

The canonicalization is deliberately keyed on **file shape, not on the active `taskConventions`**. The contract is that *GFM checkbox state is not document content* — whether the box sits in a `tasks.md` task or in a review checklist. A config-driven variant would make every doc hash depend on `.artgraph.json`, so editing config would drift every `tasks.md`/`plan.md` doc at once.

Consequence worth naming: of the 36 doc hashes that move in this repo, **15 are `specs/*/checklists/requirements.md`** review checklists, 13 are `tasks.md`, 6 `plan.md`, 2 `quickstart.md`.

### Task and req nodes are untouched

`raw`, `content` and the mdast stay exactly as parsed — canonicalization applies only to the argument of `hash()`. A task node still hashes *and labels* its own checkbox, which is the documented intent (`parsers/markdown.ts`). Rewriting the `raw` variable instead would have silently moved **411 task hashes and labels**, and task nodes are not lock entries, so `check` would never have said a word.

`src/graph/builder.ts`'s md cache key stays the file's raw bytes for the same reason: normalizing it too would stop a tick from busting the cache, replaying stale task hashes on a warm build.

Req nodes are also untouched, which leaves a grain asymmetry: a checkbox nested *under* a req is hashed verbatim into that req and still drifts it. Zero occurrences in this repo, tracked in #418, and `docs/architecture.md` now names the asymmetry rather than claiming ticks never drift.

### parse-cache SCHEMA_VERSION 8 → 9

The md cache key is the file's raw bytes, so an untouched file **HITS** and a pre-fix fragment would replay its old whole-file doc hash indefinitely, diverging from a cold rebuild (INV-L4). `computeCacheFingerprint` folds in `artgraphVersion()`, but that only cold-invalidates across a release — within one package version (a PR's own dogfood runs, CI vs. a local checkout) nothing else would. Same rationale shape as the v7 and v8 bumps.

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm -r test`)
- [x] Added tests where needed
- [x] Ran `pnpm -r knip` and `pnpm -r build`

`pnpm test`: **2669 unit + 122 e2e + 8 perf passed**. `lint` / `typecheck` / `format:check` / `knip` / `check-no-raw-nul` all clean.

**Fixtures were written first and run against the unmodified code** to fix the golden: 20 failed before the change (the bug itself), and the byte-identity / non-checkbox / code-block cases passed before *and* after (the equivalence guarantee). Named byte-identity and double-build-determinism suites — lock round-trip, warm-vs-cold cache, repeated `buildGraph`, barrel byte-stability, trace graph — are green.

Every "hash does not move" assertion sits in the **same `it()` as a control that does move**, since the negative alone survives a `hash("")` mutant. Shape cases additionally assert whether a task node exists, so a tick-visible assertion cannot pass by simply failing to parse anything.

Corpus-level equivalence (cold build, this repo, 1536 nodes / 2126 edges / 26 warnings, old vs. new binary on an identical working tree):

| | diff |
|---|---|
| task / req / symbol / test nodes | **0** |
| doc nodes | **36** (the expected set) |
| edge list (order included) | **byte-identical** |
| warning list | **byte-identical** |

Dogfood self-check unchanged: orphans **128** (same set), `coverage[].status` **{untagged: 444, impl-only: 48}**, `drifted: 0`.

Issue reproduction, end to end: tick alone → `drifted: []` and `check --diff --gate` exit 0; the same tick **plus one word of task text** → exit 2 with `newIssues.drifted: ["doc:tasks.md"]`.

## Breaking change

- [ ] Yes (described below)
- [x] No

Behavior change with a one-time migration, documented as an Upgrade note in `docs/configuration.md`: checkbox-bearing docs get a new `contentHash` once. `check --diff --gate` is **unaffected** — base and current hash the same way, so #397's drift key matches and the entry stays suppressed (measured, and now pinned by a test). An unscoped `check --gate` reports the drift once — including the Spec Kit `before_implement` gate for anyone who enabled blocking gates — and one `artgraph reconcile` clears it. `.trace.lock` is gitignored in this repo, so no lock churn appears in the diff.

## Notes

### What review changed

The second commit is review fallout, and most of it is tests holding down guards that nothing held down before. Each of these mutations left the entire suite green on the first commit and now fails exactly one assertion:

| mutation | what it proves |
|---|---|
| `children[0]` → `find(paragraph)` | a marker opening a *later* block of a list item is content. artgraph's task detection reads the first paragraph found anywhere in the item, so such a shape yields a task node whose tick still moves the doc hash — asserted both ways |
| drop the closing-bracket check | `- [x  ]` has whitespace after the box, so only the bracket position can reject it. The pre-existing `- [xx]` assertion passed for the *other* guard's reason |
| reject `after === undefined` | the "or ends the item" branch needs a file ending at the `]` with no trailing newline; the existing case went through a helper that appends one |
| disable pre-existing drift suppression | the migration test ran on a clean worktree, so its diff was empty and it reported `baselineStatus: "skipped"` — it never exercised suppression at all |

That last one is the most substantive: the migration contract this PR documents (**a doc that lands in the diff hashes identically on both sides and is suppressed as pre-existing**) had no test. There is now one pinning `suppressedCount: 1` with an empty `newIssues.drifted`, plus a control that edits the task text and gets exit 2.

Review also found two docs claims wider than the behavior — `architecture.md` said a tick "does not drift" without naming a grain, and `configuration.md` said the canonicalization applies to *every* ticked list item, which a leading BOM falsifies for a whole file (#420). Both now say which grain and which shapes they mean, and the checkbox section adds what a reader deciding whether to rely on this actually needs: unticking is equally invisible, a checklist with no task IDs records the state nowhere, and there is no opt-out.

### A `[x]` needs whitespace after it

The first implementation was one notch looser than intended: `- [x](/notes)` and `- [x][ref]` are *links* whose text happens to be one `x`, and `- [x]tight` is plain text. All three were being canonicalized, colliding with their `[ ]` spellings on a single hash. Tightened by requiring the character after `]` to be absent or whitespace, verified by removing the guard and watching the collision reappear.

The guard tests with JS `/\s/` deliberately, **not** GFM's narrower space/tab/line-ending set. This project does not use remark-gfm, so `listItem.checked` is never populated and GFM-strict is not this parser's contract; what matters is agreeing with artgraph's *own* task detection, whose presets separate on `[\s ]` — and JS `\s` already contains U+00A0, so the two classes are identical. Measured across all 25 whitespace characters: canonicalized ⇔ task node created ⇔ preset matches, with no disagreement. Tightening to GFM would break that agreement for 19 of them.

`[-]`, `[~]` and `[P]` are not GFM checkbox states and stay verbatim — they carry project-specific meaning in this repo's specs (9 files use `[P]`).

### T383-e's expectations are unchanged

Its fixture (`specs/debt.md`) carries no checkbox, so the canonicalization is the identity there. Only its comment changed: it claimed a doc hash covers "the WHOLE file's raw bytes", which was already inaccurate before this PR (the bytes are EOL-normalized). This is a comment correction, not a loss of discrimination.

`specs/008-document-graph/spec.md` SC-007 and the doc-node Key Entity were amended, since a Success Criterion asserting whole-file hashing would otherwise be false; `tasks.md` T022/T026 carried the same wording and were amended to match.

### Follow-ups

Found during the impact study and the review rounds, out of scope here:

- #418 — **req-granularity residual.** A checkbox nested under a req's list item, and a `reqPatterns.listItem` permissive enough to accept a checkbox, both still move the *req* hash. Zero occurrences in this repo; reproduced on synthetic fixtures. Left out because it would grow the migration from 172 doc entries to ~664 and introduce a composition-order question with `stripAnnotations`.
- #419 — **the built-in `kiro` preset's `taskIdRe` is rejected by `loadConfig`**, so the documented checkbox-less Kiro override is unreachable for hierarchical numeric IDs. Pre-existing.
- #420 — **two shapes the canonicalization does not reach**: a leading BOM (offsets shift by one, whole file becomes a no-op) and a list item whose first child is not a paragraph. Both fail noisy — the hash is byte-identical to the pre-PR value — so #235 simply remains unfixed there.
- #421 — **`reconcile` takes no scope**, so every upgrade note that says "run `artgraph reconcile`" also tells users to approve unrelated pending drift. Pre-existing template wording; this PR's own note now says to review `check` output first.

Two phantom `verifies` edges from string literals in `tests/markdown.test.ts` were also confirmed while measuring the dogfood baseline. Not filed separately — #387 already covers this class with the same root cause (`testReqRe` has no `matchInLineComment` guard) and counts these among its 128. This PR adds no new pollution: the orphan set is identical element for element.