### PR TITLE
fix(test): stop the plan-coverage dogfood suite writing the repository's parse cache

### DIFF
--- a/tests/plan-coverage-dogfood.test.ts
+++ b/tests/plan-coverage-dogfood.test.ts
@@ -15,7 +15,7 @@
 // tests rather than spawning the CLI. This keeps the test fast and
 // avoids depending on a built dist/ in CI.
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { runPlanCoverage } from "../src/plan-coverage/index.js";
@@ -25,6 +25,40 @@ import { runPlanCoverage } from "../src/plan-coverage/index.js";
 // runs from the project root and the test path is stable.
 const REPO_ROOT = resolve(import.meta.dirname, "..");
 const SPEC_DIR = join(REPO_ROOT, "specs/014-reinvent-impact-cli");
+
+// issue #427 — `runPlanCoverage` builds the graph of the REPOSITORY ITSELF,
+// and `buildGraph` writes `node_modules/.cache/artgraph/parse-cache.json` on
+// the way out (`cacheEnabled` only asks whether `node_modules` exists). That
+// cache is keyed by file content, not by which build produced the fragment:
+// `computeCacheFingerprint` folds in `SCHEMA_VERSION` and `artgraphVersion()`,
+// and both are identical between `src` and `dist` because `artgraphVersion()`
+// reads the same `package.json` either way. So a cache warmed by this suite
+// (`src`, via vite-node) is then READ by the CLI (`dist`) — and `dist` is
+// older than `src` for most of a development cycle, since `pnpm test:unit`
+// does not rebuild. Measured before this guard: a `dist` predating #423
+// replayed 118 orphans from fragments the fixed parser had written, where a
+// cold rebuild gives 110.
+//
+// This is the same warm-vs-cold divergence `SCHEMA_VERSION` exists to prevent,
+// arriving through a channel the counter cannot see — bumping it does not help
+// when both sides read the same number.
+//
+// Disabled for the duration of THIS FILE only: vitest reuses a worker process
+// across files, and `tests/barrel-reexport.test.ts`'s two INV-L4 tests assert
+// that warm and cold builds agree, which requires the cache file to exist
+// (measured: they fail under a global `ARTGRAPH_CACHE=0`). Same shape as
+// `tests/dogfood-self-pollution.test.ts`, which closed the other writer.
+let previousCacheEnv: string | undefined;
+
+beforeAll(() => {
+  previousCacheEnv = process.env.ARTGRAPH_CACHE;
+  process.env.ARTGRAPH_CACHE = "0";
+});
+
+afterAll(() => {
+  if (previousCacheEnv === undefined) delete process.env.ARTGRAPH_CACHE;
+  else process.env.ARTGRAPH_CACHE = previousCacheEnv;
+});
 
 describe("plan-coverage self-dogfood — spec 014 has zero implicit impacts (T027)", () => {
   it("(precondition) the spec 014 directory exists and has tasks.md / spec.md", () => {


### PR DESCRIPTION
## Summary

Closes #427.

`runPlanCoverage` builds the graph of this repository, and `buildGraph` writes `node_modules/.cache/artgraph/parse-cache.json` on the way out — `cacheEnabled` only asks whether `node_modules` exists. `pnpm test:unit` left a **748 KB cache produced by the `src` build** on disk, and the CLI running from `dist` then read it.

The fragments hit: `computeCacheFingerprint` folds in `SCHEMA_VERSION` and `artgraphVersion()`, and both are identical across the two builds because `artgraphVersion()` reads the same `package.json` either way. `dist` is older than `src` for most of a development cycle since `pnpm test:unit` does not rebuild, so the ordinary sequence — run the suite, then run `artgraph check` — **serves the new parser's fragments to the old binary**.

Measured with a `dist` predating #423: **118 orphans replayed from warm fragments where a cold rebuild gives 110** — the eight phantom claims that PR removed.

This is the warm-vs-cold divergence `SCHEMA_VERSION` exists to prevent, arriving through a channel the counter cannot see. Both sides read the same number, so bumping it does nothing.

`lefthook.yml` runs `test:unit` on pre-push, so this fired on every push.

**What it breaks is evidence, not behavior** — which is why it is worth fixing even though no user-facing feature depends on it. The triage work in this repository has been reading `check` output to rank issues.

## How the remaining writers were enumerated

The triage table added in #438 sends "a change that adds or moves tests" to checks 18-A / 18-B / 21 step 3. 18-B step 1 says to follow the **argument value**, not the function name — and that is load-bearing here:

```console
$ git grep -ln 'buildGraph(REPO_ROOT' -- tests      # the issue's own grep
tests/dogfood-self-pollution.test.ts                # 1 file — misses the target

$ git grep -ln 'REPO_ROOT\|repoRoot' -- tests       # by argument value
… 23 files
```

**The issue's grep no longer finds the file the issue is about.** It searched `buildGraph(REPO_ROOT` and this suite calls `runPlanCoverage({repoRoot: …})`.

Narrowing the 23 to unit tests that both resolve REPO_ROOT to the real repository and call a graph entry leaves three. Running each against 18-B step 2's empirical oracle — delete the cache, run the file, look — settles it:

| file | result |
|---|---|
| `doctor.test.ts` | clean (`runDoctor` is read-only) |
| `dogfood-self-pollution.test.ts` | clean (fixed in #423) |
| **`plan-coverage-dogfood.test.ts`** | **writes 747,663 bytes** |
| `check-gate-no-regression.test.ts` | clean |
| `init.test.ts` | clean |
| `packaging.test.ts` | clean |

This file is the last writer.

## Change type

- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor (no behavior change)
- [ ] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [x] test (tests only)

## Testing

**Discrimination measured, not asserted.** Removing the `process.env.ARTGRAPH_CACHE = "0"` assignment again brings the cache back at the same size:

```
with the fix       clean
mutant             747663 bytes
```

`ARTGRAPH_CACHE=0` is scoped to this file, restoring the previous value in `afterAll`. Globally it would break `tests/barrel-reexport.test.ts`'s two INV-L4 tests, which assert warm and cold builds agree and therefore need the cache to exist — the issue flags this and the full suite confirms both still pass.

- [x] Existing tests pass — unit 2708 / 125 files, e2e 122, perf 8
- [x] `pnpm typecheck`, `oxlint --deny-warnings`, `oxfmt --check`
- [x] 18-B step 2 oracle: `node_modules/.cache/artgraph` absent after the run, `git status` clean
- [ ] Added tests where needed — see Notes

## Breaking change

- [ ] Yes (described below)
- [x] No

## Notes

**No guard against the next writer.** This is the second instance of the same defect (the first was a test #423 was adding, caught before it landed), so a guard is warranted — but the right one is the structural fix the issue raises separately: a `writeCache: false` option on `buildGraph`, making the quiet case explicit instead of relying on every in-process caller remembering an environment variable. A test that greps test files for the env var would be the string-shape heuristic that Step 1's own guidance says to avoid when a real evaluator exists, and the real evaluator here is "run it and look" — which is what this PR did by hand for six files.

Filing that as a follow-up rather than guessing at it here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxwmDDksrdSBwKcvLNq2Jw)_