### PR TITLE
fix(init): seed the detected SDD tool's spec directory into specDirs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -798,12 +798,25 @@ artgraph doctor --agents=claude,codex      # restrict scope
 artgraph doctor --format json              # machine-readable
 ```
 
-`doctor` also runs one config-only diagnostic, scoped to projects where at
-least one Tier 1 agent distribution is already detected (same gate as the
-`agents`-field advisory findings): `config-pool-protection-asymmetry`
-(issue #356, judgment updated by PR #359) — advisory (severity `pass`, never
-affects the exit code) — fires when `.artgraph.json`'s `include` and
-`testPatterns` disagree on whether they effectively exclude node_modules at
+`doctor` also runs two config-only diagnostics, both scoped to projects where
+at least one Tier 1 agent distribution is already detected (same gate as the
+`agents`-field advisory findings), and both advisory (severity `pass`, never
+affects the exit code).
+
+`config-specdir-missing-sdd-tool` (issue #422) fires when a detected SDD
+tool's spec directory exists on disk — `.kiro/specs/` for Kiro,
+`.specify/specs/` for Spec Kit — but no `specDirs` entry covers it, which
+means `scan` / `check` never see any of that tool's requirements. `init`
+seeds the entry for new projects; `init --force` merges an existing config
+instead of re-deriving `specDirs`, so a project initialized before that fix
+needs the entry added by hand. An ancestor entry counts as covering
+(`specDirs: [".kiro"]` covers `.kiro/specs`), and the probe is for the specs
+directory itself, so a `.kiro/` holding only artgraph's own `skills/` and
+`hooks/` never triggers it.
+
+`config-pool-protection-asymmetry` (issue #356, judgment updated by PR #359)
+fires when `.artgraph.json`'s `include` and `testPatterns`
+disagree on whether they effectively exclude node_modules at
 every nesting depth (checked via real glob matching against representative
 synthetic paths, not a string heuristic), or when a pool's negative pattern
 mentions node_modules but doesn't actually cover every depth (a "broken

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -809,10 +809,15 @@ tool's spec directory exists on disk — `.kiro/specs/` for Kiro,
 means `scan` / `check` never see any of that tool's requirements. `init`
 seeds the entry for new projects; `init --force` merges an existing config
 instead of re-deriving `specDirs`, so a project initialized before that fix
-needs the entry added by hand. An ancestor entry counts as covering
-(`specDirs: [".kiro"]` covers `.kiro/specs`), and the probe is for the specs
-directory itself, so a `.kiro/` holding only artgraph's own `skills/` and
-`hooks/` never triggers it.
+needs the entry added by hand. Adding it makes those requirements visible for
+the first time, and they arrive uncovered — see the behavior-change note in
+`docs/configuration.md` for which gates that reaches.
+
+An ancestor entry counts as covering (`specDirs: [".kiro"]` covers
+`.kiro/specs`). The probe is for the specs directory itself and requires it to
+be a directory, so neither a `.kiro/` holding only artgraph's own `skills/` and
+`hooks/` nor a regular file named `.kiro/specs` ever triggers it — the advisory
+never names a path that would break `scan`.
 
 `config-pool-protection-asymmetry` (issue #356, judgment updated by PR #359)
 fires when `.artgraph.json`'s `include` and `testPatterns`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,7 +201,7 @@ candidates are siblings of one another — never parent/child — so none of the
 is dropped by the redundant-descendant filtering `loadConfig` applies to
 `specDirs` (issue #234).
 
-Two limits worth knowing:
+Three limits worth knowing:
 
 - The probe is for the tool's **specs directory** (`.kiro/specs`), not for its
   marker directory (`.kiro`). `init --agents=kiro` creates `.kiro/skills/` and
@@ -215,6 +215,58 @@ Two limits worth knowing:
   `specDirs`; add the entry by hand. `artgraph doctor` reports the gap as a
   `config-specdir-missing-sdd-tool` NOTICE (advisory — it does not change the
   exit code).
+- The probe answers "is this a directory?", not "does this path exist?".
+  A regular file named `.kiro/specs` is skipped: a `specDirs` entry pointing at
+  a file makes markdown enumeration fail with `ENOTDIR`, which would abort
+  `init` before it wrote `.artgraph.json` at all. An empty `.kiro/specs`
+  directory is seeded normally.
+
+Adding the entry by hand to an existing project makes requirements visible that
+were not in the graph before, and they arrive `uncovered` — the same shape as
+the grammar widening below, with the same consequences per gate. See
+[Behavior change on upgrade](#kiro-headings--the-title-after-the-number-is-optional)
+for which of them that reaches.
+
+### Kiro numbers requirements per spec, so a second spec qualifies every ID
+
+This is a property of Kiro's own output, not of any artgraph version. Kiro
+starts each spec's `requirements.md` at `Requirement 1`, so the moment a
+project has two of them the same ID is defined twice:
+
+```text
+.kiro/specs/auth/requirements.md      ### Requirement 1
+.kiro/specs/billing/requirements.md   ### Requirement 1
+```
+
+artgraph resolves that collision by qualifying each ID with its spec
+directory — `auth/Requirement-1` and `billing/Requirement-1` — the same
+namespacing it applies to any ID defined in more than one spec (see
+[architecture.md](./architecture.md)). An unqualified `// @impl Requirement-1`
+then matches both, so it is **ambiguous and the edge is dropped**, with a
+`WARNING: ambiguous ID "Requirement-1" (candidates: auth, billing)` naming the
+candidates. The requirements themselves are reported `uncovered`.
+
+The fix is on the annotation side: qualify each tag with the spec directory
+its requirement lives in.
+
+```ts
+// @impl auth/Requirement-1
+```
+
+Do this with an editor, not with `rename`: by the time the second spec exists
+there is no `Requirement-1` node left to rename, so
+`rename --from Requirement-1 --to auth/Requirement-1` exits 1 with `ID
+"Requirement-1" does not exist in the project`.
+
+`artgraph reconcile` does not resolve it either — reconcile updates the lock to
+match the graph, and an ambiguous tag leaves the requirement genuinely
+untagged, so a plain `check --gate` stays at exit `2` until the tags carry the
+prefix. Once every tag is qualified, `check` reports each requirement covered
+and the gate goes back to exit `0` (measured on a two-spec fixture).
+
+This is not a rare shape: of 26 surveyed repositories with `.kiro/specs/`
+committed, 9 had two or more specs, and every one of those started every spec
+at `Requirement 1`.
 
 ## `reqPatterns` — requirement ID grammar
 
@@ -264,8 +316,21 @@ on into prose defines nothing:
 ### Requirement 1 is important
 ```
 
-`artgraph rename Requirement-1 Requirement-9` rewrites both spellings of an
-ATX (`#`-prefixed) heading.
+`artgraph rename Requirement-1 Requirement-9` rewrites both spellings when the
+heading is an unadorned ATX line — one to six `#`s, no indentation, and the
+requirement text starting right after them. A trailing ATX closing sequence
+(`### Requirement 1 ###`) is fine and is preserved. `rename`, `rename --split`
+and `rename --merge` all read the raw line through the same normalization, so
+what one of them rewrites the others delete and scaffold.
+
+Recognition is looser than that, because it reads the parsed heading rather
+than the line: an indented, blockquoted or list-nested `###`, a setext heading
+(`Requirement 1` over `---`), an emphasis-wrapped title (`### **Requirement
+1**`) and a title carrying an HTML entity or comment are all requirements to
+`scan` / `check`, but `rename` leaves them untouched and reports success. None
+of these shapes occurred in the 62-file, 551-heading corpus behind the
+percentages above; if you write one by hand, edit it and its `@impl` tags
+together.
 
 > **Behavior change on upgrade.** Only the `:` spelling used to be recognized.
 > Upgrading a repository whose `requirements.md` uses the bare form adds req
@@ -283,7 +348,10 @@ ATX (`#`-prefixed) heading.
 >   and the newly recognized reqs do not appear in `newIssues`. Both wirings
 >   `init` installs by default — the Stop hook (`check --gate --diff`) and the
 >   CI recipe (`check --diff --base origin/<base> --gate`) — are `--diff`
->   gates, so they stay exit `0` across this upgrade.
+>   gates, so this upgrade does not by itself turn them non-zero. A `--diff`
+>   gate that cannot establish a baseline at all still fails closed with exit
+>   `1` (not a git repository, or a shallow clone without the base ref) — that
+>   is unrelated to the grammar change and is unchanged by it.
 
 ## `ignoreIdPrefixes` — exclude specific ID prefixes from tracking
 
@@ -597,9 +665,12 @@ Three things about that snippet are easy to get wrong:
 
 - **You need `verifiesTagRe` too, not just `taskIdRe`.** Tag regexes are
   per-preset: a task discovered by your preset is scanned with *your* preset's
-  tags, so leaving `verifiesTagRe` out gives you task nodes with no
-  `_Requirements:` edges at all (measured: task nodes appear, zero `verifies`
-  edges).
+  tags, so leaving `verifiesTagRe` out gives the checkbox-less lines task nodes
+  with no `_Requirements:` edges of their own (measured on an all-checkbox-less
+  fixture: task nodes appear, zero `verifies` edges). In a file that mixes both
+  spellings the checkbox lines still get their edges from the built-in preset,
+  so the count is not zero — it is missing exactly the lines your preset
+  discovered.
 - **You cannot copy the built-in `kiro` values and delete the checkbox part.**
   Both built-in patterns spell the hierarchical number as `(\d+(?:\.\d+)*)`,
   and `loadConfig`'s nested-quantifier guard rejects that shape in a

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -188,6 +188,34 @@ Three intentional, backward-incompatible behavior changes come with this:
   collision may differ from a pre-upgrade scan, but it is now the same on
   every machine and every run.
 
+### What `artgraph init` seeds (issue #422)
+
+`init` writes `specDirs` from what it finds on disk: `specs/` and `docs/` when
+those directories exist, plus the spec directory of any detected SDD tool —
+`.kiro/specs` for Kiro, `.specify/specs` for Spec Kit. It falls back to
+`["specs", "docs"]` when none of the four exist.
+
+The SDD entry is **appended**, not substituted: a Kiro project that also keeps
+a `docs/` tree gets `["docs", ".kiro/specs"]`, and both are scanned. All four
+candidates are siblings of one another — never parent/child — so none of them
+is dropped by the redundant-descendant filtering `loadConfig` applies to
+`specDirs` (issue #234).
+
+Two limits worth knowing:
+
+- The probe is for the tool's **specs directory** (`.kiro/specs`), not for its
+  marker directory (`.kiro`). `init --agents=kiro` creates `.kiro/skills/` and
+  `.kiro/hooks/` itself, so `.kiro/` alone proves only that artgraph has run
+  before. Putting `.kiro` in `specDirs` would additionally pull artgraph's own
+  distributed `SKILL.md` files into the graph as `doc` nodes, so every artgraph
+  upgrade that edits a Skill would register as lock drift.
+- `init --force` over an existing `.artgraph.json` **merges** your config and
+  does not re-derive `specDirs` (that is what preserves hand-edited values).
+  A project that ran `init` before this version therefore keeps its old
+  `specDirs`; add the entry by hand. `artgraph doctor` reports the gap as a
+  `config-specdir-missing-sdd-tool` NOTICE (advisory — it does not change the
+  exit code).
+
 ## `reqPatterns` — requirement ID grammar
 
 By default artgraph recognizes `REQ-001`, `auth/FR-2`, and `Requirement-3`.
@@ -216,6 +244,46 @@ meaning, so `REQ-001`, `FR-001`, `AUTH-2`, and `US-12` all work with **zero
 configuration**. In particular, Spec Kit's spec-template generates `FR-NNN`
 (Functional Requirements) by default: keep them as-is; there is no need to
 rename them to the `REQ-` prefix used in this documentation's examples.
+
+### Kiro headings — the title after the number is optional
+
+A markdown heading whose text reads `Requirement <n>` defines the requirement
+`Requirement-<n>`. Both spellings Kiro emits are recognized, at any heading
+level:
+
+```md
+### Requirement 1: Federated authentication
+### Requirement 2
+```
+
+What ends the match is either a `:` after the number (spaces allowed in
+between) or the end of the heading text — nothing else. A heading that carries
+on into prose defines nothing:
+
+```md
+### Requirement 1 is important
+```
+
+`artgraph rename Requirement-1 Requirement-9` rewrites both spellings of an
+ATX (`#`-prefixed) heading.
+
+> **Behavior change on upgrade.** Only the `:` spelling used to be recognized.
+> Upgrading a repository whose `requirements.md` uses the bare form adds req
+> nodes that were not in the graph before, and those reqs start out
+> `uncovered`. Where that surfaces:
+>
+> - **`artgraph reconcile`, or a first `artgraph init`** — the new reqs enter
+>   the lock, and `artgraph check` lists the uncovered ones.
+> - **plain `artgraph check --gate`** (no `--diff`) — judges the whole graph
+>   against the lock, so newly recognized uncovered reqs can turn it into an
+>   exit `2`.
+> - **`--diff` gates** — not affected the same way. `check --diff` builds its
+>   baseline by scanning the base ref with the *current* binary and the
+>   *current* config, so the base side is re-read under the new grammar too
+>   and the newly recognized reqs do not appear in `newIssues`. Both wirings
+>   `init` installs by default — the Stop hook (`check --gate --diff`) and the
+>   CI recipe (`check --diff --base origin/<base> --gate`) — are `--diff`
+>   gates, so they stay exit `0` across this upgrade.
 
 ## `ignoreIdPrefixes` — exclude specific ID prefixes from tracking
 
@@ -470,7 +538,9 @@ Notes:
 - `doc → contains → task` edges are emitted under `docGraph.autoContains` (the
   same flag that drives `doc → req`).
 - Kiro's `tasks.md` requires the `[ ]`/`[x]` checkbox on each task line — bare
-  numbered lists like `- 1 release shipped` are not treated as tasks.
+  numbered lists like `- 1 release shipped` are not treated as tasks. See
+  [Kiro `tasks.md` without checkboxes](#kiro-tasksmd-without-checkboxes-issue-419)
+  for the override, and for what the override cannot reach.
 - For nested Kiro tasks (`- [x] 1.1 ...` indented under `- [x] 1. ...`), each
   level's `_Requirements:` lists attach to its own task only; parents do not
   inherit child requirements.
@@ -500,6 +570,58 @@ All three regex fields are validated the same way `reqPatterns` is
 (≤ 200 chars, nested-quantifier rejection, capture-group required, valid regex).
 Omit `implementsTagRe` or `verifiesTagRe` if your tool doesn't have that edge
 kind (Kiro omits `implementsTagRe`).
+
+### Kiro `tasks.md` without checkboxes (issue #419) <a id="kiro-tasksmd-without-checkboxes-issue-419"></a>
+
+Kiro sometimes emits a `tasks.md` whose task lines carry no `[ ]`/`[x]`
+checkbox. The built-in `kiro` preset requires one, so those lines produce no
+task nodes. Add a second preset alongside it — built-ins stay active, so
+checkbox-prefixed lines keep working through the built-in and the new preset
+picks up the bare ones:
+
+```jsonc
+// .artgraph.json
+{
+  "taskConventions": [
+    {
+      "name": "kiro-no-checkbox",
+      "fileStems": ["tasks"],
+      "taskIdRe": "^(\\d+|\\d+\\.\\d+|\\d+\\.\\d+\\.\\d+)\\.?[\\s\\u00A0]",
+      "verifiesTagRe": "(?<=Requirements:[\\s\\d.,]*)(\\d+\\.\\d+|\\d+)"
+    }
+  ]
+}
+```
+
+Three things about that snippet are easy to get wrong:
+
+- **You need `verifiesTagRe` too, not just `taskIdRe`.** Tag regexes are
+  per-preset: a task discovered by your preset is scanned with *your* preset's
+  tags, so leaving `verifiesTagRe` out gives you task nodes with no
+  `_Requirements:` edges at all (measured: task nodes appear, zero `verifies`
+  edges).
+- **You cannot copy the built-in `kiro` values and delete the checkbox part.**
+  Both built-in patterns spell the hierarchical number as `(\d+(?:\.\d+)*)`,
+  and `loadConfig`'s nested-quantifier guard rejects that shape in a
+  user-supplied preset — for `taskIdRe` *and* for `verifiesTagRe`. The
+  enumerated alternation above (`\d+|\d+\.\d+|\d+\.\d+\.\d+`, longest-first in
+  the `verifiesTagRe` case) passes the guard and covers up to three levels.
+- **Prefer the enumerated alternation over `[\d.]+`.** A character class also
+  passes validation but matches non-numbers: on a fixture holding
+  `- . lone dot`, `- 1.. double dot` and `- 1.2.3.4 deep numeric`, `[\d.]+`
+  created a task node for each of the three; the alternation above created
+  none of them. Neither form can tell `- 3 workers were provisioned` from a
+  real task — that false positive is exactly what the built-in preset's
+  checkbox requirement was buying you, and dropping the checkbox gives it up.
+
+**What no override can reach.** When the number is followed by `.` or `)` and a
+space, CommonMark consumes it as an *ordered-list marker* rather than as text,
+so by the time `taskIdRe` runs the ID is not in the string at all. Measured on
+one fixture: `- 3. Ordered-list dot form`, `- 4) Paren form` and a top-level
+`5. Ordered list` produced no task node under any of the patterns tried, while
+`- 1 Set up`, `- 1.1 Nested numeric` and the checkbox forms did. Only the
+checkbox spelling (`- [x] 3. Something`) survives the marker rule, because the
+`[x]` comes first.
 
 ### Upgrade note
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -326,9 +326,18 @@ what one of them rewrites the others delete and scaffold.
 Recognition is looser than that, because it reads the parsed heading rather
 than the line: an indented, blockquoted or list-nested `###`, a setext heading
 (`Requirement 1` over `---`), an emphasis-wrapped title (`### **Requirement
-1**`) and a title carrying an HTML entity or comment are all requirements to
-`scan` / `check`, but `rename` leaves them untouched and reports success. None
-of these shapes occurred in the 62-file, 551-heading corpus behind the
+1**`) and an HTML entity or comment inside the `Requirement <n>` part itself
+are all requirements to `scan` / `check`, but `rename` will not rewrite them.
+(An entity later in the *title* — `### Requirement 1: Caf&eacute; login` — is
+rewritten normally; only the ID part matters.)
+
+What `rename` does when it skips one depends on where else the ID appears. If
+the ID also has `@impl` tags in code, the run exits 0 having rewritten those
+and left the definition behind, which turns the requirement into an orphan. If
+the ID exists only in the spec, there is nothing left to rewrite and the run
+exits 1 (`… was not found in any of the N files matched by …`).
+
+None of these shapes occurred in the 62-file, 551-heading corpus behind the
 percentages above; if you write one by hand, edit it and its `@impl` tags
 together.
 
@@ -661,8 +670,18 @@ picks up the bare ones:
 }
 ```
 
-Three things about that snippet are easy to get wrong:
+Four things about that snippet are easy to get wrong:
 
+- **The `verifies` edges a Kiro `tasks.md` produces point at task IDs, not at
+  requirement IDs.** `_Requirements: 1.1, 1.2_` names entries in
+  `requirements.md`'s own numbering, and those numbers collide with the task
+  numbers in the same directory — so on a standard Kiro spec the edges come out
+  as self-loops (`1 -> 1`, `2 -> 2`) or point at nodes that do not exist. That
+  is the built-in preset's behavior too, not something this recipe introduces:
+  `examples/kiro-integration/` ships the same edges and its README calls them
+  planning metadata that is intentionally not reconciled. Seeding `.kiro/specs`
+  into `specDirs` is what makes them show up by default, so expect them in
+  `scan --format json` and do not read them as spec-to-code coverage.
 - **You need `verifiesTagRe` too, not just `taskIdRe`.** Tag regexes are
   per-preset: a task discovered by your preset is scanned with *your* preset's
   tags, so leaving `verifiesTagRe` out gives the checkbox-less lines task nodes

--- a/src/config.ts
+++ b/src/config.ts
@@ -420,6 +420,26 @@ function isAncestorOf(ancestor: string, descendant: string): boolean {
   return descendant.startsWith(ancestor + "/") || descendant.startsWith(ancestor + "\\");
 }
 
+/**
+ * issue #422 — true when `dir` (a repo-root-relative POSIX path) would be
+ * enumerated by one of `specDirs`: either an entry names it exactly, or an
+ * entry is one of its ancestors (`specDirs: [".kiro"]` covers `.kiro/specs`).
+ *
+ * Exported for `doctor`'s `config-specdir-missing-sdd-tool` advisory, which
+ * has to answer exactly this question about `.kiro/specs` / `.specify/specs`.
+ * It lives here so the answer is computed with the SAME normalization
+ * `validateSpecDirs` applies when it loads the field — a doctor that compared
+ * raw strings would advise adding `.kiro/specs` to a config that already has
+ * `"./.kiro/specs/"`.
+ */
+export function specDirsCover(specDirs: readonly string[], dir: string): boolean {
+  const target = normalizeSpecDir(dir);
+  return specDirs.some((entry) => {
+    const normalized = normalizeSpecDir(entry);
+    return normalized === target || isAncestorOf(normalized, target);
+  });
+}
+
 function validateSpecDirs(value: unknown): string[] | undefined {
   if (value === undefined) return undefined;
   if (!Array.isArray(value)) {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -118,10 +118,11 @@ export type DoctorFindingKind =
    * what preserves hand-edited values), so a project initialized before
    * that fix is only reachable through this advisory. Advisory only
    * (severity `pass`) — never flips the doctor exit code. Structural
-   * (Principle V): one `existsSync` plus a path-prefix comparison against
-   * `config.specDirs`. Gated on at least one Tier 1 agent being detected,
-   * the same gate `config-missing-agents-field` uses — see that gate's
-   * comment for why the empty-report short-circuit must stay intact.
+   * (Principle V): one `statSync` plus a path-prefix comparison against
+   * `config.specDirs`. Gated on at least one Tier 1 agent being detected —
+   * the same condition its two config-level siblings use, so all three
+   * NOTICEs cover the same set of projects. See the gate's own comment at the
+   * `runDoctor` call site for what that gate does and does not buy.
    */
   | "config-specdir-missing-sdd-tool";
 
@@ -407,10 +408,21 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
   }
 
   // issue #422 — SDD-tool spec directory that `specDirs` does not cover.
-  // Gated on `detectedDescriptors.length > 0` for the same reason
-  // `config-pool-protection-asymmetry` above is: firing it on a project with
-  // no Tier 1 distribution would bypass the empty-report short-circuit below
-  // and drag Step 4's AGENTS.md check (a real FAIL) in with it.
+  // Gated on `detectedDescriptors.length > 0` to keep this advisory's scope
+  // identical to its two config-level siblings (`config-missing-agents-field`,
+  // `config-pool-protection-asymmetry`), which are the findings it shares the
+  // NOTICE rendering with: all three speak about a project doctor already has
+  // Tier 1 distribution context for.
+  //
+  // The gate is NOT what protects the empty-report short-circuit below —
+  // measured by removing it: output and `failCount` come back byte-identical
+  // on a project with no Tier 1 distribution. That short-circuit reads
+  // `configFindings`, and `specDirFindings` is a separate array appended after
+  // it, so dropping the gate could not break it. What dropping the gate WOULD
+  // change is reach: `--agents=<csv>` naming an uninstalled agent gets past the
+  // short-circuit via `absentDescriptors`, and the advisory would then fire
+  // there too. Keeping the three siblings on one condition is the reason to
+  // hold the line, not a short-circuit that this finding cannot reach.
   //
   // `detectProject` is the same probe `init` uses to decide what to seed, so
   // the advisory can never name a directory `init` itself would not write —
@@ -429,7 +441,7 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
         path: ".artgraph.json",
         expected: `"specDirs" covering ${tool.specDir}`,
         actual: `specDirs = ${JSON.stringify(config.specDirs)}`,
-        message: `${tool.name} keeps its specs in ${tool.specDir}/, but no "specDirs" entry in .artgraph.json covers it — those requirements are invisible to \`artgraph scan\` / \`check\`. Add "${tool.specDir}" to "specDirs" (\`init\` seeds it for new projects; \`init --force\` preserves an existing specDirs, so this one needs the edit by hand). See issue #422.`,
+        message: `${tool.name} keeps its specs in ${tool.specDir}/, but no "specDirs" entry in .artgraph.json covers it — those requirements are invisible to \`artgraph scan\` / \`check\`. Add "${tool.specDir}" to "specDirs" (\`init\` seeds it for new projects; \`init --force\` preserves an existing specDirs, so this one needs the edit by hand). Those requirements arrive untagged, so a plain \`check --gate\` can go from 0 to 2 on the next run — see "Behavior change on upgrade" in docs/configuration.md for which gates that reaches. See issue #422.`,
       });
     }
   }

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -28,7 +28,13 @@ import {
 import { buildAgentsMdBody, inspectMarkerBlock } from "./agents/agent-context.js";
 import { detectPackageManager } from "./package-manager.js";
 import { readSkillSource, type SkillSource } from "./agents/source.js";
-import { loadConfig, missingNodeModulesProtection, formatPoolProtectionMessage } from "./config.js";
+import {
+  loadConfig,
+  missingNodeModulesProtection,
+  formatPoolProtectionMessage,
+  specDirsCover,
+} from "./config.js";
+import { detectProject } from "./init.js";
 
 /** Skip files larger than this when hashing / walking (C-adj-1). Prevents an
  * accidentally-planted multi-GB file inside a Skills dir from OOM-ing the
@@ -102,7 +108,22 @@ export type DoctorFindingKind =
    * distribution, no config findings → clean empty report) intact; see the
    * gate's own comment at the `runDoctor` call site for why.
    */
-  | "config-pool-protection-asymmetry";
+  | "config-pool-protection-asymmetry"
+  /**
+   * issue #422 — an SDD tool keeps its specs in a directory (`.kiro/specs`,
+   * `.specify/specs`) that exists on disk but that no `specDirs` entry
+   * covers, so every requirement in it is invisible to `scan` / `check`.
+   * `init` seeds the entry for new projects, but `init --force` deliberately
+   * MERGES an existing config rather than re-deriving `specDirs` (that is
+   * what preserves hand-edited values), so a project initialized before
+   * that fix is only reachable through this advisory. Advisory only
+   * (severity `pass`) — never flips the doctor exit code. Structural
+   * (Principle V): one `existsSync` plus a path-prefix comparison against
+   * `config.specDirs`. Gated on at least one Tier 1 agent being detected,
+   * the same gate `config-missing-agents-field` uses — see that gate's
+   * comment for why the empty-report short-circuit must stay intact.
+   */
+  | "config-specdir-missing-sdd-tool";
 
 export interface DoctorFinding {
   severity: DoctorFindingSeverity;
@@ -385,6 +406,34 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
     });
   }
 
+  // issue #422 — SDD-tool spec directory that `specDirs` does not cover.
+  // Gated on `detectedDescriptors.length > 0` for the same reason
+  // `config-pool-protection-asymmetry` above is: firing it on a project with
+  // no Tier 1 distribution would bypass the empty-report short-circuit below
+  // and drag Step 4's AGENTS.md check (a real FAIL) in with it.
+  //
+  // `detectProject` is the same probe `init` uses to decide what to seed, so
+  // the advisory can never name a directory `init` itself would not write —
+  // `specDir` is populated only when the tool's SPECS directory exists, which
+  // is why an `.kiro/` that only holds artgraph's own `skills/` + `hooks/`
+  // (created by `init --agents=kiro`) produces no finding here.
+  const specDirFindings: DoctorFinding[] = [];
+  if (detectedDescriptors.length > 0) {
+    for (const tool of detectProject(rootAbs).sddTools) {
+      if (!tool.specDir) continue;
+      if (specDirsCover(config.specDirs, tool.specDir)) continue;
+      specDirFindings.push({
+        severity: "pass",
+        agent: null,
+        kind: "config-specdir-missing-sdd-tool",
+        path: ".artgraph.json",
+        expected: `"specDirs" covering ${tool.specDir}`,
+        actual: `specDirs = ${JSON.stringify(config.specDirs)}`,
+        message: `${tool.name} keeps its specs in ${tool.specDir}/, but no "specDirs" entry in .artgraph.json covers it — those requirements are invisible to \`artgraph scan\` / \`check\`. Add "${tool.specDir}" to "specDirs" (\`init\` seeds it for new projects; \`init --force\` preserves an existing specDirs, so this one needs the edit by hand). See issue #422.`,
+      });
+    }
+  }
+
   if (
     detectedDescriptors.length === 0 &&
     absentDescriptors.length === 0 &&
@@ -432,6 +481,10 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
   // (gated on `detectedDescriptors.length > 0`, same as
   // `config-missing-agents-field`).
   findings.push(...poolProtectionFindings);
+
+  // issue #422 — config-specdir-missing-sdd-tool advisory, computed above
+  // (same gate).
+  findings.push(...specDirFindings);
 
   // Step 3 — per-agent Skills + extraneous-file diagnostics.
   for (const descriptor of detectedDescriptors) {
@@ -915,10 +968,13 @@ export function formatDoctorReportText(report: DoctorReport): string {
   // NOTICE line (mirrors the agents-md-body-stale NOTICE convention).
   // issue #356 — `config-pool-protection-asymmetry` joins the same NOTICE
   // treatment: same shape (agent: null, severity: "pass", config-only).
+  // issue #422 — so does `config-specdir-missing-sdd-tool`.
   const configLevelFindings = report.findings.filter(
     (f) =>
       f.agent === null &&
-      (f.kind === "config-missing-agents-field" || f.kind === "config-pool-protection-asymmetry"),
+      (f.kind === "config-missing-agents-field" ||
+        f.kind === "config-pool-protection-asymmetry" ||
+        f.kind === "config-specdir-missing-sdd-tool"),
   );
   for (const f of configLevelFindings) {
     lines.push(`NOTICE: ${f.message}`);

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -112,7 +112,10 @@ export type DoctorFindingKind =
   /**
    * issue #422 — an SDD tool keeps its specs in a directory (`.kiro/specs`,
    * `.specify/specs`) that exists on disk but that no `specDirs` entry
-   * covers, so every requirement in it is invisible to `scan` / `check`.
+   * covers, so any requirement under it that no entry reaches is invisible to
+   * `scan` / `check`. An entry naming a SUBdirectory of it counts as
+   * uncovered, and correctly so — that configuration scans one spec and
+   * silently drops its siblings.
    * `init` seeds the entry for new projects, but `init --force` deliberately
    * MERGES an existing config rather than re-deriving `specDirs` (that is
    * what preserves hand-edited values), so a project initialized before
@@ -441,7 +444,13 @@ export function runDoctor(opts: DoctorOptions): DoctorReport {
         path: ".artgraph.json",
         expected: `"specDirs" covering ${tool.specDir}`,
         actual: `specDirs = ${JSON.stringify(config.specDirs)}`,
-        message: `${tool.name} keeps its specs in ${tool.specDir}/, but no "specDirs" entry in .artgraph.json covers it — those requirements are invisible to \`artgraph scan\` / \`check\`. Add "${tool.specDir}" to "specDirs" (\`init\` seeds it for new projects; \`init --force\` preserves an existing specDirs, so this one needs the edit by hand). Those requirements arrive untagged, so a plain \`check --gate\` can go from 0 to 2 on the next run — see "Behavior change on upgrade" in docs/configuration.md for which gates that reaches. See issue #422.`,
+        // "not fully reachable", not "invisible": an entry naming a
+        // SUBdirectory (`.kiro/specs/auth`) leaves that one spec scanned and
+        // its siblings unscanned, and `specDirsCover` — exact match or
+        // ancestor — correctly reports the tool's directory as uncovered in
+        // that case too. Claiming the requirements are invisible would be
+        // false for the specs that are configured.
+        message: `${tool.name} keeps its specs in ${tool.specDir}/, but no "specDirs" entry in .artgraph.json covers that directory — any requirement under it that no entry reaches is invisible to \`artgraph scan\` / \`check\`. Add "${tool.specDir}" to "specDirs" (\`init\` seeds it for new projects; \`init --force\` preserves an existing specDirs, so this one needs the edit by hand). Requirements that appear this way arrive untagged, so a plain \`check --gate\` can go from 0 to 2 on the next run — see "Behavior change on upgrade" in docs/configuration.md for which gates that reaches. See issue #422.`,
       });
     }
   }

--- a/src/grammar/tokens.ts
+++ b/src/grammar/tokens.ts
@@ -40,9 +40,18 @@ export const NAMESPACED_ID_TOKEN = `(?:[\\w-]+/)?(?:${REQ_ID_TOKEN})`;
 // `- **FR-2**: ...`. Group 1 is the bare ID.
 export const LIST_ITEM_RE = /^(?:\*\*)?([A-Z][A-Za-z]*-\d+)(?:\*\*)?[:\s]/;
 
-// A Kiro-style requirement heading, e.g. `### Requirement 1: ...`. Group 1 is
-// the number; consumers canonicalize it to `Requirement-<n>`.
-export const KIRO_HEADING_RE = /^Requirement\s+(\d+)\s*:/;
+// A Kiro-style requirement heading. Both spellings occur in real Kiro output
+// and neither is rare — measured over 549 requirement headings in 62 files
+// across 26 repositories with `.kiro/specs/` committed: 41.5% bare
+// (`### Requirement 1`), 58.5% titled (`### Requirement 1: Some Title`).
+// Four repositories use both, and one file uses both. Kiro's own spec-agent
+// prompt templates the bare form; the model adds titles anyway.
+//
+// The alternative is `$`, NOT `:?` — `:?` would also accept prose headings
+// like `### Requirement 1 is important`, which are not requirement
+// definitions. Group 1 is the number; consumers canonicalize it to
+// `Requirement-<n>`.
+export const KIRO_HEADING_RE = /^Requirement\s+(\d+)\s*(?::|$)/;
 
 // Bare code-side ID shape (no namespace, whole-string match) used to validate
 // annotation targets when no custom `reqPatterns.codeId` is set.

--- a/src/grammar/tokens.ts
+++ b/src/grammar/tokens.ts
@@ -6,6 +6,12 @@
 // drift apart. Before this module existed that parity was comment-based
 // ("mirror the parser defaults") — a change on one side could silently strand
 // the other.
+//
+// The same rule covers `splitAtxHeading` at the bottom of this file: the
+// recognition side reads mdast heading *text*, every rewriting side reads the
+// *raw line*, and the only way those two agree is for every raw-line reader to
+// derive its heading text from one shared normalization rather than re-spelling
+// an ATX pattern of its own.
 
 // Canonical requirement-ID *token* shared across the code parser
 // (`@impl` / `[tag]` / `req:` annotations in src/parsers/typescript.ts) and the
@@ -56,3 +62,54 @@ export const KIRO_HEADING_RE = /^Requirement\s+(\d+)\s*(?::|$)/;
 // Bare code-side ID shape (no namespace, whole-string match) used to validate
 // annotation targets when no custom `reqPatterns.codeId` is set.
 export const DEFAULT_CODE_ID_RE = /^[A-Z][A-Za-z]*-\d+$/;
+
+/** The pieces a raw ATX heading line splits into (see splitAtxHeading). */
+export interface AtxHeadingParts {
+  /** Opening `#`s plus the whitespace run after them. */
+  prefix: string;
+  /** Heading text as the recognition side sees it — closing sequence removed. */
+  text: string;
+  /** The stripped closing sequence with its surrounding spaces ("" when absent). */
+  suffix: string;
+}
+
+// Everything before the heading text: the opening `#` run and the whitespace
+// that separates it from the text. Capped at 6 `#`s because that is where
+// CommonMark stops calling it a heading — `####### Requirement 1` is a
+// paragraph, so the recognition side never produces a requirement from it and
+// neither may any rewriter.
+const ATX_OPENING_RE = /^(#{1,6}\s+)(.*)$/;
+
+// An ATX *closing* sequence: a run of `#`s that ends the line, preceded by at
+// least one space/tab (or sitting at the very start of the text, which is the
+// empty-heading spelling `### ###`) and followed by nothing but spaces/tabs.
+// The "preceded by a space" half is load-bearing in both directions — without
+// it `### Requirement 1#` would look like a heading whose text is
+// `Requirement 1`, which is the opposite of what mdast reports.
+const ATX_CLOSING_RE = /(?:^|[ \t])[ \t]*#+[ \t]*$/;
+
+/**
+ * Split a raw markdown line into its ATX heading parts, or null when the line
+ * is not an ATX heading.
+ *
+ * This is the ONE place a raw-line consumer is allowed to turn a line into
+ * heading text. The recognition side (src/parsers/markdown.ts) reads mdast,
+ * which has already dropped the opening `#`s and any closing sequence; every
+ * rewriting side (src/rename.ts's `specDefinitionId` and `rewriteSpecHeading`,
+ * and through the former, split/merge in src/rename-executor.ts) reads the raw
+ * line instead. When those spell their own ATX pattern they drift: shipping
+ * closing-sequence support in one rewriter but not its sibling left
+ * `rename --merge` deleting one definition of a pair, rewriting both `@impl`
+ * tags and reporting success while the surviving heading turned into an orphan.
+ *
+ * `prefix + text + suffix === line`, so a caller rewrites `text` and
+ * reassembles without having to know what it was handed.
+ */
+export function splitAtxHeading(line: string): AtxHeadingParts | null {
+  const opening = line.match(ATX_OPENING_RE);
+  if (!opening) return null;
+  const body = opening[2];
+  const closing = body.match(ATX_CLOSING_RE);
+  const cut = closing ? (closing.index ?? body.length) : body.length;
+  return { prefix: opening[1], text: body.slice(0, cut), suffix: body.slice(cut) };
+}

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,4 +1,4 @@
-import { existsSync, rmdirSync, unlinkSync } from "node:fs";
+import { existsSync, rmdirSync, statSync, unlinkSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import {
   DEFAULT_CONFIG,
@@ -144,6 +144,21 @@ export interface InitResult {
   hooksInstall?: { perAgent: HookOutcome[]; anyFailure: boolean };
 }
 
+/**
+ * `existsSync` narrowed to directories. Total like `existsSync` — a missing
+ * path, a broken symlink or an unreadable parent all answer `false` rather
+ * than throwing, so callers keep treating the probe as a plain predicate.
+ * Symlinks are followed (`statSync`, not `lstatSync`): a `.kiro/specs` that
+ * points at a real directory is one artgraph can enumerate.
+ */
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path, { throwIfNoEntry: false })?.isDirectory() ?? false;
+  } catch {
+    return false;
+  }
+}
+
 export function detectProject(rootDir: string): DetectionResult {
   const abs = resolve(rootDir);
   const sddTools: SddToolInfo[] = [];
@@ -155,22 +170,25 @@ export function detectProject(rootDir: string): DetectionResult {
   // nodes (measured: 11 of them), so every artgraph upgrade that touches a
   // Skill would show up as lock drift in every downstream project.
   //
-  // `existsSync` (not `statSync().isDirectory()`) on purpose: it is the same
-  // probe the sibling `hasSpecs` / `hasDocs` / `marker` checks use, and the
-  // worst case for the odd shape it lets through (a regular FILE named
-  // `.kiro/specs`) is a specDirs entry that enumerates nothing — the same
-  // no-op the `["specs","docs"]` fallback already produces on a repo that has
-  // neither directory.
+  // The probe is `isDirectory()`, not the bare `existsSync` the sibling
+  // `hasSpecs` / `hasDocs` / `marker` checks use, because this is the only one
+  // of them whose answer is WRITTEN INTO specDirs. A regular file named
+  // `.kiro/specs` is not the harmless no-op it looks like: the builder feeds
+  // every specDirs entry to `listFilesGuarded(resolve(root, entry, "**/*.md"))`,
+  // which raises `ENOTDIR` on a file, so `init` aborts before writing
+  // `.artgraph.json` at all and every later `scan` exits 1 (measured). A
+  // directory that merely holds no `.md` files IS the harmless case, and it
+  // still reaches specDirs.
   //
   // The push conditions themselves are unchanged: `sddTools` still keys on
   // `marker` alone, so which tools are reported as "detected" and which
   // integrations run are exactly what they were before.
   if (existsSync(resolve(abs, ".specify"))) {
-    const specDir = existsSync(resolve(abs, ".specify/specs")) ? ".specify/specs" : undefined;
+    const specDir = isDirectory(resolve(abs, ".specify/specs")) ? ".specify/specs" : undefined;
     sddTools.push({ name: "Spec Kit", marker: ".specify", specDir });
   }
   if (existsSync(resolve(abs, ".kiro"))) {
-    const specDir = existsSync(resolve(abs, ".kiro/specs")) ? ".kiro/specs" : undefined;
+    const specDir = isDirectory(resolve(abs, ".kiro/specs")) ? ".kiro/specs" : undefined;
     sddTools.push({ name: "Kiro", marker: ".kiro", specDir });
   }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -147,11 +147,31 @@ export interface InitResult {
 export function detectProject(rootDir: string): DetectionResult {
   const abs = resolve(rootDir);
   const sddTools: SddToolInfo[] = [];
+  // issue #422 — the `specDir` probe keys on the tool's SPECS directory, not
+  // on `marker`. `init --agents=kiro` creates `.kiro/hooks/` and
+  // `.kiro/skills/` itself, so a later `detectProject` run sees `.kiro/` on
+  // disk purely because artgraph ran before; feeding `.kiro` into specDirs
+  // would then pull artgraph's own distributed SKILL.md files in as `doc`
+  // nodes (measured: 11 of them), so every artgraph upgrade that touches a
+  // Skill would show up as lock drift in every downstream project.
+  //
+  // `existsSync` (not `statSync().isDirectory()`) on purpose: it is the same
+  // probe the sibling `hasSpecs` / `hasDocs` / `marker` checks use, and the
+  // worst case for the odd shape it lets through (a regular FILE named
+  // `.kiro/specs`) is a specDirs entry that enumerates nothing — the same
+  // no-op the `["specs","docs"]` fallback already produces on a repo that has
+  // neither directory.
+  //
+  // The push conditions themselves are unchanged: `sddTools` still keys on
+  // `marker` alone, so which tools are reported as "detected" and which
+  // integrations run are exactly what they were before.
   if (existsSync(resolve(abs, ".specify"))) {
-    sddTools.push({ name: "Spec Kit", marker: ".specify" });
+    const specDir = existsSync(resolve(abs, ".specify/specs")) ? ".specify/specs" : undefined;
+    sddTools.push({ name: "Spec Kit", marker: ".specify", specDir });
   }
   if (existsSync(resolve(abs, ".kiro"))) {
-    sddTools.push({ name: "Kiro", marker: ".kiro" });
+    const specDir = existsSync(resolve(abs, ".kiro/specs")) ? ".kiro/specs" : undefined;
+    sddTools.push({ name: "Kiro", marker: ".kiro", specDir });
   }
 
   // FR-019: share the `detect` / `isInstalled` logic with `integrate` by
@@ -176,12 +196,23 @@ export function generateConfig(detection: DetectionResult): ArtgraphConfig {
     ? [...DEFAULT_CONFIG.include]
     : ["**/*.ts", "**/*.tsx", "!**/node_modules/**"];
 
-  // "specs" and "docs" are always siblings, never parent/child, so this can't
-  // produce the parent+child specDirs shape loadConfig's validateSpecDirs
-  // filters (issue #234).
+  // "specs", "docs", ".kiro/specs" and ".specify/specs" are all siblings of
+  // one another, never parent/child, so this can't produce the parent+child
+  // specDirs shape loadConfig's validateSpecDirs filters (issue #234).
   const specDirs: string[] = [];
   if (detection.hasSpecs) specDirs.push("specs");
   if (detection.hasDocs) specDirs.push("docs");
+  // issue #422 — an SDD tool that keeps specs outside `specs/` needs its own
+  // directory in the list, or the very first scan finds zero reqs and the
+  // init summary says "no matching specs yet" — the opposite of the truth.
+  // Appended, never substituted: a Kiro project with a `docs/` tree still
+  // wants `docs/` scanned.
+  for (const tool of detection.sddTools) {
+    if (tool.specDir && !specDirs.includes(tool.specDir)) specDirs.push(tool.specDir);
+  }
+  // The fallback runs LAST, after the SDD append, so a repo whose only spec
+  // tree is `.kiro/specs/` gets `[".kiro/specs"]` rather than two entries
+  // (`specs`, `docs`) that enumerate nothing plus the one that does.
   if (specDirs.length === 0) specDirs.push(...DEFAULT_CONFIG.specDirs);
 
   return {

--- a/src/parsers/markdown.ts
+++ b/src/parsers/markdown.ts
@@ -47,9 +47,22 @@ export const BUILTIN_TASK_PRESETS: TaskConventionPreset[] = [
     verifiesTagRe: `\\[((?:REQ-[\\w/-]+)|(?:${NAMESPACED_ID_TOKEN}))\\]`,
   },
   {
-    // Kiro tasks.md: require the checkbox prefix so ordinary numbered prose
-    // (`- 1 release shipped`) doesn't false-match as a task. Users with a
-    // checkbox-less Kiro variant can override via `.artgraph.json` `taskConventions`.
+    // Kiro tasks.md: the `[ ]`/`[x]` checkbox prefix is required, and it does
+    // two jobs at once.
+    //   1. False-positive guard — ordinary numbered prose (`- 1 release
+    //      shipped`) does not become a task.
+    //   2. Load-bearing on the markdown shape — with the checkbox in front,
+    //      the `1.` in `- [x] 1. Do the thing` stays TEXT. Without it,
+    //      CommonMark reads `- 1. Do the thing` as a nested ordered list and
+    //      `toString` drops the marker, so the ID is not in the string
+    //      `taskIdRe` sees no matter what `taskIdRe` says.
+    // A checkbox-less Kiro variant therefore needs an ADDITIONAL preset, not
+    // a copy of this one with the checkbox deleted: `loadConfig`'s
+    // nested-quantifier guard rejects the `(\d+(?:\.\d+)*)` spelling below in
+    // a user-supplied preset, and even once that is re-spelled, job 2 above
+    // still costs the `- N. …` / `- N) …` forms. See docs/configuration.md
+    // "Kiro `tasks.md` without checkboxes (issue #419)" for the recipe and
+    // its limits.
     name: "kiro",
     fileStems: ["tasks"],
     taskIdRe: "^\\[[xX ]\\][\\s\\u00A0]+(\\d+(?:\\.\\d+)*)\\.?[\\s\\u00A0]",

--- a/src/rename.ts
+++ b/src/rename.ts
@@ -248,7 +248,28 @@ export function rewriteSpecHeading(
     const oldNum = oldMatch[1];
     const newNum = newMatch[1];
 
-    const re = new RegExp(`^(#+\\s+)Requirement\\s+${escapeRegExp(oldNum)}(\\s*:)`);
+    // Kept in lockstep with KIRO_HEADING_RE's own separator alternation
+    // (grammar/tokens.ts) — this regex re-spells what that one already
+    // accepted, so a narrower class here would recognize a heading as a
+    // requirement and then silently refuse to rename it. `usingDefault`
+    // above only pins the RECOGNITION regex; this rewrite pattern is spelled
+    // separately and has to be widened with it.
+    //
+    // `\s*$` (end of the raw line) stands in for KIRO_HEADING_RE's `$` (end
+    // of the mdast heading TEXT); the trailing run it captures is replayed
+    // verbatim into group 2, so `### Requirement 1   ` keeps its padding.
+    //
+    // The optional `#+` inside that branch is what makes the two sides agree
+    // on an ATX *closing sequence* (`### Requirement 1 ###`). mdast strips it
+    // before KIRO_HEADING_RE ever sees the text, so recognition accepts the
+    // heading; matching the raw line here without allowing for it would
+    // recognize that heading and then refuse to rename it. It cannot widen
+    // the match into prose: `### Requirement 1 is important` still fails both
+    // branches, because `#+` is only reachable with the line ending right
+    // after it.
+    const re = new RegExp(
+      `^(#+\\s+)Requirement\\s+${escapeRegExp(oldNum)}(\\s*:|\\s*(?:#+\\s*)?$)`,
+    );
     for (let i = 0; i < lines.length; i++) {
       if (fenced.has(i)) continue;
       const match = lines[i].match(re);

--- a/src/rename.ts
+++ b/src/rename.ts
@@ -5,7 +5,7 @@ import {
   findFrontmatterBounds,
   maskInlineProtectedSpans,
 } from "./parsers/markdown.js";
-import { LIST_ITEM_RE, KIRO_HEADING_RE } from "./grammar/tokens.js";
+import { LIST_ITEM_RE, KIRO_HEADING_RE, splitAtxHeading } from "./grammar/tokens.js";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -136,6 +136,14 @@ export function fencedLines(content: string): Set<number> {
  * parser would turn into a req node), return that requirement's ID; otherwise
  * null. Mirrors the parser's list-item / heading grammar so split/merge can
  * remove the exact lines the parser treats as definitions.
+ *
+ * The heading branch goes through `splitAtxHeading` rather than its own ATX
+ * pattern so its acceptance set is identical to `rewriteSpecHeading`'s below.
+ * They must not be spelled separately: when only the rewriter learned about
+ * ATX closing sequences, `rename --merge` on `### Requirement 1 ###` /
+ * `### Requirement 2` removed the second definition, rewrote both `@impl`
+ * tags onto the merge target and reported success — leaving the first heading
+ * behind as an orphan and turning a green `check --gate` into exit 2.
  */
 export function specDefinitionId(line: string, opts?: RewriteOptions): string | null {
   const pm = line.match(/^(\s*[-*]\s+)/);
@@ -146,10 +154,10 @@ export function specDefinitionId(line: string, opts?: RewriteOptions): string | 
       if (m && m[1] != null) return m[1];
     }
   }
-  const hm = line.match(/^(#+\s+)(.*)$/);
-  if (hm) {
+  const heading = splitAtxHeading(line);
+  if (heading) {
     const headRe = headingRegex(opts);
-    const m = hm[2].match(headRe);
+    const m = heading.text.match(headRe);
     if (m && m[1] != null) {
       return headRe.source === KIRO_HEADING_RE.source ? `Requirement-${m[1]}` : m[1];
     }
@@ -248,34 +256,26 @@ export function rewriteSpecHeading(
     const oldNum = oldMatch[1];
     const newNum = newMatch[1];
 
-    // Kept in lockstep with KIRO_HEADING_RE's own separator alternation
-    // (grammar/tokens.ts) — this regex re-spells what that one already
-    // accepted, so a narrower class here would recognize a heading as a
-    // requirement and then silently refuse to rename it. `usingDefault`
-    // above only pins the RECOGNITION regex; this rewrite pattern is spelled
-    // separately and has to be widened with it.
+    // Matched against the heading TEXT `splitAtxHeading` hands back, which is
+    // the same string the recognition side gets from mdast — so this pattern
+    // only has to re-spell KIRO_HEADING_RE's separator alternation, not the
+    // ATX shape around it. `usingDefault` above pins the RECOGNITION regex
+    // only; this one is spelled separately and has to be widened with it.
     //
-    // `\s*$` (end of the raw line) stands in for KIRO_HEADING_RE's `$` (end
-    // of the mdast heading TEXT); the trailing run it captures is replayed
-    // verbatim into group 2, so `### Requirement 1   ` keeps its padding.
-    //
-    // The optional `#+` inside that branch is what makes the two sides agree
-    // on an ATX *closing sequence* (`### Requirement 1 ###`). mdast strips it
-    // before KIRO_HEADING_RE ever sees the text, so recognition accepts the
-    // heading; matching the raw line here without allowing for it would
-    // recognize that heading and then refuse to rename it. It cannot widen
-    // the match into prose: `### Requirement 1 is important` still fails both
-    // branches, because `#+` is only reachable with the line ending right
-    // after it.
-    const re = new RegExp(
-      `^(#+\\s+)Requirement\\s+${escapeRegExp(oldNum)}(\\s*:|\\s*(?:#+\\s*)?$)`,
-    );
+    // `\s*$` here is KIRO_HEADING_RE's own `$` (end of the heading text): the
+    // trailing run it captures is replayed verbatim into group 1, so
+    // `### Requirement 1   ` keeps its padding, and a closing sequence rides
+    // along untouched in `suffix`.
+    const re = new RegExp(`^Requirement\\s+${escapeRegExp(oldNum)}(\\s*:|\\s*$)`);
     for (let i = 0; i < lines.length; i++) {
       if (fenced.has(i)) continue;
-      const match = lines[i].match(re);
+      const heading = splitAtxHeading(lines[i]);
+      if (!heading) continue;
+      const match = heading.text.match(re);
       if (!match) continue;
       const before = lines[i];
-      lines[i] = match[1] + "Requirement " + newNum + match[2] + lines[i].slice(match[0].length);
+      const text = "Requirement " + newNum + match[1] + heading.text.slice(match[0].length);
+      lines[i] = heading.prefix + text + heading.suffix;
       changes.push({
         filePath: "",
         line: i + 1,
@@ -287,20 +287,23 @@ export function rewriteSpecHeading(
     return { content: lines.join("\n"), changes };
   }
 
-  // Custom heading grammar: heading text after the leading `#`s is matched by
-  // headRe; capture group 1 holds the verbatim ID.
-  const headingLineRe = /^(#+\s+)(.*)$/;
+  // Custom heading grammar: the heading text `splitAtxHeading` returns is
+  // matched by headRe; capture group 1 holds the verbatim ID. Same helper as
+  // the default branch and as `specDefinitionId`, so a custom grammar cannot
+  // drift from them either.
   for (let i = 0; i < lines.length; i++) {
     if (fenced.has(i)) continue;
-    const hm = lines[i].match(headingLineRe);
-    if (!hm) continue;
-    const m = hm[2].match(headRe);
+    const heading = splitAtxHeading(lines[i]);
+    if (!heading) continue;
+    const m = heading.text.match(headRe);
     if (!m || m[1] !== oldId) continue;
     const idOffsetInMatch = m[0].indexOf(m[1]);
     if (idOffsetInMatch === -1) continue;
-    const idStart = hm[1].length + (m.index ?? 0) + idOffsetInMatch;
+    const idStart = (m.index ?? 0) + idOffsetInMatch;
     const before = lines[i];
-    lines[i] = lines[i].slice(0, idStart) + newId + lines[i].slice(idStart + oldId.length);
+    const text =
+      heading.text.slice(0, idStart) + newId + heading.text.slice(idStart + oldId.length);
+    lines[i] = heading.prefix + text + heading.suffix;
     changes.push({
       filePath: "",
       line: i + 1,

--- a/src/types.ts
+++ b/src/types.ts
@@ -344,6 +344,20 @@ export interface ScanSummary {
 export interface SddToolInfo {
   name: string;
   marker: string;
+  /**
+   * Directory this SDD tool keeps its specs in, relative to the repo root —
+   * present only when that directory actually exists on disk.
+   *
+   * Deliberately NOT derived from `marker`: `init --agents=kiro` itself
+   * creates `.kiro/hooks/` and `.kiro/skills/`, so `.kiro/` existing proves
+   * only that artgraph has run before, not that the project has specs. The
+   * specDirs decision has to key on the specs directory itself.
+   *
+   * Optional to preserve back-compat for callers that construct
+   * SddToolInfo literals (tests) — same reason DetectionResult.integrations
+   * is optional.
+   */
+  specDir?: string;
 }
 
 export interface DetectionResult {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { writeFileSync, existsSync, unlinkSync, mkdirSync, rmSync } from "node:fs";
 import { loadConfig } from "../src/config.js";
 import { scan } from "../src/scan.js";
+import { BUILTIN_TASK_PRESETS } from "../src/parsers/markdown.js";
 
 const TMP_DIR = resolve(import.meta.dirname, "fixtures/config-test");
 const CONFIG_PATH = resolve(TMP_DIR, ".artgraph.json");
@@ -440,6 +441,81 @@ describe("loadConfig", () => {
         }),
       );
       expect(() => loadConfig(TMP_DIR)).toThrow("implementsTagRe: must not be empty");
+    });
+
+    // issue #419 — the built-in presets and the user-supplied ones are NOT
+    // held to the same standard, and nothing said so out loud before this.
+    //
+    // `BUILTIN_TASK_PRESETS` is compiled directly into the parser and never
+    // travels through `validateTaskConventions`, so the built-in `kiro`
+    // preset is free to spell the hierarchical task number as
+    // `(\d+(?:\.\d+)*)` — a shape `detectReDoSRisk` rejects outright in a
+    // user preset. The practical consequence is issue #419's report: a user
+    // with a checkbox-less Kiro `tasks.md` copies the built-in value, deletes
+    // the checkbox prefix, and gets a hard `loadConfig` error rather than a
+    // working override. It bites BOTH regex fields, and `verifiesTagRe`
+    // matters as much as `taskIdRe` because tag regexes are per-preset — a
+    // preset without one produces task nodes with no `_Requirements:` edges.
+    //
+    // This test pins the asymmetry as it stands today rather than asserting
+    // it is fine. `docs/configuration.md` carries the working recipe. If the
+    // validator is ever relaxed (or the built-ins re-spelled to pass it),
+    // this is the test that flips first.
+    describe("built-in presets vs. the user-preset validator (issue #419)", () => {
+      const feed = (preset: Record<string, unknown>) => {
+        mkdirSync(TMP_DIR, { recursive: true });
+        writeFileSync(CONFIG_PATH, JSON.stringify({ taskConventions: [preset] }));
+        return () => loadConfig(TMP_DIR);
+      };
+
+      const builtin = (name: string) => {
+        const p = BUILTIN_TASK_PRESETS.find((x) => x.name === name);
+        expect(p, `built-in preset "${name}" disappeared`).toBeDefined();
+        return p!;
+      };
+
+      it("accepts the spec-kit preset's own values verbatim", () => {
+        const p = builtin("spec-kit");
+        expect(
+          feed({
+            name: "spec-kit-copy",
+            fileStems: [...p.fileStems],
+            taskIdRe: p.taskIdRe,
+            implementsTagRe: p.implementsTagRe,
+            verifiesTagRe: p.verifiesTagRe,
+          }),
+        ).not.toThrow();
+      });
+
+      it("rejects the kiro preset's own taskIdRe, and its verifiesTagRe too", () => {
+        const p = builtin("kiro");
+
+        expect(
+          feed({ name: "kiro-copy", fileStems: [...p.fileStems], taskIdRe: p.taskIdRe }),
+        ).toThrow("taskIdRe: nested quantifiers");
+
+        // Same defect in the other field — masked above because `taskIdRe` is
+        // validated first, so it needs its own valid-taskIdRe carrier.
+        expect(
+          feed({
+            name: "kiro-copy",
+            fileStems: [...p.fileStems],
+            taskIdRe: "^(K-\\d+)",
+            verifiesTagRe: p.verifiesTagRe,
+          }),
+        ).toThrow("verifiesTagRe: nested quantifiers");
+      });
+
+      it("accepts the checkbox-less Kiro recipe documented in docs/configuration.md", () => {
+        expect(
+          feed({
+            name: "kiro-no-checkbox",
+            fileStems: ["tasks"],
+            taskIdRe: "^(\\d+|\\d+\\.\\d+|\\d+\\.\\d+\\.\\d+)\\.?[\\s\\u00A0]",
+            verifiesTagRe: "(?<=Requirements:[\\s\\d.,]*)(\\d+\\.\\d+|\\d+)",
+          }),
+        ).not.toThrow();
+      });
     });
   });
 

--- a/tests/issue-422-kiro-specdirs.test.ts
+++ b/tests/issue-422-kiro-specdirs.test.ts
@@ -1,0 +1,493 @@
+// issue #422 — `artgraph init` detected Kiro, wrote the Kiro integration, and
+// then handed the project a `.artgraph.json` whose `specDirs` was still the
+// default `["specs", "docs"]`. Kiro keeps its specs in `.kiro/specs/`, so the
+// very first scan found zero requirements and zero docs, and the init summary
+// said "@impl tags found, but no matching specs yet" — the exact opposite of
+// the truth.
+//
+// Three changes ship together here, because fixing only the first one leaves
+// the symptom in place for a measured 41.5% of real Kiro spec files:
+//
+//   (1) `detectProject` probes each SDD tool's SPECS directory and
+//       `generateConfig` appends it to `specDirs` (never substitutes).
+//   (2) the Kiro heading grammar accepts the bare `### Requirement 1`
+//       spelling, not just `### Requirement 1: Title`.
+//   (3) `rename`'s heading rewriter is widened in lockstep with (2), so a
+//       heading that is now RECOGNIZED as a requirement is also RENAMEABLE.
+//       Without that pairing `artgraph rename` reports success while silently
+//       leaving the heading untouched.
+//
+// `artgraph doctor` gets an advisory for the population (1) cannot reach:
+// projects initialized before this version, whose `specDirs` `init --force`
+// deliberately preserves rather than re-derives.
+
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { detectProject, generateConfig, runInit } from "../src/init.js";
+import { loadConfig } from "../src/config.js";
+import { parseMarkdownContent } from "../src/parsers/markdown.js";
+import { rewriteSpecHeading } from "../src/rename.js";
+import { runDoctor, type DoctorFinding } from "../src/doctor.js";
+import { createFreshProject, type FreshProject } from "./agents/helpers.js";
+import type { DetectionResult } from "../src/types.js";
+
+const KIRO_SPECS = ".kiro/specs";
+const SPECIFY_SPECS = ".specify/specs";
+
+/** Requirements file holding both heading spellings Kiro emits in the wild. */
+const REQUIREMENTS_MD = [
+  "# Requirements Document",
+  "",
+  "## Requirements",
+  "",
+  "### Requirement 1: Federated authentication",
+  "",
+  "**User Story:** As a user, I want to sign in.",
+  "",
+  "### Requirement 2",
+  "",
+  "**User Story:** As a user, I want rate limiting.",
+  "",
+].join("\n");
+
+function mkdirp(root: string, rel: string): void {
+  mkdirSync(join(root, ...rel.split("/")), { recursive: true });
+}
+
+function write(root: string, rel: string, content: string): void {
+  const parts = rel.split("/");
+  mkdirSync(join(root, ...parts.slice(0, -1)), { recursive: true });
+  writeFileSync(join(root, ...parts), content, "utf-8");
+}
+
+function readConfig(root: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(root, ".artgraph.json"), "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// (1a) detectProject / generateConfig — which directories reach `specDirs`
+// ---------------------------------------------------------------------------
+
+describe("issue #422 — generateConfig seeds an SDD tool's spec directory", () => {
+  let proj: FreshProject;
+
+  beforeEach(() => {
+    proj = createFreshProject();
+  });
+
+  afterEach(() => {
+    proj.cleanup();
+  });
+
+  // F1 — the whole point of the issue. A Kiro-only project must not be handed
+  // a specDirs of two directories that do not exist plus the one that does:
+  // the SDD append happens BEFORE the "nothing found, fall back to the
+  // defaults" branch, so the fallback never fires here.
+  it("F1: a repo whose only spec tree is .kiro/specs gets exactly that one entry", () => {
+    mkdirp(proj.dir, KIRO_SPECS);
+    const config = generateConfig(detectProject(proj.dir));
+    expect(config.specDirs).toEqual([KIRO_SPECS]);
+  });
+
+  // F2 — appended, never substituted, and in a pinned order. A Kiro project
+  // that also keeps a `docs/` tree still wants `docs/` scanned.
+  it("F2: specs/ and docs/ are kept alongside .kiro/specs, in that order", () => {
+    mkdirp(proj.dir, "specs");
+    mkdirp(proj.dir, "docs");
+    mkdirp(proj.dir, KIRO_SPECS);
+    const config = generateConfig(detectProject(proj.dir));
+    expect(config.specDirs).toEqual(["specs", "docs", KIRO_SPECS]);
+  });
+
+  // F3 — the self-detection trap, with its positive control in the same test.
+  // `init --agents=kiro` creates `.kiro/skills/` and `.kiro/hooks/` itself, so
+  // a `.kiro/` on disk proves only that artgraph has run before. Keying the
+  // decision on `.kiro` rather than `.kiro/specs` would put artgraph's own
+  // distributed SKILL.md files into the graph as doc nodes, and every artgraph
+  // upgrade that edits a Skill would then read as lock drift downstream.
+  it("F3: artgraph's own .kiro/skills + .kiro/hooks do NOT seed a spec dir, while .kiro/specs does", () => {
+    mkdirp(proj.dir, "specs");
+    mkdirp(proj.dir, "docs");
+    mkdirp(proj.dir, ".kiro/skills");
+    mkdirp(proj.dir, ".kiro/hooks");
+
+    const detectedWithoutSpecs = detectProject(proj.dir);
+    expect(detectedWithoutSpecs.sddTools.map((t) => t.name)).toContain("Kiro");
+    expect(detectedWithoutSpecs.sddTools.find((t) => t.name === "Kiro")!.specDir).toBeUndefined();
+    expect(generateConfig(detectedWithoutSpecs).specDirs).toEqual(["specs", "docs"]);
+
+    // Positive control on the same tree: add the specs dir and the entry appears.
+    mkdirp(proj.dir, KIRO_SPECS);
+    const detectedWithSpecs = detectProject(proj.dir);
+    expect(detectedWithSpecs.sddTools.find((t) => t.name === "Kiro")!.specDir).toBe(KIRO_SPECS);
+    expect(generateConfig(detectedWithSpecs).specDirs).toEqual(["specs", "docs", KIRO_SPECS]);
+  });
+
+  // F4 — Spec Kit has the identical defect; the fix is the same branch.
+  it("F4: .specify/specs is seeded the same way (Spec Kit symmetry)", () => {
+    mkdirp(proj.dir, SPECIFY_SPECS);
+    const config = generateConfig(detectProject(proj.dir));
+    expect(config.specDirs).toEqual([SPECIFY_SPECS]);
+  });
+
+  // F5 — both tools present.
+  it("F5: a repo with both tools gets both spec directories", () => {
+    mkdirp(proj.dir, SPECIFY_SPECS);
+    mkdirp(proj.dir, KIRO_SPECS);
+    const config = generateConfig(detectProject(proj.dir));
+    expect(config.specDirs).toEqual([SPECIFY_SPECS, KIRO_SPECS]);
+  });
+
+  // F6 — back-compat for hand-built literals: `integrations` and the new
+  // `specDir` are both optional, and a caller that omits them must not crash.
+  it("F6: a DetectionResult literal without integrations / specDir still generates a config", () => {
+    const legacy: DetectionResult = {
+      hasSrc: true,
+      hasSpecs: true,
+      hasDocs: false,
+      sddTools: [{ name: "Kiro", marker: ".kiro" }],
+    };
+    expect(legacy.integrations).toBeUndefined();
+    const config = generateConfig(legacy);
+    expect(config.specDirs).toEqual(["specs"]);
+  });
+
+  // F9 — the append can only ever add SIBLINGS of the existing entries, so it
+  // can never produce the parent/child shape `loadConfig` silently filters
+  // (issue #234). Second half shows what that filtering does, so the first
+  // half is not just an assertion about an unreachable state.
+  it("F9: no hasSpecs x hasDocs x tool combination yields a parent/child specDirs pair, which loadConfig would drop", () => {
+    const combos: DetectionResult[] = [];
+    for (const hasSpecs of [false, true]) {
+      for (const hasDocs of [false, true]) {
+        for (const specify of [undefined, SPECIFY_SPECS]) {
+          for (const kiro of [undefined, KIRO_SPECS]) {
+            combos.push({
+              hasSrc: true,
+              hasSpecs,
+              hasDocs,
+              sddTools: [
+                ...(specify ? [{ name: "Spec Kit", marker: ".specify", specDir: specify }] : []),
+                ...(kiro ? [{ name: "Kiro", marker: ".kiro", specDir: kiro }] : []),
+              ],
+            });
+          }
+        }
+      }
+    }
+    expect(combos).toHaveLength(16);
+
+    for (const detection of combos) {
+      const dirs = generateConfig(detection).specDirs;
+      expect(new Set(dirs).size, JSON.stringify(dirs)).toBe(dirs.length);
+      for (const a of dirs) {
+        for (const b of dirs) {
+          if (a === b) continue;
+          expect(b.startsWith(a + "/"), `${b} is a descendant of ${a}`).toBe(false);
+        }
+      }
+    }
+
+    // What the shape above avoids: an ancestor entry swallows its descendant
+    // at load time, so a config that listed both would lose `.kiro/specs`.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      write(
+        proj.dir,
+        ".artgraph.json",
+        JSON.stringify({ specDirs: [".kiro", KIRO_SPECS], include: ["src/**/*.ts"] }),
+      );
+      expect(loadConfig(proj.dir).specDirs).toEqual([".kiro"]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (1b) runInit end-to-end — the behaviour the issue actually reported
+// ---------------------------------------------------------------------------
+
+describe("issue #422 — init's first scan sees a Kiro project's requirements", () => {
+  let proj: FreshProject;
+
+  beforeEach(() => {
+    proj = createFreshProject();
+  });
+
+  afterEach(() => {
+    proj.cleanup();
+  });
+
+  // F7 — the reported symptom, end to end. Every other init test in this repo
+  // runs with `--no-scan`, so nothing before this one could observe that the
+  // first scan came back empty on a Kiro project.
+  //
+  // Deliberately runs the Skills stage as well: it is what creates
+  // `.kiro/skills/`, and the doc count below is what proves those distributed
+  // SKILL.md files did NOT enter the graph.
+  it("F7: `init --agents=kiro` scans .kiro/specs and reports a non-zero reqCount", () => {
+    write(proj.dir, ".kiro/specs/auth/requirements.md", REQUIREMENTS_MD);
+    write(proj.dir, "src/app.ts", "export const x = 1;\n");
+
+    const result = runInit(proj.dir, { agents: ["kiro"], noIntegrate: true, noHooks: true });
+
+    expect(result.config.specDirs).toEqual([KIRO_SPECS]);
+    expect(readConfig(proj.dir).specDirs).toEqual([KIRO_SPECS]);
+
+    // Both heading spellings in the fixture became requirements.
+    expect(result.scanSummary!.reqCount).toBe(2);
+
+    // The Skills stage really did create `.kiro/skills/` before the scan ran —
+    // this is the self-detection trap F3 covers, here in its live form — and
+    // exactly one doc node exists, the requirements file. Had `specDirs`
+    // keyed on `.kiro`, every distributed SKILL.md would be a doc node too.
+    expect(existsSync(join(proj.dir, ".kiro", "skills"))).toBe(true);
+    expect(result.scanSummary!.docCount).toBe(1);
+  });
+
+  // F8 — the `--force` contract (`tests/init.test.ts` pins the general form).
+  // `--force` MERGES an existing config instead of re-deriving detection
+  // fields, and that must keep holding now that `specDirs` has a new source.
+  it("F8: `init --force` leaves an existing specDirs alone even when .kiro/specs is present", () => {
+    write(proj.dir, ".kiro/specs/auth/requirements.md", REQUIREMENTS_MD);
+    write(proj.dir, ".artgraph.json", JSON.stringify({ specDirs: ["my-specs"] }));
+
+    runInit(proj.dir, { force: true, minimal: true });
+
+    expect(readConfig(proj.dir).specDirs).toEqual(["my-specs"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (2) heading grammar — the bare spelling
+// ---------------------------------------------------------------------------
+
+describe("issue #422 — Kiro heading grammar accepts a bare number", () => {
+  function reqIdsOf(markdown: string): string[] {
+    return parseMarkdownContent(markdown, "requirements.md")
+      .nodes.filter((n) => n.kind === "req")
+      .map((n) => n.id);
+  }
+
+  // F10 + F11 + F12 in one test: the widening, its positive control, and the
+  // prose heading that must stay OUT. The three belong together — the
+  // narrower `:?` spelling of the same widening would pass F10 and F11 while
+  // silently flipping F12 to accept.
+  it("F10/F11/F12: bare and titled numbers define a requirement; a prose heading does not", () => {
+    // F11 — positive control, the spelling that always worked.
+    expect(reqIdsOf("### Requirement 1: Federated authentication")).toEqual(["Requirement-1"]);
+
+    // F10 — the widening. 41.5% of measured real-world Kiro headings.
+    expect(reqIdsOf("### Requirement 2")).toEqual(["Requirement-2"]);
+
+    // F12 — prose is not a definition. `:?` would accept this one.
+    expect(reqIdsOf("### Requirement 3 is important")).toEqual([]);
+
+    // Neighbouring shapes that must also stay out, so the assertion above is
+    // not carrying the whole negative side on its own.
+    expect(reqIdsOf("### Requirements")).toEqual([]);
+    expect(reqIdsOf("### Requirement Completeness")).toEqual([]);
+  });
+
+  it("recognizes the bare spelling at every heading level Kiro emits", () => {
+    expect(reqIdsOf("## Requirement 4")).toEqual(["Requirement-4"]);
+    expect(reqIdsOf("### Requirement 5")).toEqual(["Requirement-5"]);
+    expect(reqIdsOf("#### Requirement 6")).toEqual(["Requirement-6"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (3) rename parity — recognized implies renameable
+// ---------------------------------------------------------------------------
+
+describe("issue #422 — rename rewrites both heading spellings", () => {
+  // F13 + F14. The pairing is the point: widening only the RECOGNITION regex
+  // produces a heading that `check` treats as a requirement and that `rename`
+  // reports as successfully renamed while leaving the file byte-identical.
+  it("F13/F14: the bare spelling is rewritten, and so is the titled one", () => {
+    // F14 — positive control.
+    const titled = rewriteSpecHeading(
+      "### Requirement 1: Federated authentication",
+      "Requirement-1",
+      "Requirement-9",
+    );
+    expect(titled.content).toBe("### Requirement 9: Federated authentication");
+    expect(titled.changes).toHaveLength(1);
+
+    // F13 — the parity case. Fails when only the recognition side is widened.
+    const bare = rewriteSpecHeading("### Requirement 1", "Requirement-1", "Requirement-9");
+    expect(bare.content).toBe("### Requirement 9");
+    expect(bare.changes).toHaveLength(1);
+    expect(bare.changes[0].kind).toBe("spec-heading");
+  });
+
+  it("preserves trailing whitespace and does not match a longer number", () => {
+    // The captured separator run is replayed verbatim, so padding survives.
+    expect(
+      rewriteSpecHeading("### Requirement 1   ", "Requirement-1", "Requirement-9").content,
+    ).toBe("### Requirement 9   ");
+
+    // `### Requirement 12` must not be rewritten when renaming number 1 —
+    // the alternation requires a colon or the end of the line right after it.
+    const other = rewriteSpecHeading("### Requirement 12", "Requirement-1", "Requirement-9");
+    expect(other.content).toBe("### Requirement 12");
+    expect(other.changes).toHaveLength(0);
+  });
+
+  it("leaves a prose heading alone (mirrors the recognition side)", () => {
+    const prose = rewriteSpecHeading(
+      "### Requirement 1 is important",
+      "Requirement-1",
+      "Requirement-9",
+    );
+    expect(prose.content).toBe("### Requirement 1 is important");
+    expect(prose.changes).toHaveLength(0);
+  });
+
+  it("rewrites a heading closed with an ATX closing sequence", () => {
+    // mdast strips a closing `###` before the recognition regex sees the
+    // text, so `### Requirement 1 ###` IS recognized as a requirement. Only
+    // the rewriter reads the raw line, which is why the two sides can
+    // disagree here and nowhere else. Widening recognition to the bare
+    // spelling without this branch produces a heading that renames to
+    // nothing while `rename` reports success.
+    const closed = rewriteSpecHeading("### Requirement 1 ###", "Requirement-1", "Requirement-9");
+    expect(closed.content).toBe("### Requirement 9 ###");
+    expect(closed.changes).toHaveLength(1);
+
+    // Negative control in the same `it()`: the `#+` branch must not be a
+    // door into prose. Both of these end in text, not in the line ending, so
+    // neither side accepts them.
+    const proseHash = rewriteSpecHeading(
+      "### Requirement 1 ### and then some",
+      "Requirement-1",
+      "Requirement-9",
+    );
+    expect(proseHash.content).toBe("### Requirement 1 ### and then some");
+    expect(proseHash.changes).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (4) doctor advisory — the population `init` cannot reach
+// ---------------------------------------------------------------------------
+
+describe("issue #422 — doctor advisory for an uncovered SDD spec directory", () => {
+  let proj: FreshProject;
+
+  beforeEach(() => {
+    proj = createFreshProject();
+  });
+
+  afterEach(() => {
+    proj.cleanup();
+  });
+
+  function findingsOf(dir: string): DoctorFinding[] {
+    return runDoctor({ rootDir: dir }).findings.filter(
+      (f) => f.kind === "config-specdir-missing-sdd-tool",
+    );
+  }
+
+  function initClaude(dir: string): void {
+    runInit(dir, {
+      agents: ["claude"],
+      noScan: true,
+      noIntegrate: true,
+      noHooks: true,
+      force: true,
+    });
+  }
+
+  // F16 + F17. The negative control shares the test so an advisory that
+  // simply never fires cannot pass as "correctly silent".
+  it("F16/F17: fires when specDirs misses .kiro/specs, and is silent once an entry covers it", () => {
+    write(proj.dir, ".kiro/specs/auth/requirements.md", REQUIREMENTS_MD);
+    initClaude(proj.dir);
+    write(
+      proj.dir,
+      ".artgraph.json",
+      JSON.stringify({
+        include: ["src/**/*.ts", "!**/node_modules/**"],
+        testPatterns: ["**/*.test.ts", "!**/node_modules/**"],
+        specDirs: ["specs", "docs"],
+        agents: ["claude"],
+      }),
+    );
+
+    // F16 — advisory present, and advisory ONLY: severity `pass`, so the
+    // doctor exit code is untouched (same contract as the `agents`-field and
+    // pool-protection advisories).
+    const report = runDoctor({ rootDir: proj.dir });
+    const found = report.findings.filter((f) => f.kind === "config-specdir-missing-sdd-tool");
+    expect(found, JSON.stringify(report.findings, null, 2)).toHaveLength(1);
+    expect(found[0].severity).toBe("pass");
+    expect(found[0].agent).toBeNull();
+    expect(found[0].path).toBe(".artgraph.json");
+    expect(found[0].message).toContain(KIRO_SPECS);
+    expect(report.summary.failCount).toBe(0);
+
+    // F17 — same tree, config extended: the advisory goes away.
+    write(
+      proj.dir,
+      ".artgraph.json",
+      JSON.stringify({
+        include: ["src/**/*.ts", "!**/node_modules/**"],
+        testPatterns: ["**/*.test.ts", "!**/node_modules/**"],
+        specDirs: ["specs", "docs", KIRO_SPECS],
+        agents: ["claude"],
+      }),
+    );
+    expect(findingsOf(proj.dir)).toEqual([]);
+  });
+
+  it("treats an ancestor entry as covering, and normalizes before comparing", () => {
+    write(proj.dir, ".kiro/specs/auth/requirements.md", REQUIREMENTS_MD);
+    initClaude(proj.dir);
+
+    const base = {
+      include: ["src/**/*.ts", "!**/node_modules/**"],
+      testPatterns: ["**/*.test.ts", "!**/node_modules/**"],
+      agents: ["claude"],
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      // Ancestor entry covers the descendant.
+      write(proj.dir, ".artgraph.json", JSON.stringify({ ...base, specDirs: [".kiro"] }));
+      expect(findingsOf(proj.dir)).toEqual([]);
+
+      // Same entry, spelled with a leading `./` and a trailing `/`.
+      write(proj.dir, ".artgraph.json", JSON.stringify({ ...base, specDirs: ["./.kiro/specs/"] }));
+      expect(findingsOf(proj.dir)).toEqual([]);
+
+      // Prefix collision must NOT count as covering (positive control for the
+      // two negatives above).
+      write(proj.dir, ".artgraph.json", JSON.stringify({ ...base, specDirs: [".kiro-archive"] }));
+      expect(findingsOf(proj.dir)).toHaveLength(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("stays silent when only artgraph's own .kiro/skills is on disk, but fires once .kiro/specs appears", () => {
+    initClaude(proj.dir);
+    write(
+      proj.dir,
+      ".artgraph.json",
+      JSON.stringify({
+        include: ["src/**/*.ts", "!**/node_modules/**"],
+        testPatterns: ["**/*.test.ts", "!**/node_modules/**"],
+        specDirs: ["specs", "docs"],
+        agents: ["claude"],
+      }),
+    );
+    mkdirp(proj.dir, ".kiro/skills");
+    mkdirp(proj.dir, ".kiro/hooks");
+    expect(findingsOf(proj.dir)).toEqual([]);
+
+    mkdirp(proj.dir, KIRO_SPECS);
+    expect(findingsOf(proj.dir)).toHaveLength(1);
+  });
+});

--- a/tests/issue-422-kiro-specdirs.test.ts
+++ b/tests/issue-422-kiro-specdirs.test.ts
@@ -22,12 +22,13 @@
 // deliberately preserves rather than re-derives.
 
 import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { detectProject, generateConfig, runInit } from "../src/init.js";
 import { loadConfig } from "../src/config.js";
 import { parseMarkdownContent } from "../src/parsers/markdown.js";
-import { rewriteSpecHeading } from "../src/rename.js";
+import { rewriteSpecHeading, specDefinitionId } from "../src/rename.js";
+import { mergeMarkdown, splitMarkdown } from "../src/rename-executor.js";
 import { runDoctor, type DoctorFinding } from "../src/doctor.js";
 import { createFreshProject, type FreshProject } from "./agents/helpers.js";
 import type { DetectionResult } from "../src/types.js";
@@ -137,6 +138,28 @@ describe("issue #422 — generateConfig seeds an SDD tool's spec directory", () 
     mkdirp(proj.dir, KIRO_SPECS);
     const config = generateConfig(detectProject(proj.dir));
     expect(config.specDirs).toEqual([SPECIFY_SPECS, KIRO_SPECS]);
+  });
+
+  // The probe has to be `isDirectory()`, not a bare `existsSync`: a regular
+  // file named `.kiro/specs` is the one odd shape that must NOT reach
+  // specDirs. The builder globs `<entry>/**/*.md` under every entry, and on a
+  // file that raises ENOTDIR — `init` then aborts before writing
+  // `.artgraph.json` at all, and every later `scan` exits 1. The positive
+  // control in the same test is an EMPTY directory, which is the genuinely
+  // harmless case and still has to be seeded.
+  it("a regular file named .kiro/specs is not seeded, while an empty .kiro/specs directory is", () => {
+    write(proj.dir, KIRO_SPECS, "this is a file, not a directory\n");
+    const asFile = detectProject(proj.dir);
+    expect(asFile.sddTools.map((t) => t.name)).toContain("Kiro");
+    expect(asFile.sddTools.find((t) => t.name === "Kiro")!.specDir).toBeUndefined();
+    expect(generateConfig(asFile).specDirs).toEqual(["specs", "docs"]);
+
+    // Same tree, `.kiro/specs` replaced by an empty directory: seeded.
+    unlinkSync(join(proj.dir, ".kiro", "specs"));
+    mkdirp(proj.dir, KIRO_SPECS);
+    const asDir = detectProject(proj.dir);
+    expect(asDir.sddTools.find((t) => t.name === "Kiro")!.specDir).toBe(KIRO_SPECS);
+    expect(generateConfig(asDir).specDirs).toEqual([KIRO_SPECS]);
   });
 
   // F6 — back-compat for hand-built literals: `integrations` and the new
@@ -264,13 +287,14 @@ describe("issue #422 — init's first scan sees a Kiro project's requirements", 
 // (2) heading grammar — the bare spelling
 // ---------------------------------------------------------------------------
 
-describe("issue #422 — Kiro heading grammar accepts a bare number", () => {
-  function reqIdsOf(markdown: string): string[] {
-    return parseMarkdownContent(markdown, "requirements.md")
-      .nodes.filter((n) => n.kind === "req")
-      .map((n) => n.id);
-  }
+/** The requirement IDs the RECOGNITION side derives from `markdown`. */
+function reqIdsOf(markdown: string): string[] {
+  return parseMarkdownContent(markdown, "requirements.md")
+    .nodes.filter((n) => n.kind === "req")
+    .map((n) => n.id);
+}
 
+describe("issue #422 — Kiro heading grammar accepts a bare number", () => {
   // F10 + F11 + F12 in one test: the widening, its positive control, and the
   // prose heading that must stay OUT. The three belong together — the
   // narrower `:?` spelling of the same widening would pass F10 and F11 while
@@ -348,18 +372,26 @@ describe("issue #422 — rename rewrites both heading spellings", () => {
 
   it("rewrites a heading closed with an ATX closing sequence", () => {
     // mdast strips a closing `###` before the recognition regex sees the
-    // text, so `### Requirement 1 ###` IS recognized as a requirement. Only
-    // the rewriter reads the raw line, which is why the two sides can
-    // disagree here and nowhere else. Widening recognition to the bare
-    // spelling without this branch produces a heading that renames to
-    // nothing while `rename` reports success.
+    // text, so `### Requirement 1 ###` IS recognized as a requirement, while
+    // every rewriter reads the raw line. `splitAtxHeading` (grammar/tokens.ts)
+    // is what keeps those raw-line readers on one normalization.
+    //
+    // It does NOT make the two sides agree everywhere. Widening recognition to
+    // the bare spelling newly reached 10 shapes whose raw line is not an
+    // unadorned `###` line — indented, blockquoted, list-nested, setext,
+    // emphasis-wrapped, entity- or comment-carrying headings — and those are
+    // still recognized without being renameable. That gap is pre-existing for
+    // the titled spelling and out of scope here: measured over the 551
+    // requirement headings in the 62-file real-world corpus behind
+    // KIRO_HEADING_RE's percentages, every one of them is a plain `###` line
+    // and none of the 10 shapes occurs even once.
     const closed = rewriteSpecHeading("### Requirement 1 ###", "Requirement-1", "Requirement-9");
     expect(closed.content).toBe("### Requirement 9 ###");
     expect(closed.changes).toHaveLength(1);
 
-    // Negative control in the same `it()`: the `#+` branch must not be a
-    // door into prose. Both of these end in text, not in the line ending, so
-    // neither side accepts them.
+    // Negative control in the same `it()`: the closing-sequence branch must
+    // not be a door into prose. Both of these end in text, not in the line
+    // ending, so neither side accepts them.
     const proseHash = rewriteSpecHeading(
       "### Requirement 1 ### and then some",
       "Requirement-1",
@@ -367,6 +399,113 @@ describe("issue #422 — rename rewrites both heading spellings", () => {
     );
     expect(proseHash.content).toBe("### Requirement 1 ### and then some");
     expect(proseHash.changes).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (3b) split / merge parity — the SECOND raw-line reader
+// ---------------------------------------------------------------------------
+//
+// `rewriteSpecHeading` is not the only rewriter that reads the raw line:
+// `specDefinitionId` does too, and split/merge locate the definition line to
+// DELETE through it. Shipping closing-sequence support in one and not the
+// other is what these tests pin down — and the merge case is worse than a
+// no-op, because merge deletes the definitions it does recognize while
+// rewriting every `@impl` tag regardless.
+
+describe("issue #422 — split/merge see the same heading definitions rename does", () => {
+  const CLOSED = "### Requirement 1 ###";
+
+  it("the definition probe and the rewriter accept exactly the same headings", () => {
+    // Same acceptance set, positive and negative, in one place: these two now
+    // derive their heading text from a single helper instead of each spelling
+    // its own ATX pattern.
+    const agree = (line: string): { defines: boolean; rewrites: boolean } => ({
+      defines: specDefinitionId(line) === "Requirement-1",
+      rewrites: rewriteSpecHeading(line, "Requirement-1", "Requirement-9").changes.length > 0,
+    });
+
+    // Positive: plain, titled, closing sequence, closing sequence + padding.
+    expect(agree("### Requirement 1")).toEqual({ defines: true, rewrites: true });
+    expect(agree("### Requirement 1: Federated authentication")).toEqual({
+      defines: true,
+      rewrites: true,
+    });
+    expect(agree(CLOSED)).toEqual({ defines: true, rewrites: true });
+    expect(agree("### Requirement 1 ###   ")).toEqual({ defines: true, rewrites: true });
+
+    // Negative, and each one is a shape the recognition side also rejects, so
+    // agreement here is agreement with mdast rather than a shared mistake:
+    //   - a `#` with no space in front of it is heading TEXT, not a closing
+    //     sequence, so the heading reads `Requirement 1#`;
+    //   - seven `#`s is a paragraph in CommonMark, not a heading at all;
+    //   - prose after the closing sequence puts the `#`s back into the text.
+    for (const line of [
+      "### Requirement 1#",
+      "####### Requirement 1",
+      "####### Requirement 1: T",
+      "### Requirement 1 ### and then some",
+      "### Requirement 1 is important",
+    ]) {
+      expect({ line, ...agree(line) }).toEqual({ line, defines: false, rewrites: false });
+      expect(reqIdsOf(line)).toEqual([]);
+    }
+  });
+
+  it("split removes a closing-sequence definition and scaffolds the new IDs", () => {
+    const before = ["# Requirements Document", "", CLOSED, "", "body", ""].join("\n");
+    const { content, changes } = splitMarkdown(
+      ".kiro/specs/auth/requirements.md",
+      before,
+      "Requirement-1",
+      ["Requirement-11", "Requirement-12"],
+      {},
+    );
+
+    // The definition line is gone and both scaffolds are present. Without the
+    // shared helper this returned the input byte-for-byte while the CLI
+    // printed "Split ..." and exited 0.
+    expect(content).not.toContain(CLOSED);
+    expect(content).toContain("- Requirement-11:");
+    expect(content).toContain("- Requirement-12:");
+    expect(changes.filter((c) => c.after === "(removed)")).toHaveLength(1);
+  });
+
+  it("merge removes BOTH definitions when one of them carries a closing sequence", () => {
+    // The half-application. `### Requirement 2` was always removed; the
+    // closing-sequence sibling was not, so the merge left the original heading
+    // behind as an orphan while every `@impl` tag had already moved to the
+    // target — a reported-success rename that turns `check --gate` red.
+    const before = [
+      "# Requirements Document",
+      "",
+      CLOSED,
+      "",
+      "body one",
+      "",
+      "### Requirement 2",
+      "",
+      "body two",
+      "",
+    ].join("\n");
+    const { content, changes } = mergeMarkdown(
+      ".kiro/specs/auth/requirements.md",
+      before,
+      ["Requirement-1", "Requirement-2"],
+      "Requirement-5",
+      false,
+      {},
+    );
+
+    expect(content).not.toContain(CLOSED);
+    expect(content).not.toContain("### Requirement 2");
+    expect(changes.filter((c) => c.after === "(removed)")).toHaveLength(2);
+    // Merge scaffolds the brand-new target exactly once, so the file still
+    // defines every ID the lock will hold after the rewrite.
+    expect(content.match(/- Requirement-5:/g)).toHaveLength(1);
+    expect(
+      parseMarkdownContent(content, "requirements.md").nodes.filter((n) => n.kind === "req"),
+    ).toHaveLength(1);
   });
 });
 
@@ -488,6 +627,70 @@ describe("issue #422 — doctor advisory for an uncovered SDD spec directory", (
     expect(findingsOf(proj.dir)).toEqual([]);
 
     mkdirp(proj.dir, KIRO_SPECS);
+    expect(findingsOf(proj.dir)).toHaveLength(1);
+  });
+
+  // The advisory names a directory for the user to paste into specDirs, so it
+  // must never name one that breaks the very next command. A regular file at
+  // `.kiro/specs` used to earn a NOTICE whose advice made `init` and `scan`
+  // exit 1 with ENOTDIR; the shared `isDirectory()` probe closes both ends at
+  // once, because `detectProject` is what `init` and `doctor` both consult.
+  it("stays silent when .kiro/specs is a regular file, and fires once it is a directory", () => {
+    initClaude(proj.dir);
+    write(
+      proj.dir,
+      ".artgraph.json",
+      JSON.stringify({
+        include: ["src/**/*.ts", "!**/node_modules/**"],
+        testPatterns: ["**/*.test.ts", "!**/node_modules/**"],
+        specDirs: ["specs", "docs"],
+        agents: ["claude"],
+      }),
+    );
+    write(proj.dir, KIRO_SPECS, "this is a file, not a directory\n");
+    expect(findingsOf(proj.dir)).toEqual([]);
+
+    unlinkSync(join(proj.dir, ".kiro", "specs"));
+    mkdirp(proj.dir, KIRO_SPECS);
+    expect(findingsOf(proj.dir)).toHaveLength(1);
+  });
+
+  // Pins the `detectedDescriptors.length > 0` gate itself. `--agents=<csv>`
+  // naming an agent that is NOT installed produces an absent descriptor, which
+  // is enough to get past the empty-report short-circuit — so this run reports
+  // findings, and the advisory still has to be missing from them. Without the
+  // gate the advisory appears here, which is the only observable difference it
+  // makes anywhere.
+  it("does not fire for an agent that is named but not installed, even though doctor still reports", () => {
+    write(proj.dir, ".kiro/specs/auth/requirements.md", REQUIREMENTS_MD);
+    write(
+      proj.dir,
+      ".artgraph.json",
+      JSON.stringify({
+        include: ["src/**/*.ts", "!**/node_modules/**"],
+        testPatterns: ["**/*.test.ts", "!**/node_modules/**"],
+        specDirs: ["specs", "docs"],
+      }),
+    );
+
+    const report = runDoctor({ rootDir: proj.dir, agents: ["claude"] });
+    // Positive control: the run is not empty, so "no advisory" is a real
+    // decision rather than a short-circuited report.
+    expect(report.summary.totalFindings).toBeGreaterThan(0);
+    expect(report.findings.filter((f) => f.kind === "config-specdir-missing-sdd-tool")).toEqual([]);
+
+    // Same tree, agent installed: the advisory appears.
+    initClaude(proj.dir);
+    write(
+      proj.dir,
+      ".artgraph.json",
+      JSON.stringify({
+        include: ["src/**/*.ts", "!**/node_modules/**"],
+        testPatterns: ["**/*.test.ts", "!**/node_modules/**"],
+        specDirs: ["specs", "docs"],
+        agents: ["claude"],
+      }),
+    );
     expect(findingsOf(proj.dir)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Closes #422. Closes #419.

`artgraph init` announced `Kiro detected (.kiro/)`, wired up the steering file and the hooks, then wrote a config whose `specDirs` was still the default `["specs","docs"]`. Kiro keeps its specs under `.kiro/specs/`, so the first scan found zero requirements and the summary said `@impl tags found, but no matching specs yet.` — the opposite of the truth, with no error to search for.

**Seeding `specDirs` alone does not fix the reported symptom.** `KIRO_HEADING_RE` required a trailing colon, so `### Requirement 1` produced no req node and a Kiro project still scanned to `req: 0` with its `@impl` claims dangling. Both halves ship together.

### Measured gate impact

| path | before | after |
|---|---|---|
| `check --diff --gate` on a PR adding an unimplemented req | **exit 0** "No new issues" | **exit 2** `UNCOVERED (1)` |
| `plan-coverage --gate` | **exit 0** "No implicit impacts." | **exit 1** |

`init --agents=kiro` writes a steering file that instructs the Kiro agent to run exactly these commands, so the blind gate was self-installed.

### Kiro heading spellings — why the colon became optional

Measured over **549 requirement headings in 62 files across 26 repositories** with `.kiro/specs/` committed:

| spelling | headings | files | repos |
|---|---:|---:|---:|
| `### Requirement 1` (bare) | 228 (41.5%) | 25 | 9 |
| `### Requirement 1: Title` | 321 (58.5%) | 32 | 12 |
| both, same repo | — | — | 4 |

One file uses both — `### Requirement 1`–`12` bare, `### Requirement 13: …` titled. Kiro's own spec-agent prompt templates the bare form; the model adds titles anyway. Requirement headings were `###` in all 62 files, and every one of the 321 separators was ASCII `: `, so neither of those axes is widened.

The alternation is `(?::|$)`, **not** `:?` — `:?` would also accept prose headings like `### Requirement 1 is important`.

### One ATX normalization for every raw-line rewriter

Recognition reads the mdast heading **text**; every rewriter reads the **raw line**. Each rewriter used to re-spell its own ATX pattern, and the first version of this branch widened one of them and not its sibling. Measured on `### Requirement 1 ###` / `### Requirement 2`:

```
rename --split   exit 0, "Split Requirement-1 → …", markdown byte-identical,
                 lock unchanged — a silent no-op
rename --merge   deleted only the second definition, added the scaffold,
                 rewrote BOTH @impl tags onto the merge target and reported
                 success, leaving the first heading behind as an orphan:
                 check --gate went 0 → 2
```

`splitAtxHeading` in `grammar/tokens.ts` now does that normalization once, returning `{prefix, text, suffix}` with `prefix + text + suffix === line`. All three raw-line readers go through it: `specDefinitionId`, `rewriteSpecHeading`'s default branch, and its **custom-grammar branch** — moving the third is what stops the fix from opening the same divergence for projects with a custom `reqPatterns.heading`.

The opening run is capped at `#{1,6}` (CommonMark), so `####### Requirement 1` is no longer accepted by a rewriter that recognition would never produce a requirement from. A closing sequence must be preceded by whitespace, keeping `### Requirement 1#` as text ending in `#`, matching mdast.

Acceptance sets over the 29 shapes review measured:

| | before | after |
|---|---:|---:|
| rewriter disagrees with `specDefinitionId` | 3 | **0** |
| rewriter accepts what recognition won't | 3 | **0** |
| recognized but not renameable | 12 | 12 |

The last row is unchanged on purpose — those are indented, blockquoted, list-nested, bold and setext headings, where the two sides diverge because one reads mdast and the other reads lines. Two predate this branch, and **none occurs in the measured corpus (0 of 551)**. They need `extractSectionContent`, a fourth raw-line reader with a `headingLevel` fallback of its own → **#430**.

### Why the probe is `.kiro/specs`, not `.kiro`

`init --agents=kiro` creates `.kiro/hooks/` and `.kiro/skills/` itself, so `.kiro/` existing proves only that artgraph ran before. Measured with `specDirs: [".kiro"]`:

```
Nodes 21  req 0  doc 15  task 4
doc: doc:skills/artgraph-bootstrap/SKILL.md    <- .kiro/skills/…
… 11 of artgraph's own distributed Skill files, all lock entries
```

That would turn every artgraph upgrade touching a Skill into lock drift in every downstream project. `sddTools`' push conditions are unchanged, so which tools report as detected and which integrations run are exactly what they were.

The probe is `isDirectory()`, not bare `existsSync`: a regular file by that name made the builder's `<entry>/**/*.md` glob raise ENOTDIR, so `init` aborted before writing `.artgraph.json` at all and every later `scan` exited 1.

### Spec Kit

`.specify/specs/` was broken identically (measured) — the layout `examples/speckit-integration/.artgraph.json` and `plan-coverage`'s resolver both assume. Fixed in the same branch; splitting it would leave the asymmetry behind.

### `doctor` advisory

`init --force` merges an existing config rather than re-deriving `specDirs` (pinned by `tests/init.test.ts:332-364`), so already-initialized projects get nothing from the above. `config-specdir-missing-sdd-tool` is advisory only, never flips the exit code, and shares the Tier 1 gate with its two config-level siblings. Coverage uses `specDirsCover` (same normalization `validateSpecDirs` applies), so `"./.kiro/specs/"` is not reported as missing and an ancestor entry counts.

### #419 — docs (direction 3)

The advice to override the `kiro` preset via `taskConventions` could not be followed: `loadConfig`'s nested-quantifier guard rejects the `(\d+(?:\.\d+)*)` spelling the preset itself uses — **and rejects its `verifiesTagRe` too**, so a user rewriting the override has two fields to re-spell.

Replaced with a recipe that loads, plus its limits. `^(\d+|\d+\.\d+|\d+\.\d+\.\d+)\.?[\s ]` is accepted and produces fewer false tasks than the flat `[\d.]+` workaround (same fixture: 3 vs 1). The `- 1. …` / `1. …` / `- 1) …` shapes **cannot be rescued by any regex** — CommonMark reads the number as an ordered-list marker and `toString` drops it. That makes the checkbox load-bearing on the markdown shape, not just a false-positive guard.

Directions 1 and 2 were measured and rejected: a `kiro-flat` preset breaks `src/rename-validate-id.ts:9-12`'s positional parallel arrays with a `TypeError` (short-circuited for valid IDs, so smoke tests stay green) and still does not rescue the target shape; loosening `detectReDoSRisk` is a fail-closed guard relaxation that also does not rescue it.

### Gate behavior on upgrade — measured on all three wirings

| wiring | before → after |
|---|---|
| plain `check --gate` | 0 → **2** |
| `check --gate --diff` (Stop hook) | 0 → **0** |
| `check --diff --base origin/main --gate` (CI recipe) | 0 → **0** |

`--diff` baselines are built by re-scanning the base tree with the **same binary and the working tree's config**, so newly-recognized reqs appear on both sides and never land in `newIssues`. Verified by mechanism: with the config edit committed on the feature side the CI form still exits 0, and adding a genuinely new req makes it exit 2 with `2 pre-existing issues in blast radius were suppressed`. A non-git or shallow checkout is fail-closed exit 1, byte-identical to the base binary.

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

17 required fixtures, each with a stated discrimination oracle. Discrimination **measured with 11 mutants**, not asserted:

| mutant | tests that fail |
|---|---|
| drop the specDirs append | F1, F2, F3, F4, F5, F7 |
| move the fallback before the append | F1, F4, F5, F7 |
| probe `.kiro` instead of `.kiro/specs` | 8 incl. F3, F16/F17 |
| revert the heading widening | F7, F10/F11/F12 |
| `:?` instead of `(?::\|$)` | **F10/F11/F12 only** |
| revert the rewriter widening | F13 (F14 stays green) |
| drop the closing-sequence branch from the shared helper | **4, incl. split/merge** |
| `#{1,6}` → `#+` | 1 |
| drop "closing sequence must be preceded by space" | 1 |
| disable `detectReDoSRisk` | **F15** |
| remove the doctor Tier 1 gate | the gate-reach test |

`F7` is the end-to-end one the issue asked for: `init --agents=kiro` followed by a real scan asserting `reqCount > 0`. Every pre-existing `init` test runs `--no-scan`, which is why a passing `init` with an empty graph was tolerated.

Every negative assertion sits in the same `it()` as its positive control.

**E2E against the real CLI** confirmed all seven behaviors this branch claims, with no counterexamples — including reproducing the silent no-op and the state destruction verbatim on the intermediate commit, and confirming the three upgrade wirings above. Its oracle was `scan --format json`, cross-checked by driving the same remark-parse artgraph depends on in a separate process to prove each fixture constitutes the shape it claims.

Positive control, `ARTGRAPH_CACHE=0`, base binary vs this branch on artgraph's own repository: `scan --format json`, `check` and `doctor --format json` all **byte-identical** — 1527 nodes / 2116 edges / 492 req, orphans 110 → 110. Zero requirements newly recognized here. `examples/` unchanged too.

- [x] Existing tests pass — unit 2708 / 125 files, e2e 122, perf 8
- [x] Added tests where needed — `tests/issue-422-kiro-specdirs.test.ts` (new), `tests/config.test.ts`
- [x] Ran `pnpm knip` and `pnpm build`; also `typecheck`, `oxlint --deny-warnings`, `oxfmt --check`, `check:no-raw-nul` (729 files)

## Breaking change

- [ ] Yes (described below)
- [x] No

Existing configs are untouched — `init --force` still merges rather than re-deriving. New `init` runs get one additional `specDirs` entry. Projects whose Kiro specs use bare headings gain req nodes they did not have; that is the fix, and the gate table above says which wirings can turn red on it.

## Notes

Follow-ups filed rather than folded in:

- **#430** — the 12 heading shapes recognition accepts and `rename` skips, plus `extractSectionContent`'s `headingLevel` fallback. 0 of 551 in the corpus; needs position-driven resolution, not more line regexes.
- **#431** — `### 要件 1` and `### Requirement 0.1`, both real Kiro output, both matching nothing today. Each needs an ID-space decision first.
- **#432** — the three config-level advisories are gated on a Tier 1 distribution, so `init --minimal` projects never see them; and `config-pool-protection-asymmetry`'s gate comment carries a claim measurement disproves.
- **#433** — non-git `--diff` prints a raw stack trace before its (correct) fail-closed exit 1.

Three docs claims were narrowed after E2E measured them as over-broad: what `rename` does with a heading it skips (exit 1 when the ID is spec-only, exit 0 + orphan when code tags exist), which HTML entities matter (only inside the `Requirement <n>` part), and what the `taskConventions` recipe's `verifies` edges actually point at (self-loops on a standard Kiro spec — the built-in preset's own behavior, which `init` seeding now surfaces by default).

`kiro.dev`'s official docs could not be retrieved (403 through every route tried, including archive mirrors), so the heading corpus is measured from committed repositories only. It skews toward hackathon entries, where `.kiro/` is committed by rule; the per-repository split (9 / 12 / 4) is less concentrated than the per-heading split, and both support the same conclusion.