### PR TITLE
docs(dev-process): wire the last two interventions into the brief the agent actually reads

### DIFF
--- a/.claude/skills/artgraph-graph-primitive-impact/SKILL.md
+++ b/.claude/skills/artgraph-graph-primitive-impact/SKILL.md
@@ -33,7 +33,7 @@ disable-model-invocation: false
 サブエージェント brief テンプレ:
 
 > あなたは artgraph リポジトリの調査担当です。これから `<変更対象の primitive / 関数 / エッジ kind>` を `<変更の一行要約>` する変更を検討しています。実装はまだ存在しません。
-> `.claude/skills/artgraph-graph-primitive-impact/SKILL.md` の 24 チェックを順に実行し、「この primitive を変えると SILENT に破壊される経路」のランク付きリストを報告してください。各項目には (a) 経路の説明 (b) 影響を受ける CLI コマンド (c) 該当テストの有無 (d) 推奨 (本 PR で fix / 別 issue / accept) を含めること。
+> `.claude/skills/artgraph-graph-primitive-impact/SKILL.md` の「どのチェックが今回必須か」表を先に引いて必須列を確定させ、それを報告の必須セクションとして確保したうえでチェックを実行し、「この primitive を変えると SILENT に破壊される経路」のランク付きリストを報告してください。各項目には (a) 経路の説明 (b) 影響を受ける CLI コマンド (c) 該当テストの有無 (d) 推奨 (本 PR で fix / 別 issue / accept / 起票しない — 起票ゲート A/B/C/D の答えを併記) (e) 根拠 (実測 / 未実測) を含めること。**測定はすべて「どの案について取ったか」でラベルする** — 採用案が変わったら、その案で取り直していない測定は結論として使えない。
 
 ## 横断 grep を始める前に
 


### PR DESCRIPTION
## Summary

Step 9 retro on the #435 / #443 loop. The classification came back **11 "detectable by a check that already exists" vs 2 "needs a new observation point"** — the lowest conditional ratio on record:

| loop | PR | checklist lines | 可能 | 条件付き | conditional share |
|---|---|---:|---:|---:|---:|
| #235 | #417 | 370 | 3 | 10 | 77% |
| #387 | #423 | 370 | 3 | 12 | 80% |
| #422 | #429 | 540 | 9 | 8 | 47% |
| **#435** | **#443** | **535** | **11** | **2** | **15%** |

`issue-retro`'s own rule reads: *"「条件付き」が横ばい〜減少なら、カバレッジは足りている。そこへ新観点を足しても効かない"*, and *"「可能」が増えているなら、壊れているのは実行"*. Both conditions fire. **So this PR adds no check.** Numbering stays at 24.

## What it changes

The brief template on line 36 — the only text a Step 0-pre subagent ever receives.

#438 added the "which checks are mandatory this time" table and a re-entry trigger. #442 replaced the three-value recommendation with four values behind a filing gate. Both correctly updated this file's body. **Neither updated the brief.** So the subagent was still being told to run the checks *in order* — the exact behavior the mandatory-column table was introduced to replace — and to answer in the retired three values.

Four things are added to the brief, and **all four already exist** in this file or in `issue-loop`:

| added to brief | already defined at |
|---|---|
| pull the mandatory-column table first | SKILL.md:44 |
| four values + filing gate A/B/C/D | issue-loop:33, SKILL.md:513 |
| (e) evidence — measured / not measured | SKILL.md:514 |
| label every measurement with the candidate it was taken under | SKILL.md:119, check 4-B step 3 |

No new observation point. This is a wiring fix, not coverage.

## Why the measurement label specifically

It is the one that would have changed #443's outcome directly. Its Step 0-pre measured **one** candidate for the task-hub restriction; the design shipped a **different** one and inherited the numbers unlabelled. That is how a fail-open narrowing of every spec-kit project — `plan-coverage --gate` going from exit 1 to exit 0 — reached review instead of being caught at design time.

## The pattern this retro surfaced

Looking at which interventions actually got executed on their first loop:

| intervention | shape | executed first time? |
|---|---|---|
| #442 filing gate | one question → one of four written values | **yes** — 13 findings became 1 new issue + 3 appends |
| #438 re-entry trigger | "go back and re-run the mandatory column" | no — its non-execution *is* #443's central failure |
| #428 check 11-B | long procedure producing a table nobody requires | no — 6 of the previous loop's 9 misses |

**Rules that force a written artifact get executed. Rules that ask for rework do not.** That is why this PR's fix is shaped as fields the subagent must fill in, rather than as an instruction to go back.

It also argues for a stronger version — requiring the Step 0-pre report to carry the mandatory-column verdicts as a table. **Deliberately not doing that here.** Three consecutive loops have now shipped execution fixes; stacking a fourth without observing whether this one moves the 可能 count would repeat the same trap.

## Change type

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] refactor (no behavior change)
- [x] docs (documentation only)
- [ ] chore / build / ci (toolchain)
- [ ] test (tests only)

## Testing

Documentation only; no code paths touched. The skill is repository-internal (not in `templates/skills/`), canonical only under `.claude/skills/`, so there are no synced copies to keep byte-identical — verified.

Verified that both references the new brief text points at resolve: the mandatory-column table at `SKILL.md:44` and the filing gate at `issue-loop/SKILL.md:33`.

**Net: 0 lines, +7 words** (3147 → 3154). For contrast: #428 +1455 words, #438 +344, #442 +273.

## Breaking change

- [ ] Yes
- [x] No

## Notes

### Checks that fired on this diff

Per `issue-loop`'s rule that an orchestrator-authored diff still runs the checks its own content triggers: this adds one assertive sentence (*"採用案が変わったら、その案で取り直していない測定は結論として使えない"*), which fires **12-B** — a new assertive claim needs a counterexample hunt before it ships. None found: check 4-B step 3 already asserts the same proposition, and it is supported by two independent loops (#423 and #443).

### Classification caveat

n=4, a different agent classified each loop, and no shared threshold was calibrated between them. Checklist length was also flat this loop (540 → 535), so this data cannot test "length causes misses" — only the direction of the two counts. The retro was delegated to a clean agent specifically because the orchestrator authored the design error being classified.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxwmDDksrdSBwKcvLNq2Jw)_