### PR TITLE
fix(parser): count an @impl only when it opens a line comment

### DIFF
--- a/.artgraph.json
+++ b/.artgraph.json
@@ -11,7 +11,10 @@
   "testPatterns": [
     "**/*.test.ts",
     "**/*.spec.ts",
-    "**/*.test.tsx"
+    "**/*.test.tsx",
+    "!**/node_modules/**",
+    "!tests/fixtures/**",
+    "!examples/**"
   ],
   "lockFile": ".trace.lock",
   "packageManager": "pnpm"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -316,15 +316,30 @@ notation:
 — is unaffected, because it never registered: `@impl` is recognized only
 immediately after a `//`.)
 
-How loudly a lost claim surfaces depends on **which** gate you run. It always
-appears in `artgraph check`'s `UNCOVERED:` list, and a plain
-`artgraph check --gate` — the blocking Spec Kit `before_implement` hook, if you
-opted into it — goes red. The gates `artgraph init` wires up by default do
-**not**: the agent Stop hook (`check --gate --diff`) and the CI recipe
+How loudly a lost claim surfaces depends on whether the requirement had
+another one. If it was the requirement's **only** claim, the requirement turns
+up in `artgraph check`'s `UNCOVERED:` list and a plain `artgraph check --gate`
+— the blocking Spec Kit `before_implement` hook, if you opted into it — goes
+red. If the requirement is claimed somewhere else too, `check` reports nothing
+at all: coverage still says `impl-only`, the lock does not drift, and the only
+visible trace is that `artgraph impact <file>` on the file that lost the tag no
+longer reaches that requirement.
+
+Note also that the gates `artgraph init` wires up by default stay green either
+way: the agent Stop hook (`check --gate --diff`) and the CI recipe
 (`check --diff --base origin/<base> --gate`) both exclude pre-existing debt
 from the verdict, and a claim lost to this upgrade is pre-existing debt
-relative to the change being judged, so they stay green. Run a plain
-`artgraph check` once after upgrading rather than relying on the wired gates.
+relative to the change being judged.
+
+So do not rely on a gate to find these. Grep for the shape directly — a
+comment with a second `//` before the tag is the only one affected:
+
+```console
+$ git grep -nE '//.*//[^\S\n]*@impl'
+```
+
+then run a plain `artgraph check` to see which of the requirements involved
+lost their last claim.
 
 ## `docGraph` — doc nodes and their relations
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -258,6 +258,53 @@ Rules:
   is why nothing is excluded by default and `artgraph integrate speckit` does
   not write this setting for you.
 
+## Code tags — where an `@impl` counts <a id="code-tags-where-an-impl-counts"></a>
+
+**An `@impl` is a tag only when it opens a line comment (issue #387).** The
+comment may start with any number of slashes and the tag may be preceded by
+in-line whitespace, so all of these register:
+
+```ts
+// @impl REQ-001
+//@impl REQ-002
+/// @impl REQ-003
+  // @impl REQ-004      ← indentation is fine; it is outside the comment
+```
+
+Everything else that merely *contains* the same characters does not:
+
+```ts
+const doc = "// @impl REQ-900";                  // string / template / JSX text
+/* @impl REQ-901 */                              // block & JSDoc comments
+// Issue #214: `// @impl A, B` used to drop B    // prose quoting the syntax
+// TODO: @impl REQ-902                           // tag not at the comment start
+```
+
+The reasoning is that a tag is a *claim about this file*, while a sentence
+that quotes the notation is *documentation about the notation*. Without the
+distinction, every code comment, test fixture, and doc snippet that spells out
+the syntax silently became a claim.
+
+One exception, by design: a file artgraph could not hand to the parser at all
+(`pathological-bracket-nesting`) has no comment spans to check, so its tags are
+still text-scanned as before — a documented fail-open, not a guarantee.
+
+### Upgrade note
+
+If a tag was written part-way through a comment — `// TODO: @impl REQ-001`,
+or a tag appended after prose — it no longer registers. Move it to the start of
+its own comment line:
+
+```diff
+-// TODO: @impl REQ-001
++// @impl REQ-001
++// TODO: …
+```
+
+This change is **fail-loud**: a requirement that loses its only claim this way
+shows up in `artgraph check`'s `UNCOVERED:` list and turns `check --gate` red,
+so it cannot pass unnoticed.
+
 ## `docGraph` — doc nodes and their relations
 
 Doc nodes (one per markdown file under `specDirs`) and their relations can be

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -285,25 +285,46 @@ that quotes the notation is *documentation about the notation*. Without the
 distinction, every code comment, test fixture, and doc snippet that spells out
 the syntax silently became a claim.
 
-One exception, by design: a file artgraph could not hand to the parser at all
-(`pathological-bracket-nesting`) has no comment spans to check, so its tags are
-still text-scanned as before — a documented fail-open, not a guarantee.
+This rule can only be applied where artgraph actually has comment spans, and
+there are two ways it ends up without any. A file that is never handed to the
+parser (`pathological-bracket-nesting`, which is skipped deliberately) and a
+file whose parse throws both fall back to the plain text scan, so their tags
+register as they did before. That is a documented **fail-open**, not a
+guarantee.
+
+The opposite case exists too and predates this rule: for a few inputs the
+parser returns successfully but reports *no comments at all* — an unterminated
+block comment, string, or template literal, or a tag sharing its line with a
+hashbang. An empty comment list is still a list, so the rule does run, finds no
+comment to open, and every tag in that file is rejected. That **fail-closed**
+behaviour is unchanged by the rule above (it is the same before and after) and
+is tracked separately.
 
 ### Upgrade note
 
-If a tag was written part-way through a comment — `// TODO: @impl REQ-001`,
-or a tag appended after prose — it no longer registers. Move it to the start of
-its own comment line:
+A tag that used to be picked up out of the *middle* of a comment no longer is.
+Concretely, that means a comment that opens with prose and then quotes the
+notation:
 
 ```diff
--// TODO: @impl REQ-001
+-// see below // @impl REQ-001
 +// @impl REQ-001
-+// TODO: …
++// see below
 ```
 
-This change is **fail-loud**: a requirement that loses its only claim this way
-shows up in `artgraph check`'s `UNCOVERED:` list and turns `check --gate` red,
-so it cannot pass unnoticed.
+(A tag merely preceded by prose with no second `//` — `// TODO: @impl REQ-001`
+— is unaffected, because it never registered: `@impl` is recognized only
+immediately after a `//`.)
+
+How loudly a lost claim surfaces depends on **which** gate you run. It always
+appears in `artgraph check`'s `UNCOVERED:` list, and a plain
+`artgraph check --gate` — the blocking Spec Kit `before_implement` hook, if you
+opted into it — goes red. The gates `artgraph init` wires up by default do
+**not**: the agent Stop hook (`check --gate --diff`) and the CI recipe
+(`check --diff --base origin/<base> --gate`) both exclude pre-existing debt
+from the verdict, and a claim lost to this upgrade is pre-existing debt
+relative to the change being judged, so they stay green. Run a plain
+`artgraph check` once after upgrading rather than relying on the wired gates.
 
 ## `docGraph` — doc nodes and their relations
 

--- a/src/parse-cache.ts
+++ b/src/parse-cache.ts
@@ -143,7 +143,17 @@ export interface ParseCacheData {
 // `computeCacheFingerprint` folds in `artgraphVersion()`, but that only
 // cold-invalidates across a release: within one package version (a PR's own
 // dogfood runs, CI vs. a local checkout) nothing else would.
-const SCHEMA_VERSION = 9;
+// v10 (issue #387): an `@impl` now counts only when it OPENS a line comment,
+// so a tag QUOTED mid-comment (`// Issue #214: \`// @impl A, B\` used to …`)
+// no longer emits an `implements` edge. A pre-fix fragment for such a file
+// carries those edges baked in, and the md/ts cache key is the file's own
+// content hash — an untouched file HITS, replaying the phantom claims for as
+// long as it is not edited. Measured on this repository: a cache warmed by the
+// pre-fix build and then read by the fixed build reproduced all 8 stale edges
+// (118 orphans) where a cold rebuild of the identical tree yields 110 — the
+// warm ≡ cold divergence (INV-L4) this counter exists to prevent, same
+// rationale as v7/v8/v9.
+const SCHEMA_VERSION = 10;
 const CACHE_RELDIR = join("node_modules", ".cache", "artgraph");
 const CACHE_FILENAME = "parse-cache.json";
 

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -1030,7 +1030,9 @@ function parseTSFile(
         `pathological bracket nesting depth ${depth} exceeds ${limit}; skipped parsing ` +
         `"${relPath}" to avoid a native oxc-parser crash (issue #247). No symbols or imports ` +
         "were extracted from this file; text-scanned tags (`@impl` comments, `[REQ-…]` test " +
-        "titles) are still honored.",
+        "titles) are still honored — including ones an ordinarily-parsed file would reject " +
+        "(a quoted `@impl` in a string or mid-comment), since the comment spans needed to tell " +
+        "them apart are exactly what the skipped parse would have produced.",
     });
   }
 
@@ -2801,13 +2803,18 @@ function extractImplTags(
 
   implRe.lastIndex = 0;
   while ((match = implRe.exec(content)) !== null) {
-    // D6: a `// @impl …` counts only when its `//` is a REAL line comment. The
+    // D6: a `// @impl …` counts only when it OPENS a REAL line comment. The
     // same text inside a string / template / JSX attribute (no comment span at
     // all) or inside a block/JSDoc comment (e.g. a backtick-quoted `// @impl`
-    // in docs, type "Block") is not a tag and must not emit an edge. `comments`
-    // is undefined only for pathological unparseable input; there we keep the
+    // in docs, type "Block") is not a tag and must not emit an edge; neither is
+    // one quoted PART-WAY THROUGH a line comment (issue #387). `comments` is
+    // undefined only for pathological unparseable input; there we keep the
     // regex-only behavior so a broken file's tags still survive.
-    if (comments && !matchInLineComment(comments, match.index)) continue;
+    //
+    // `match.index` is the `//` the regex itself matched; the tag proper starts
+    // at the first `@` of that match (the ID grammar contains no `@`).
+    const tagIndex = match.index + match[0].indexOf("@");
+    if (comments && !matchOpensLineComment(comments, content, match.index, tagIndex)) continue;
 
     const reqIds = match[1].match(reqIdRe);
     if (!reqIds) continue;
@@ -2920,13 +2927,41 @@ function resolveSymbolsAtLine(ranges: SymbolRange[], line: number): string[] {
     .map((r) => r.name);
 }
 
-// True when `index` (the `//` offset of an @impl match) lands inside a real
-// LINE comment. Block/JSDoc comments (type "Block") and string / template /
-// JSX-attribute literals (no comment span covering the offset) are excluded,
-// so a `// @impl` appearing there is not treated as a tag (D6).
-function matchInLineComment(comments: readonly OxcComment[], index: number): boolean {
+// issue #387 — what may sit between a line comment's start and the `@` of a
+// tag that OPENS it: the comment's own slashes and in-line whitespace, nothing
+// else. oxc reports a `Line` comment span STARTING at its first `/` (pinned by
+// tests/parser-oxc-canary.test.ts), so `// @impl X` yields the prefix `"// "`,
+// `///` yields `"/// "` and `//@impl X` yields `"//"` — all tags — while
+// prose quoting the syntax (`// Issue #214: \`// @impl X\` used to …`) yields a
+// prefix containing that prose and is rejected. Any leading indentation is
+// OUTSIDE the span and therefore never part of the prefix.
+const TAG_COMMENT_PREFIX_RE = /^\/\/+[ \t]*$/;
+
+// True when the @impl tag at `tagIndex` OPENS a real LINE comment — i.e. the
+// comment containing `matchIndex` (the `//` the regex matched) is of type
+// "Line" and only that comment's own slashes/whitespace precede the tag.
+//
+// Block/JSDoc comments (type "Block") and string / template / JSX-attribute
+// literals (no comment span covering the offset at all) are excluded, so a
+// `// @impl` appearing there is not a tag (D6). A tag quoted mid-comment is
+// excluded too (#387): it is documentation ABOUT the syntax, not a claim about
+// this file. Comment spans never overlap, so the first `Line` comment
+// containing `matchIndex` is the only candidate — its verdict is final.
+//
+// The `type`/containment tests are deliberately kept even though the prefix
+// test alone now decides every case measured (a Block comment's prefix starts
+// `/*` and a tag outside the span drags the intervening text into the prefix,
+// so both are already rejected): they state the intent the prefix test only
+// implies, and they are what keeps this correct if that regex is ever relaxed.
+function matchOpensLineComment(
+  comments: readonly OxcComment[],
+  content: string,
+  matchIndex: number,
+  tagIndex: number,
+): boolean {
   for (const c of comments) {
-    if (c.type === "Line" && index >= c.start && index < c.end) return true;
+    if (c.type !== "Line" || matchIndex < c.start || matchIndex >= c.end) continue;
+    return TAG_COMMENT_PREFIX_RE.test(content.slice(c.start, tagIndex));
   }
   return false;
 }

--- a/src/parsers/typescript.ts
+++ b/src/parsers/typescript.ts
@@ -155,6 +155,17 @@ interface IdMatchers {
   testAnnotationRe: RegExp;
 }
 
+// Single source of truth for "in-line whitespace" — any whitespace except a
+// newline. `implRe` (below) and `TAG_COMMENT_PREFIX_RE` (issue #387, near
+// `matchOpensLineComment`) MUST share it: the prefix guard re-validates the
+// exact separator `implRe` already accepted, so a narrower class there
+// (`[ \t]`, say) silently drops tags that genuinely DO open their comment —
+// `//<U+00A0>@impl REQ-1` and `//<U+3000>@impl REQ-1` are the measured cases.
+// Same discovery/rewriting-parity idiom as src/grammar/tokens.ts.
+// `docs/configuration.md`'s "the tag may be preceded by in-line whitespace"
+// is this class, verbatim.
+const INLINE_WS = "[^\\S\\n]";
+
 // For codeId, the whole match is the ID, so the constructed matchers below rely
 // on the token having no significance beyond what it matches.
 //
@@ -168,7 +179,10 @@ interface IdMatchers {
 function buildIdMatchers(codeId?: string): IdMatchers {
   const token = codeId ?? NAMESPACED_ID_TOKEN;
   return {
-    implRe: new RegExp(`//[^\\S\\n]*@impl[^\\S\\n]+((?:(?:${token})(?:[^\\S\\n]|,)*)+)`, "gm"),
+    implRe: new RegExp(
+      `//${INLINE_WS}*@impl${INLINE_WS}+((?:(?:${token})(?:${INLINE_WS}|,)*)+)`,
+      "gm",
+    ),
     reqIdRe: new RegExp(token, "g"),
     testReqRe: new RegExp(`\\[(?:${token})]`, "g"),
     testAnnotationRe: new RegExp(`req:\\s*["']?(${token})["']?`, "g"),
@@ -2935,7 +2949,13 @@ function resolveSymbolsAtLine(ranges: SymbolRange[], line: number): string[] {
 // prose quoting the syntax (`// Issue #214: \`// @impl X\` used to …`) yields a
 // prefix containing that prose and is rejected. Any leading indentation is
 // OUTSIDE the span and therefore never part of the prefix.
-const TAG_COMMENT_PREFIX_RE = /^\/\/+[ \t]*$/;
+//
+// The whitespace class is `INLINE_WS`, the same constant `implRe` is built
+// from, and it has to stay that way: this guard re-validates the very
+// separator `implRe` already matched, so anything narrower here rejects tags
+// that DO open their comment (`//<U+00A0>@impl X`, `//<U+3000>@impl X` — both
+// `[^\S\n]`, neither ` ` nor `\t`; pinned in tests/barrel-reexport.test.ts).
+const TAG_COMMENT_PREFIX_RE = new RegExp(`^//+${INLINE_WS}*$`);
 
 // True when the @impl tag at `tagIndex` OPENS a real LINE comment — i.e. the
 // comment containing `matchIndex` (the `//` the regex matched) is of type
@@ -2948,11 +2968,20 @@ const TAG_COMMENT_PREFIX_RE = /^\/\/+[ \t]*$/;
 // this file. Comment spans never overlap, so the first `Line` comment
 // containing `matchIndex` is the only candidate — its verdict is final.
 //
-// The `type`/containment tests are deliberately kept even though the prefix
-// test alone now decides every case measured (a Block comment's prefix starts
-// `/*` and a tag outside the span drags the intervening text into the prefix,
-// so both are already rejected): they state the intent the prefix test only
-// implies, and they are what keeps this correct if that regex is ever relaxed.
+// Only the `type !== "Line"` conjunct is currently redundant: a Block
+// comment's prefix starts `/*`, so the prefix test rejects it anyway (measured
+// — deleting that conjunct leaves the whole suite green). It is kept because
+// it states the intent the prefix test only implies, and it is what keeps this
+// correct if that regex is ever relaxed.
+//
+// The CONTAINMENT conjunct is load-bearing, and in the false-NEGATIVE
+// direction: this loop `return`s on the first comment that passes the filter,
+// so without containment every tag in the file is judged against the FIRST
+// `Line` comment instead of its own. The slice then spans from that comment's
+// start all the way to the tag, dragging the intervening source into the
+// prefix, and every genuine tag in a later comment is rejected. Measured:
+// deleting it reddens tests across the parser, check, impact, plan-coverage
+// and trace suites.
 function matchOpensLineComment(
   comments: readonly OxcComment[],
   content: string,

--- a/tests/barrel-reexport.test.ts
+++ b/tests/barrel-reexport.test.ts
@@ -256,6 +256,34 @@ describe("#387 @impl counts only when it opens the line comment", () => {
     expect(implSourcesFor(frag, "REQ-932")).toEqual(["symbol:src/forms.ts#tabbed"]);
     expect(implSourcesFor(frag, "REQ-933")).toEqual([]);
   });
+
+  it("accepts every in-line whitespace `implRe` accepts (NBSP, ideographic space) yet still rejects prose", () => {
+    // The separator class is a SHARED invariant: `implRe` matches `//` +
+    // `[^\S\n]*` + the tag, so a prefix guard that re-validates that same
+    // separator with a NARROWER class (e.g. `[ \t]`) silently drops tags that
+    // genuinely DO open their comment. Written with `\u…` escapes so the
+    // fixture's exact bytes are visible in the source:
+    //   U+00A0 NO-BREAK SPACE, U+3000 IDEOGRAPHIC SPACE.
+    // Both are `[^\S\n]` but neither is ` ` or `\t`.
+    //
+    // The third line is the contrast that keeps the first two honest: a guard
+    // widened all the way to "anything" would accept REQ-940/941 AND the prose
+    // line, so REQ-942 must stay rejected — the #387 narrowing is unaffected
+    // by which whitespace class the guard uses.
+    makeRepo({
+      "src/ws.ts":
+        `//\u00A0${IMPL} REQ-940\n` +
+        "export function nbsp() {\n  return 1;\n}\n\n" +
+        `//\u3000${IMPL} REQ-941\n` +
+        "export function ideographic() {\n  return 1;\n}\n\n" +
+        `// see also //\u00A0${IMPL} REQ-942\n` +
+        "export function proseWithNbsp() {\n  return 1;\n}\n",
+    });
+    const frag = parseOne("src/ws.ts");
+    expect(implSourcesFor(frag, "REQ-940")).toEqual(["symbol:src/ws.ts#nbsp"]);
+    expect(implSourcesFor(frag, "REQ-941")).toEqual(["symbol:src/ws.ts#ideographic"]);
+    expect(implSourcesFor(frag, "REQ-942")).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/barrel-reexport.test.ts
+++ b/tests/barrel-reexport.test.ts
@@ -199,6 +199,66 @@ describe("#177 (D6) @impl in strings / templates / JSX / block comments is not a
 });
 
 // ---------------------------------------------------------------------------
+// (issue #387) a tag counts only when it OPENS the line comment
+// ---------------------------------------------------------------------------
+
+// The `@impl` token, assembled at runtime. Written split so THIS file's own
+// source never contains a contiguous `@impl` preceded by `//` inside one of
+// its OWN comments: artgraph dogfoods itself, and such a comment would now
+// register as a real code tag on this test file (that is exactly the
+// self-pollution issue #387 is about). Same split convention as
+// tests/parser-oxc-canary.test.ts's `fixtureTestTag`.
+const IMPL = "@" + "impl";
+
+describe("#387 @impl counts only when it opens the line comment", () => {
+  it("ignores a quoted tag INSIDE a line comment but keeps one that opens a comment", () => {
+    // The dogfood shape this guard exists for: prose documenting the tag
+    // syntax lives in a real `Line` comment, so "is this a line comment?"
+    // alone accepts it and registers REQ-920 / REQ-921 as claims about this
+    // file. Only "does the tag OPEN the comment?" rejects it.
+    //
+    // The second line is the mandatory positive control: a genuine tag in the
+    // very same file must survive. Without it the first two assertions would
+    // also pass for a guard that rejects every tag unconditionally.
+    makeRepo({
+      "src/prose.ts":
+        `// Issue #214: \`// ${IMPL} REQ-920, REQ-921\` used to register only the FIRST ID\n` +
+        `// ${IMPL} REQ-922\n` +
+        "export function real() {\n  return 1;\n}\n",
+    });
+    const frag = parseOne("src/prose.ts");
+    expect(implSourcesFor(frag, "REQ-920")).toEqual([]);
+    expect(implSourcesFor(frag, "REQ-921")).toEqual([]);
+    expect(implSourcesFor(frag, "REQ-922")).toEqual(["symbol:src/prose.ts#real"]);
+  });
+
+  it("accepts `///`, no-space and indented/tabbed tags; rejects a second `//` mid-comment", () => {
+    // Boundary sweep over what may precede the tag inside the comment span.
+    // oxc's `Line` comment span STARTS at the first `/`, so the only thing a
+    // genuine tag may have in front of it is the comment's own slashes plus
+    // in-line whitespace: `///` (triple slash) and `//@impl` (no space) are
+    // ordinary tags and must keep working, while a second `//` further along
+    // the same comment is prose quoting the syntax and must not.
+    makeRepo({
+      "src/forms.ts":
+        `/// ${IMPL} REQ-930\n` +
+        "export function tripleSlash() {\n  return 1;\n}\n\n" +
+        `//${IMPL} REQ-931\n` +
+        "export function noSpace() {\n  return 1;\n}\n\n" +
+        `  //\t${IMPL} REQ-932\n` +
+        "export function tabbed() {\n  return 1;\n}\n\n" +
+        `// see below // ${IMPL} REQ-933\n` +
+        "export function proseOnly() {\n  return 1;\n}\n",
+    });
+    const frag = parseOne("src/forms.ts");
+    expect(implSourcesFor(frag, "REQ-930")).toEqual(["symbol:src/forms.ts#tripleSlash"]);
+    expect(implSourcesFor(frag, "REQ-931")).toEqual(["symbol:src/forms.ts#noSpace"]);
+    expect(implSourcesFor(frag, "REQ-932")).toEqual(["symbol:src/forms.ts#tabbed"]);
+    expect(implSourcesFor(frag, "REQ-933")).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // (D1) a leading tag binds to EVERY sibling binding of one declaration
 // ---------------------------------------------------------------------------
 

--- a/tests/dogfood-self-pollution.test.ts
+++ b/tests/dogfood-self-pollution.test.ts
@@ -28,15 +28,51 @@
 // intentional pairs, say) rather than deleted — the point is that a leak has
 // to be argued for, not merely not-noticed.
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { resolve } from "node:path";
 import { buildGraph } from "../src/graph/builder.js";
 import { loadConfig } from "../src/config.js";
+import type { ArtifactGraph } from "../src/types.js";
 
 const REPO_ROOT = resolve(import.meta.dirname, "..");
 
+// This builds the graph of the REPOSITORY ITSELF, which means it would also
+// write the repository's real `node_modules/.cache/artgraph/parse-cache.json`.
+// That cache is keyed by file content, not by which binary produced the
+// fragment, so a cache warmed by the test run (`src/`, via vite-node) is then
+// READ by the CLI (`dist/`) — the same src-vs-dist replay hazard (INV-L4) that
+// made issue #387 bump SCHEMA_VERSION.
+//
+// Disable the cache for the duration of THIS FILE only: vitest reuses a worker
+// process across files, and several suites (tests/barrel-reexport.test.ts's
+// INV-L4 pair among them) require the cache to be live, so the flag is
+// restored in `afterAll` rather than left set.
+//
+// This is not the only self-scanning suite — tests/plan-coverage-dogfood.test.ts
+// builds the repo graph too and still warms that cache (measured). Closing
+// that one is out of scope here; it predates issue #387.
+let previousCacheEnv: string | undefined;
+
 describe("dogfood self-pollution (#387)", () => {
-  const { graph } = buildGraph(REPO_ROOT, loadConfig(REPO_ROOT));
+  let graph: ArtifactGraph;
+
+  // Built in `beforeAll`, not in the describe body: at collection time a throw
+  // from `loadConfig` / `buildGraph` is reported as a FILE-COLLECTION error
+  // rather than a test failure, which hides which invariant broke.
+  beforeAll(() => {
+    previousCacheEnv = process.env.ARTGRAPH_CACHE;
+    process.env.ARTGRAPH_CACHE = "0";
+    graph = buildGraph(REPO_ROOT, loadConfig(REPO_ROOT)).graph;
+    // Cheap insurance that the build below is a real one. The per-test
+    // preconditions are about specific edge kinds; this one catches the case
+    // where the scan pool collapsed entirely.
+    expect(graph.nodes.size).toBeGreaterThan(0);
+  });
+
+  afterAll(() => {
+    if (previousCacheEnv === undefined) delete process.env.ARTGRAPH_CACHE;
+    else process.env.ARTGRAPH_CACHE = previousCacheEnv;
+  });
 
   it("no code-tag `verifies` edge resolves to a real requirement node", () => {
     const codeTagVerifies = graph.edges.filter(

--- a/tests/dogfood-self-pollution.test.ts
+++ b/tests/dogfood-self-pollution.test.ts
@@ -1,0 +1,86 @@
+// issue #387 — self-pollution guard for THIS repository's own graph.
+//
+// artgraph scans itself. Its `[REQ-…]` / `@impl` scanners are plain-text
+// regexes over every file in the scan pool, so a requirement ID written
+// anywhere in a test file — an `it.each` data row, a fixture string, a
+// sentence in a comment — becomes a real `verifies` / `implements` edge.
+//
+// Most of those point at IDs that do not exist, and `check` already reports
+// them as orphans. The dangerous ones are the IDs that DO resolve: a fixture
+// that happens to name a real requirement silently marks it as verified.
+// `orphans` cannot see that (the edge is not dangling), no warning fires, and
+// `check --gate` stays green — the requirement's `impl-only` status just flips
+// to `verified` on the strength of a test that never tested it.
+//
+// The invariant below is what makes that observable. It is narrow on purpose:
+// it does NOT pin the orphan count (that changes on every PR and would be
+// noise), only the property that no code-tag `verifies` edge in this
+// repository resolves to a real requirement node.
+//
+// Why zero is the right number HERE: artgraph's own suite deliberately does
+// not tag test titles with `[REQ-…]`; its coverage story is execution
+// evidence (`artgraph/vitest` trace shards) plus `@impl` tags in `src/`. So
+// every resolving code-tag `verifies` edge in this repo is, by construction,
+// a fixture leak.
+//
+// If artgraph ever adopts genuine `[REQ-…]` test-title tagging for its own
+// requirements, this test SHOULD be updated deliberately (to an allowlist of
+// intentional pairs, say) rather than deleted — the point is that a leak has
+// to be argued for, not merely not-noticed.
+
+import { describe, it, expect } from "vitest";
+import { resolve } from "node:path";
+import { buildGraph } from "../src/graph/builder.js";
+import { loadConfig } from "../src/config.js";
+
+const REPO_ROOT = resolve(import.meta.dirname, "..");
+
+describe("dogfood self-pollution (#387)", () => {
+  const { graph } = buildGraph(REPO_ROOT, loadConfig(REPO_ROOT));
+
+  it("no code-tag `verifies` edge resolves to a real requirement node", () => {
+    const codeTagVerifies = graph.edges.filter(
+      (e) => e.kind === "verifies" && e.provenances.includes("code-tag"),
+    );
+
+    // PRECONDITION: a build that produced no code-tag verifies edges at all
+    // (a broken scan, an empty file pool) would make the assertion below
+    // vacuously true. artgraph's test files quote bracket notation in plenty
+    // of prose and fixtures, so this pool is never empty in practice.
+    expect(codeTagVerifies.length).toBeGreaterThan(0);
+
+    const resolving = codeTagVerifies
+      .filter((e) => graph.nodes.get(e.target)?.kind === "req")
+      .map((e) => `${e.source} --verifies--> ${e.target}`)
+      .sort();
+
+    if (resolving.length > 0) {
+      console.error(
+        "[dogfood] a test file's text names a REAL requirement id, which silently\n" +
+          "marks that requirement verified. Rewrite the occurrence (split the\n" +
+          'literal, e.g. "[" + "REQ-1" + "]") or pick an id that does not exist:\n  ' +
+          resolving.join("\n  "),
+      );
+    }
+    expect(resolving).toEqual([]);
+  });
+
+  it("every `impl-only` requirement stays impl-only — no fixture flips one to verified", () => {
+    // The consequence the edge-level invariant above exists to prevent, stated
+    // at the level `check` reports it. `verified` is reached only through a
+    // `verifies` edge, and this repo has no legitimate source of those, so the
+    // count must be exactly zero — while `impl-only` must NOT be, otherwise a
+    // scan that lost every `@impl` tag would also satisfy the first half.
+    const reqs = [...graph.nodes.values()].filter((n) => n.kind === "req");
+    const verifiedTargets = new Set(
+      graph.edges.filter((e) => e.kind === "verifies").map((e) => e.target),
+    );
+    const implementedTargets = new Set(
+      graph.edges.filter((e) => e.kind === "implements").map((e) => e.target),
+    );
+    const implemented = reqs.filter((n) => implementedTargets.has(n.id));
+
+    expect(implemented.length).toBeGreaterThan(0);
+    expect(implemented.filter((n) => verifiedTargets.has(n.id)).map((n) => n.id)).toEqual([]);
+  });
+});

--- a/tests/dogfood-self-pollution.test.ts
+++ b/tests/dogfood-self-pollution.test.ts
@@ -59,6 +59,11 @@ describe("dogfood self-pollution (#387)", () => {
   // Built in `beforeAll`, not in the describe body: at collection time a throw
   // from `loadConfig` / `buildGraph` is reported as a FILE-COLLECTION error
   // rather than a test failure, which hides which invariant broke.
+  // The explicit timeout is required, not defensive: `testTimeout: 30000` in
+  // vitest.config.ts does not cover hooks, which keep vitest's 10s default.
+  // Scanning this whole repository cold takes a few seconds locally and 13s+ on
+  // a loaded CI runner, so the default kills this hook there while every local
+  // run passes. Same trap vitest.e2e.config.ts documents for its own hooks.
   beforeAll(() => {
     previousCacheEnv = process.env.ARTGRAPH_CACHE;
     process.env.ARTGRAPH_CACHE = "0";
@@ -67,7 +72,7 @@ describe("dogfood self-pollution (#387)", () => {
     // preconditions are about specific edge kinds; this one catches the case
     // where the scan pool collapsed entirely.
     expect(graph.nodes.size).toBeGreaterThan(0);
-  });
+  }, 120_000);
 
   afterAll(() => {
     if (previousCacheEnv === undefined) delete process.env.ARTGRAPH_CACHE;

--- a/tests/mention-detector.test.ts
+++ b/tests/mention-detector.test.ts
@@ -11,6 +11,17 @@
 import { describe, it, expect } from "vitest";
 import { detectMentions } from "../src/plan-coverage/mention.js";
 
+// issue #387 — artgraph scans itself, and its test-tag regex reads a test
+// file's RAW TEXT, not just its titles. Writing REQ-3 in brackets anywhere in
+// this file therefore emitted a `verifies` edge to the REAL `REQ-3` node
+// (`specs/014-reinvent-impact-cli/contracts/mention-semantics.md`), polluting
+// `impact` output and `.trace.lock` with a test that never tested it. Assemble
+// the bracketed form at runtime instead: the strings `detectMentions` sees are
+// byte-identical, this file's own source no longer contains the tag. (This
+// comment deliberately spells out neither form contiguously, for the same
+// reason.)
+const BRACKETED_REQ3 = "[" + "REQ-3" + "]";
+
 describe("detectMentions — basic match (戦略 1)", () => {
   it("plain REQ-3 occurrence in tasks is mentioned", () => {
     const result = detectMentions(["REQ-3"], { tasks: "We touch REQ-3 here." });
@@ -43,7 +54,7 @@ describe("detectMentions — false-positive guards (戦略 2)", () => {
 
 describe("detectMentions — boundary variations (戦略 3)", () => {
   it.each([
-    ["[REQ-3] markdown bracket", "see [REQ-3] for details"],
+    [`${BRACKETED_REQ3} markdown bracket`, `see ${BRACKETED_REQ3} for details`],
     ["(REQ-3) parens", "we considered (REQ-3) in the audit"],
     ["<REQ-3> angle brackets", "tracked <REQ-3>"],
     ["`REQ-3` inline code", "the requirement `REQ-3` applies"],
@@ -118,7 +129,7 @@ describe("detectMentions — case sensitivity (戦略 6)", () => {
 
 describe("detectMentions — multiple matches collapse to one (戦略 7)", () => {
   it("a REQ that appears N times is mentioned exactly once", () => {
-    const text = "REQ-3 here, [REQ-3] there, and Considered: REQ-3 again.";
+    const text = `REQ-3 here, ${BRACKETED_REQ3} there, and Considered: REQ-3 again.`;
     const result = detectMentions(["REQ-3"], { tasks: text });
     expect(result.mentioned.has("REQ-3")).toBe(true);
     // The Set has size 1 even though there are 3 textual hits — proves

--- a/tests/parse-cache.test.ts
+++ b/tests/parse-cache.test.ts
@@ -275,7 +275,7 @@ describe("parse cache", () => {
     expect(snapshotGraph(graph)).toBe(buildWithoutCache(tmp));
   });
 
-  it("rejects a cache file with a stale schemaVersion (SCHEMA_VERSION was bumped 8→9 in issue #235)", () => {
+  it("rejects a cache file with a stale schemaVersion (SCHEMA_VERSION was bumped 9→10 in issue #387)", () => {
     // spec 021 (T016, issue #218) bumped 4→5 for class-method-grain symbols;
     // PR #242 review A bumped 5→6 when `TsFragment` gained the `warnings`
     // field (a v5 fragment has no `warnings` key at all, so a warm hit on it
@@ -291,7 +291,11 @@ describe("parse cache", () => {
     // never recorded; issue #235 bumped 8→9 because an `MdFragment` carries
     // its doc node's `contentHash` verbatim while the cache key is the file's
     // raw bytes — an untouched file HITS, so a pre-#235 fragment would keep
-    // replaying the old whole-file hash (checkbox state included) forever.
+    // replaying the old whole-file hash (checkbox state included) forever;
+    // issue #387 bumped 9→10 because an `@impl` quoted mid-comment stopped
+    // being a tag, so a pre-fix TsFragment carries `implements` edges the
+    // fixed parser no longer emits (measured on this repo: 118 warm orphans
+    // vs 110 cold, from the identical tree).
     // Populate the cache normally, then hand-edit its schemaVersion down to
     // the previous value. `readParseCache` must reject it and force a cold
     // path — otherwise a warm build could serve a fragment that predates the
@@ -300,17 +304,17 @@ describe("parse cache", () => {
     buildGraph(tmp, config); // populate cache
     const rawPath = join(tmp, CACHE_REL);
     const cache = JSON.parse(readFileSync(rawPath, "utf-8"));
-    expect(cache.schemaVersion).toBe(9);
-    cache.schemaVersion = 8;
+    expect(cache.schemaVersion).toBe(10);
+    cache.schemaVersion = 9;
     writeFileSync(rawPath, JSON.stringify(cache));
 
     // The next build sees a schema-mismatched cache and must fall back to
     // a cold parse. Behaviorally identical to a cache-disabled build.
     const { graph } = buildGraph(tmp, config);
     expect(snapshotGraph(graph)).toBe(buildWithoutCache(tmp));
-    // The rewritten cache carries the current schemaVersion (=9).
+    // The rewritten cache carries the current schemaVersion (=10).
     const rewritten = JSON.parse(readFileSync(rawPath, "utf-8"));
-    expect(rewritten.schemaVersion).toBe(9);
+    expect(rewritten.schemaVersion).toBe(10);
   });
 
   // PR #242 review A — the headline fix: the class-member collision warning

--- a/tests/parser-oxc-canary.test.ts
+++ b/tests/parser-oxc-canary.test.ts
@@ -80,6 +80,49 @@ describe("oxc-parser canary (issue #246): fatal syntax errors yield an EMPTY pro
 });
 
 // ---------------------------------------------------------------------------
+// #387 — the comment-span shape extractImplTags's "does the tag OPEN this
+// comment?" guard is built on. Direct parseSync probes, no artgraph code
+// involved: the guard slices `content` from `comment.start` up to the `@` of
+// the tag and demands that only the comment's own slashes plus in-line
+// whitespace sit in between, so it is only correct as long as oxc keeps
+// reporting Line-comment spans that INCLUDE the leading `//`. If oxc ever
+// starts excluding the slashes (start pointing at the comment TEXT), this
+// canary goes red — which is the signal to re-derive that guard rather than
+// letting every genuine tag silently stop registering.
+// ---------------------------------------------------------------------------
+
+describe("oxc-parser canary (issue #387): Line comment spans include the leading `//`", () => {
+  // Written split so this file's own source never contains a contiguous
+  // `// @impl` inside one of its OWN comments — see the `fixtureTestTag`
+  // note further down for the same reasoning applied to bracket tags.
+  const IMPL = "@" + "impl";
+
+  it.each<[name: string, source: string, expectedPrefix: string]>([
+    ["a tag that opens the comment", `// ${IMPL} REQ-001\n`, "// "],
+    ["an indented tag (indent is OUTSIDE the span)", `  // ${IMPL} REQ-002\n`, "// "],
+    ["a triple-slash tag", `/// ${IMPL} REQ-003\n`, "/// "],
+    ["a no-space tag", `//${IMPL} REQ-004\n`, "//"],
+    [
+      "a backtick-quoted tag in prose",
+      `// Issue #214: \`// ${IMPL} REQ-005\` used to drop IDs\n`,
+      "// Issue #214: `// ",
+    ],
+  ])("%s", (_name, source, expectedPrefix) => {
+    const result = oxcParseSync("comment-canary.ts", source);
+    expect(result.comments).toHaveLength(1);
+    const c = result.comments[0];
+    expect(c.type).toBe("Line");
+    // The span starts at the first `/` of the comment (NOT at its text) and
+    // ends before the newline.
+    expect(source.slice(c.start, c.start + 2)).toBe("//");
+    expect(source.slice(c.start, c.end)).toBe(source.trimStart().replace(/\n$/, ""));
+    // What the guard actually inspects: comment start → the tag's `@`.
+    const tagIndex = source.indexOf(IMPL);
+    expect(source.slice(c.start, tagIndex)).toBe(expectedPrefix);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // maxBracketNestingDepth — pure-function accuracy, including the documented
 // over-approximation (string-literal brackets are counted too).
 // ---------------------------------------------------------------------------
@@ -332,7 +375,7 @@ describe("integration: createTSParser survives a pathological file in the scan s
 // Pin: a pathological file's OWN text-scanned tags (PR #261 review).
 // extractImplTags is a plain-text regex scan over `content`, entirely
 // independent of the AST — it runs unconditionally regardless of whether
-// safeParseSync actually parsed the file. These three cases pin exactly what
+// safeParseSync actually parsed the file. These four cases pin exactly what
 // that means for a depth-guard-skipped file ITSELF (not an importER of one,
 // which the block above already covers):
 //
@@ -344,7 +387,7 @@ describe("integration: createTSParser survives a pathological file in the scan s
 //   3. A FAKE `// @impl` tag sitting inside a STRING LITERAL (not a real
 //      comment) ALSO produces an edge when the file is depth-guard-skipped —
 //      a documented fail-open. The D6 "is this really a `//` comment" guard
-//      (`matchInLineComment`) needs `parsed.comments` from a successful
+//      (`matchOpensLineComment`) needs `parsed.comments` from a successful
 //      parse to reject a string-literal false match; a depth-guard-skipped
 //      file has no `comments` at all (`parsed` is undefined), so
 //      extractImplTags falls back to its pre-D6 regex-only behavior (see the
@@ -352,6 +395,13 @@ describe("integration: createTSParser survives a pathological file in the scan s
 //      file would correctly reject this same fake tag. Pinned here as
 //      documented CURRENT behavior, not a guarantee — if this is ever
 //      tightened, this test should fail and force a deliberate update.
+//   4. Same fail-open for issue #387's stricter "does the tag OPEN the
+//      comment?" half of that guard: a tag quoted INSIDE a line comment of a
+//      depth-guard-skipped file still produces an edge. This is the isolating
+//      input for the guard's `comments !== undefined` conjunct — it is the
+//      only case whose verdict is decided by that conjunct alone, so it pins
+//      that #387 tightened the ordinarily-parsed path WITHOUT narrowing the
+//      pathological path's documented fail-open.
 // ---------------------------------------------------------------------------
 
 describe("pin: a pathological file's own @impl / test-title tags (PR #261 review)", () => {
@@ -400,6 +450,20 @@ describe("pin: a pathological file's own @impl / test-title tags (PR #261 review
         "",
       ].join("\n"),
     );
+    // Same split convention as `fixtureTestTag` above, for the same reason:
+    // this fixture's tag sits in a real LINE comment, so writing it
+    // contiguously in this file's own comments would register a genuine code
+    // tag on this test file under issue #387's tightened guard.
+    const quotedTag = "@" + "impl CANARY-005";
+    write(
+      root,
+      "src/pathological-quoted-tag.ts",
+      [
+        `// docs: \`// ${quotedTag}\` is prose about the syntax, not a claim`,
+        `export const alsoPathological = ${"(".repeat(2000)}1${")".repeat(2000)};`,
+        "",
+      ].join("\n"),
+    );
   });
 
   afterAll(() => {
@@ -443,6 +507,25 @@ describe("pin: a pathological file's own @impl / test-title tags (PR #261 review
           e.kind === "implements" &&
           e.source === "file:src/pathological-fake-tag.ts" &&
           e.target === "CANARY-004",
+      ),
+    ).toBe(true);
+  });
+
+  it("documented current fail-open (#387): a tag QUOTED inside a line comment still produces an edge for a depth-guard-skipped file", () => {
+    const result = createTSParser(root, ["src/**/*.ts"], "symbol").parse();
+    // Isolating input for the guard's `comments !== undefined` conjunct: an
+    // ordinarily-parsed file rejects this exact shape (see
+    // tests/barrel-reexport.test.ts's #387 block), and the ONLY reason it
+    // survives here is that the depth guard left `parsed` undefined. The
+    // positive control in the same fixture set — CANARY-002's genuine
+    // comment-leading tag, asserted above — keeps this from passing for a
+    // build that simply stopped filtering anything at all.
+    expect(
+      result.edges.some(
+        (e) =>
+          e.kind === "implements" &&
+          e.source === "file:src/pathological-quoted-tag.ts" &&
+          e.target === "CANARY-005",
       ),
     ).toBe(true);
   });

--- a/tests/rename-cli.test.ts
+++ b/tests/rename-cli.test.ts
@@ -238,7 +238,11 @@ describe("CLI: rename --split/--into", () => {
     expect(spec).toContain("REQ-101");
     expect(spec).toContain("REQ-102");
 
-    // @impl REQ-001 should NOT be rewritten (manual assignment needed).
+    // The code-side tag in src/feature.ts must NOT be rewritten (splitting one
+    // ID into two needs a manual re-assignment decision), so it still names the
+    // old ID. Phrased without the tag notation on purpose: this comment opens a
+    // line comment, so writing the notation here would register a real code tag
+    // on this test file in artgraph's own self-scan (issue #387).
     const src = readFileSync(resolve(tmp, "src/feature.ts"), "utf-8");
     expect(src).toContain("@impl REQ-001");
     expect(stdout + stderr).toMatch(/manual.*assignment|WARNING/i);

--- a/tests/typescript-oxc-regression.test.ts
+++ b/tests/typescript-oxc-regression.test.ts
@@ -809,6 +809,19 @@ describe("oxc regression: BOM / export-from / syntax errors (R9–R11)", () => {
       "src/broken.test.ts",
       'import { t } from "./target.js";\ndescribe("[BRK-001] broken", () => {\nconst y = ;\n',
     );
+    // issue #387 — the OTHER "the AST is unusable" state. A syntax error
+    // empties `program.body` but oxc still hands back `comments`, so unlike a
+    // depth-guard skip (see tests/parser-oxc-canary.test.ts) the tag guard
+    // DOES run here and must reject a quoted tag while keeping the genuine
+    // one. Split-written for the same dogfood reason as elsewhere.
+    const implTag = "@" + "impl";
+    write(
+      root,
+      "src/broken-prose.ts",
+      `// docs: \`// ${implTag} BRK-902\` is prose about the syntax\n` +
+        `// ${implTag} BRK-901\n` +
+        'import { t } from "./target.js";\nexport function ok() {}\nconst x = ;\n',
+    );
   });
 
   afterAll(() => {
@@ -880,6 +893,17 @@ describe("oxc regression: BOM / export-from / syntax errors (R9–R11)", () => {
         provenances: ["code-tag"],
       },
     ]);
+  });
+
+  it("still applies the opens-the-comment tag guard to a file with a syntax error (#387)", () => {
+    // `program.body` is empty here (issue #246), but `comments` is not — so
+    // the quoted BRK-902 must be rejected while the genuine BRK-901 survives.
+    // Both halves matter: dropping only the first assertion would pass for a
+    // build with no guard, dropping only the second would pass for a build
+    // that fails CLOSED on any file it could not fully parse.
+    const parsed = parseOne("src/broken-prose.ts", "file");
+    const targets = parsed.edges.filter((e) => e.kind === "implements").map((e) => e.target);
+    expect(targets).toEqual(["BRK-901"]);
   });
 
   it("emits NO symbol nodes for a broken file in symbol mode (known limit, R11)", () => {

--- a/tests/typescript-oxc-regression.test.ts
+++ b/tests/typescript-oxc-regression.test.ts
@@ -809,11 +809,18 @@ describe("oxc regression: BOM / export-from / syntax errors (R9–R11)", () => {
       "src/broken.test.ts",
       'import { t } from "./target.js";\ndescribe("[BRK-001] broken", () => {\nconst y = ;\n',
     );
-    // issue #387 — the OTHER "the AST is unusable" state. A syntax error
-    // empties `program.body` but oxc still hands back `comments`, so unlike a
-    // depth-guard skip (see tests/parser-oxc-canary.test.ts) the tag guard
-    // DOES run here and must reject a quoted tag while keeping the genuine
-    // one. Split-written for the same dogfood reason as elsewhere.
+    // issue #387 — the OTHER "the AST is unusable" state. For THIS fixture's
+    // error (`const x = ;`, a bad expression discovered after every comment
+    // has already been lexed) oxc empties `program.body` yet still hands back
+    // `comments`, so unlike a depth-guard skip (see
+    // tests/parser-oxc-canary.test.ts) the tag guard DOES run here and must
+    // reject a quoted tag while keeping the genuine one.
+    //
+    // Not a general property of syntax errors: an error that breaks LEXING
+    // instead — an unterminated block comment / string / template literal —
+    // makes oxc return `comments: []`, and the guard then rejects every tag in
+    // that file (docs/configuration.md, "Code tags — where an `@impl`
+    // counts"). Split-written for the same dogfood reason as elsewhere.
     const implTag = "@" + "impl";
     write(
       root,


### PR DESCRIPTION
## Summary

Refs #387 (partial — see [Scope](#scope) for what is deliberately left).

artgraph scans its own `tests/`, so prose in a test file that *quotes* tag syntax became a claim about that file:

```ts
// Issue #214: `// @impl REQ-001, REQ-002` used to register only the FIRST ID
```

Two `implements` edges to requirements this file never implements. 128 such phantom edges existed across 36 files.

The old guard asked **"is the match inside a line comment?"** — which is true for prose quoting the syntax. This asks **"does the tag OPEN the comment?"**: only the comment's own slashes and in-line whitespace may precede it.

| shape | counts as a tag |
|---|---|
| `// @impl REQ-1` | yes |
| `/// @impl REQ-1`, `//@impl REQ-1` | yes |
| `//<U+00A0>@impl REQ-1`, `//<U+3000>@impl REQ-1` | yes — `implRe` accepts any in-line whitespace |
| `export const x = 1; // @impl REQ-1` | yes — it opens its own comment |
| ``// Issue #214: `// @impl REQ-1` used to …`` | **no** (this PR's change) |
| `/* @impl REQ-1 */`, `const s = "// @impl REQ-1"` | no (unchanged) |

Measured on this repository: **63 matches passed the old guard — 53 open their comment, 10 are quoted mid-comment, and all 10 are test-file prose.** In edges: **62 = 52 owned by `src/` + 2 real tags in test files + 8 from quotes**. The parser change alone removes those **8**; `src/`-owned edges are **52 before and after**.

### Why the comment side and not the test-title side

The impact study evaluated narrowing `testReqRe` to AST test-title spans — nominally the root-cause fix, and by far the biggest number (128 → 26). It is not in this PR because it **fails silent**.

A tag that stops registering on the comment side leaves its requirement with no implementation, so it surfaces in `uncovered`. On the test-title side, a lost `[REQ]` tag downgrades a requirement from `verified` to `impl-only`, and **no `newIssues` field reports that**: `uncovered` covers requirements with zero implements edges, and `testFailures` requires `testFiles.length > 0` — which the narrowing empties. Structurally invisible to every gate.

Worse, the narrowing disagrees with artgraph's *own* runtime tagger. Running vitest and feeding its output to `resolveReqTags` showed **4 of 8 tag shapes** where the runtime recognizes the tag and a static title-span predicate does not: `it.each` data rows, variable titles, custom wrappers, and aliased imports. Filed as #424 with that measurement attached.

### Scope

- **In:** the comment-side guard, plus this repo's own scan scope and two hand-fixed test files.
- **Out:** the test-title narrowing (#424), a reserved fixture-ID prefix, a pre-commit guard against new contamination (#425), the parser/rewriter divergences the review sweep turned up (#426), a pre-existing cache-writing test (#427), and the reporting-side gap in #415 — the impact study measured that `code-tag` dangling edges are *already* 100% covered by `check.orphans`, so widening the `orphan-edge` warning would double-report them, while `task-tag` is invisible for a different reason (a deliberate skip in `findOrphans` for Kiro numeric IDs). Two separate guards, not one.

### Scan scope: `tests/fixtures/**` and `examples/**`

Their `describe("[VER-002] …")` titles are the *documented* way to write a tag. The bug is that a parent scan ingests fixture projects at all — that is scope, not grammar, so it is fixed in `.artgraph.json` rather than in the parser. Adding `!**/node_modules/**` at the same time clears the standing `config-pool-protection-asymmetry` warning.

Side effect worth naming: 11 files leave the graph (`test` nodes 141 → 131), and per `docs/configuration.md` excluded files also leave `artgraph rename`'s rewrite scope. Desirable here — fixture projects should not be rewritten by the parent repo's rename — but note the negation is on `testPatterns` only. That is sufficient while `include` is `src/**`, and would need mirroring if `include` ever widens.

### Two files fixed by hand

`tests/mention-detector.test.ts` carried `[REQ-3]` in `it.each` data — and **`REQ-3` is a real requirement here** (`specs/014-reinvent-impact-cli/contracts/mention-semantics.md`). #387 states that no phantom target collides with a real id; that was **false at HEAD**. The edge was inflating `impact src/parsers/typescript.ts` and had been written into the lock. `tests/rename-cli.test.ts` opened a comment with a tag it only meant to talk about. Both now use the split-literal convention.

### parse-cache SCHEMA_VERSION 9 → 10

A pre-fix fragment has the phantom edges baked in and the cache key is the file's own content hash, so an unedited file **HITS**. Measured: a cache warmed by the old build and then read by the new one replays all 8 stale edges (**118 orphans**) where a cold rebuild of the identical tree yields **110**. Same rationale as v7/v8/v9.

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

- [x] Existing tests pass (`pnpm -r test`)
- [x] Added tests where needed
- [x] Ran `pnpm -r knip` and `pnpm -r build`

**2681 unit + 122 e2e + 8 perf passed.** `lint` / `typecheck` / `format:check` / `knip` clean.

Fixtures were written first and run against unmodified `src/`: **4 failed** (the discriminators), **112 passed** (the positive controls — notably `///`, `//@impl`, and indented/tabbed forms already passed, proving the predicate does not over-reject).

**Conjunct ledger.** Each conjunct was removed from a separate compiled build and the isolating input run through the real parser:

| conjunct dropped | isolating input | flips? |
|---|---|---|
| `comments !== undefined` | depth-guard-skipped file with a quoted tag | **yes** — proves the pathological fail-open is not narrowed |
| `c.type === "Line"` | `/* @impl X */` | no — genuinely redundant today |
| span containment | a genuine tag in a *later* comment | **yes** — see below |
| prefix regex | ``// Issue #214: `// @impl X` used to …`` | **yes** — the HEAD→fix behavior delta lives here |

The containment row is a review correction. The first version of this PR called both middle conjuncts redundant; containment is in fact load-bearing in the **false-negative** direction, because the loop returns on the first comment that passes the filter — without it, every tag is judged against the file's *first* line comment and genuine tags in later comments are all rejected.

**Independent recount of the headline numbers** (`ARTGRAPH_CACHE=0`):

| | HEAD | this PR |
|---|---:|---:|
| orphans | 128 | **110** |
| `coverage[].status` | `{untagged: 444, impl-only: 48}` | **unchanged** |
| warnings | 26 | **23** |
| `code-tag` implements from `src/` | 52 | **52** |
| `code-tag` verifies resolving to a real node | 1 | **0** |

Of the three warnings, **two are parser-derived** (`ambiguous-id` for `ns-a/FR-001` and bare `FR-001`, both from quoted prose in `tests/builder.test.ts`) and one is the config change.

A new dogfood test pins the last row. Pinning the orphan *count* would break on every PR and prove nothing; pinning "no `code-tag` verifies edge resolves to a real requirement" is what actually catches the dangerous case — a fixture id colliding with a real `impl-only` requirement flips it to `verified` with the orphan count unmoved and no warning anywhere. Verified by reverting the split literal in `tests/mention-detector.test.ts` and watching it fail.

## Breaking change

- [ ] Yes (described below)
- [x] No

A project writing a tag part-way through a comment — `// see below // @impl REQ-001` — loses it. The requirement then appears in `uncovered`.

Note the qualification in the Upgrade note: bare `check --gate` does redden, but **both wirings `artgraph init` produces are `--diff` based** (the Stop hook and the CI recipe), and those suppress pre-existing debt, so they stay green. The opt-in Spec Kit `before_implement` gate uses the bare form and does redden. Hence the note asks for one bare `artgraph check` after upgrading.

## Notes

### What review changed

The second commit is review fallout. The substantive one is a **regression this PR introduced and nothing caught**: the new guard spelled in-line whitespace `[ \t]` while `implRe` spells it `[^\S\n]`, so a tag separated from its slashes by a non-breaking space, ideographic space, form feed, vertical tab or carriage return **genuinely opens its comment and was being dropped**. Widening the class left the entire suite green, so nothing pinned the narrow one. Both now build from a shared `INLINE_WS` constant — the same discovery-and-rewriting-parity idiom `src/grammar/tokens.ts` already uses for the ID token — with U+00A0 and U+3000 pinned by a test that carries a control.

The reviewed alternative (taking the prefix from `match.index + 2`) accepts exactly the same inputs — verified across 327 matches, zero disagreements — but hides the invariant that an `implRe` match always begins at `//` behind a literal `2`.

Three claims were also corrected. The upgrade note offered `// TODO: @impl REQ-001` as something that stops registering; `implRe` allows only whitespace between `//` and `@impl`, so **that never registered in the first place**. The note called the change fail-loud without saying which gates. And "one exception, by design" undercounted — the parse-failure fail-open has two paths, and there is an undocumented **fail-closed** one: an unterminated comment, string or template leaves oxc succeeding with *no comment spans at all*, so every tag in that file is dropped. Behavior unchanged, now written down.

Finally, the new dogfood test was building the repository graph during collection and writing the real parse cache — opening in the `src` build the same warm/cold divergence the `SCHEMA_VERSION` bump closes for `dist`. It now runs in `beforeAll` with the cache disabled for that file only. A pre-existing test does the same thing and is filed as #427.

### Phantom ids act as BFS hubs

`impact src/parsers/typescript.ts` reported 7 docs and 11 tasks at HEAD; it now reports 4 and 0. The BFS adds unresolved targets to `visited`, so the phantom `REQ-001` was reachable from `tests/typescript.test.ts` and then reachable *backwards* along `verifies` into `- [x] T002 … \`[REQ-001]\` …` lines in two unrelated specs' `tasks.md`. Confirmed by adding one `// @impl REQ-001` back to the fixed tree and watching tasks return to 11.

This matters beyond the 18 edges removed here: the remaining 110 orphans still hub the same way, which is a second argument for closing the test-title side (#424).

### The oracle earned its place immediately

The implementation agent's own explanatory comment self-contaminated — it wrote `` `[REQ-3]` `` verbatim while documenting why that literal had to be split, and the new dogfood test caught it. Recorded because "the note explaining the fixture becomes a fixture" is a real recursion.