### PR TITLE
docs(kiro): correct the corpus denominator and the bare-spelling share

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -337,7 +337,7 @@ and left the definition behind, which turns the requirement into an orphan. If
 the ID exists only in the spec, there is nothing left to rewrite and the run
 exits 1 (`… was not found in any of the N files matched by …`).
 
-None of these shapes occurred in the 62-file, 551-heading corpus behind the
+None of these shapes occurred in the 62-file, 549-heading corpus behind the
 percentages above; if you write one by hand, edit it and its `@impl` tags
 together.
 

--- a/src/grammar/tokens.ts
+++ b/src/grammar/tokens.ts
@@ -47,11 +47,18 @@ export const NAMESPACED_ID_TOKEN = `(?:[\\w-]+/)?(?:${REQ_ID_TOKEN})`;
 export const LIST_ITEM_RE = /^(?:\*\*)?([A-Z][A-Za-z]*-\d+)(?:\*\*)?[:\s]/;
 
 // A Kiro-style requirement heading. Both spellings occur in real Kiro output
-// and neither is rare — measured over 549 requirement headings in 62 files
-// across 26 repositories with `.kiro/specs/` committed: 41.5% bare
-// (`### Requirement 1`), 58.5% titled (`### Requirement 1: Some Title`).
-// Four repositories use both, and one file uses both. Kiro's own spec-agent
-// prompt templates the bare form; the model adds titles anyway.
+// and neither is rare. Counted as HEADING LINES over 62 requirements.md files
+// from 26 repositories with `.kiro/specs/` committed — 549 in total, every one
+// of them an unindented `###`: 227 bare (41.3%, `### Requirement 1`), 321
+// titled (58.5%, `### Requirement 1: Some Title`), and one that is neither
+// (`### Requirement 0.1`, hierarchical — issue #431). Four repositories use
+// both spellings and one file uses both. Kiro's own spec-agent prompt
+// templates the bare form; the model adds titles anyway.
+//
+// The bare count includes the five `### 要件 N` headings in the corpus, which
+// this pattern does NOT match (issue #431) — they are counted because the
+// question the percentage answers is "how often does Kiro omit the colon",
+// not "how many headings does this regex accept".
 //
 // The alternative is `$`, NOT `:?` — `:?` would also accept prose headings
 // like `### Requirement 1 is important`, which are not requirement

--- a/tests/issue-422-kiro-specdirs.test.ts
+++ b/tests/issue-422-kiro-specdirs.test.ts
@@ -6,7 +6,9 @@
 // the truth.
 //
 // Three changes ship together here, because fixing only the first one leaves
-// the symptom in place for a measured 41.5% of real Kiro spec files:
+// the symptom in place for the 41.3% of measured real-world Kiro requirement
+// HEADINGS that omit the colon (227 of 549 heading lines; by file the share is
+// different, and the two must not be quoted interchangeably):
 //
 //   (1) `detectProject` probes each SDD tool's SPECS directory and
 //       `generateConfig` appends it to `specDirs` (never substitutes).
@@ -303,7 +305,7 @@ describe("issue #422 — Kiro heading grammar accepts a bare number", () => {
     // F11 — positive control, the spelling that always worked.
     expect(reqIdsOf("### Requirement 1: Federated authentication")).toEqual(["Requirement-1"]);
 
-    // F10 — the widening. 41.5% of measured real-world Kiro headings.
+    // F10 — the widening. 41.3% of measured real-world Kiro heading lines.
     expect(reqIdsOf("### Requirement 2")).toEqual(["Requirement-2"]);
 
     // F12 — prose is not a definition. `:?` would accept this one.
@@ -381,10 +383,10 @@ describe("issue #422 — rename rewrites both heading spellings", () => {
     // unadorned `###` line — indented, blockquoted, list-nested, setext,
     // emphasis-wrapped, entity- or comment-carrying headings — and those are
     // still recognized without being renameable. That gap is pre-existing for
-    // the titled spelling and out of scope here: measured over the 551
-    // requirement headings in the 62-file real-world corpus behind
-    // KIRO_HEADING_RE's percentages, every one of them is a plain `###` line
-    // and none of the 10 shapes occurs even once.
+    // the titled spelling and out of scope here: measured over the 549
+    // requirement heading lines in the 62-file real-world corpus behind
+    // KIRO_HEADING_RE's percentages, every one of them is a plain unindented
+    // `###` line and none of the 10 shapes occurs even once.
     const closed = rewriteSpecHeading("### Requirement 1 ###", "Requirement-1", "Requirement-9");
     expect(closed.content).toBe("### Requirement 9 ###");
     expect(closed.changes).toHaveLength(1);


### PR DESCRIPTION
## Summary

The retrospective for #429 found three counting errors that landed on main. An independent recount of the corpus confirms all three. **The conclusion they support — both Kiro heading spellings are real and neither is rare — is unaffected**; only the numbers were wrong.

Recounted over the 62 committed `requirements.md` files from 26 repositories with `.kiro/specs/`, matching `^###\s+(Requirement|要件)\s+[0-9]`:

| | count |
|---|---:|
| requirement heading lines, total | **549** |
| bare (222 English + 5 Japanese) | **227** |
| titled | **321** |
| neither (`### Requirement 0.1`, hierarchical — #431) | 1 |

549 is stable across every definition tried — any heading level, any leading indentation, and with hierarchical numbering allowed all return the same count.

| site | was | now |
|---|---|---|
| `docs/configuration.md`, test file | `551` | `549` |
| `src/grammar/tokens.ts`, test file | `41.5%` bare | `41.3%` (227/549) |
| test file header | "41.5% of real Kiro spec **files**" | the share of heading **lines**, with the units named |

`551` is not reproducible under any of the definitions above. `41.5%` implies 228 of 549; the bare count is 227. The titled share (58.5%) was already right.

The header's unit error is the one worth calling out: the percentage is a share of heading *lines*, the per-file share is a different number, and the two were being quoted interchangeably in the same file (one site had the unit right, the other did not).

The bare count deliberately includes the five `### 要件 N` headings, which `KIRO_HEADING_RE` does not match. The percentage answers "how often does Kiro omit the colon", not "how many headings does this regex accept" — the comment now says which of those it is, since the gap between them is #431.

## Change type

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [x] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

Comments and prose only — no code paths touched.

## Testing

- [x] Existing tests pass — `tests/issue-422-kiro-specdirs.test.ts` 24 passed
- [x] `pnpm typecheck`, `oxlint --deny-warnings`, `oxfmt --check`
- [ ] Added tests where needed — none; nothing executable changed

Recount is reproducible against the corpus snapshot with `grep -ahcE '^###[[:space:]]+(Requirement|要件)[[:space:]]+[0-9]'` and the bare/titled variants of it.

## Breaking change

- [ ] Yes (described below)
- [x] No

## Notes

Filed from the same retrospective: **#434** (two files in one spec dir defining the same `Requirement N` — last alphabetically wins the filePath/contentHash), **#435** (Kiro `_Requirements:` edges resolve into the task ID space, so they self-loop), **#436** (`specDirsCover` normalization vs. the scanner's resolution, and a symlinked `.kiro/specs` pulling out-of-tree files into the lock).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxwmDDksrdSBwKcvLNq2Jw)_